### PR TITLE
docs: refresh state of RLS policies in resource docs (FLEX-429)

### DIFF
--- a/db/flex/controllable_unit_rls.sql
+++ b/db/flex/controllable_unit_rls.sql
@@ -60,7 +60,7 @@ USING (
             AND controllable_unit_service_provider.service_provider_id
             = current_party()
     ) OR (
-        -- the SP last edited the CU (e.g., created it)
+        -- the SP created the CU
         created_by_party_id = current_party()
     )
 );

--- a/docs/resources/controllable_unit.md
+++ b/docs/resources/controllable_unit.md
@@ -89,7 +89,7 @@ No policies.
 
 | Policy key | Policy                                 | Status |
 |------------|----------------------------------------|--------|
-| CU-COM001  | Read history on CU that they can read. | TODO   |
+| CU-COM001  | Read history on CU that they can read. | DONE   |
 
 #### Balance Responsible Party
 
@@ -123,10 +123,10 @@ No policies.
 
 #### System Operator
 
-| Policy key | Policy                                                       | Status  |
-|------------|--------------------------------------------------------------|---------|
-| CU-SO001   | Read and update CU that are connected to AP belonging to SO. | PARTIAL |
-| CU-SO002   | Read CU belonging to SPG that the SO can see.                | DONE    |
+| Policy key | Policy                                                       | Status |
+|------------|--------------------------------------------------------------|--------|
+| CU-SO001   | Read and update CU that are connected to AP belonging to SO. | DONE   |
+| CU-SO002   | Read CU belonging to SPG that the SO can see.                | DONE   |
 
 #### Service Provider
 


### PR DESCRIPTION
Went through all the RLS policies marked `TODO` or `PARTIAL` (they are in the controllable unit resource) and checked whether the status was correct for each of them.

- `CU-COM001` was implemented by code generation, but not marked as such. `DONE`.
- `CU-SO001` is fully implemented, but was not marked as such, probably because at that time we did not have SO ID in the `accounting_point` resource. Now it is properly marked as `DONE`.
- `CU-SP001` remains `PARTIAL` because the policy description implies an SP cannot see a CU if they are _no longer_ in charge of it, but the implementation allows such cases. This can be aligned as a follow-up commit in this PR by changing the description or adding a check to the `valid_time` to the policy implementation. We just need to identify which one is the target.
- `CU-(BRP/EU/ES/MO)001` are still `TODO` because we need to add more resources around `accounting_point` to be able to implement them (contract subresources to link an AP to a BRP/EU/ES/MO). This work can be done in separate later stories.