### PR TITLE
feat(ui): always activate save button on CU input page (FLEX-430)

### DIFF
--- a/frontend/src/controllable_unit/ControllableUnitInput.tsx
+++ b/frontend/src/controllable_unit/ControllableUnitInput.tsx
@@ -16,7 +16,7 @@ export const ControllableUnitInput = () => {
   const createOrUpdate = useCreateOrUpdate();
 
   return (
-    <SimpleForm maxWidth={1280} toolbar={<Toolbar />}>
+    <SimpleForm maxWidth={1280} toolbar={<Toolbar saveAlwaysEnabled />}>
       <Stack direction="column" spacing={1}>
         <Typography variant="h6" gutterBottom>
           Basic information


### PR DESCRIPTION
This PR proposes a quick fix to the save button always being disabled. This fix not looking harmful at all, no further investigation was done.

> [!NOTE]
> This preserves the semantics of `required` fields : we still get the error message about the form being incomplete, before the API call is made, when some of the required fields are missing.