### PR TITLE
feat(backend): lint check and change all logging to slog w/ ctx (FLEX-414)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,12 @@ linters-settings:
       - (github.com/jackc/pgx/v5.Tx).Commit
       - (github.com/jackc/pgx/v5.Tx).Rollback
       - (io.Closer).Close
+  forbidigo:
+    forbid:
+      - ^fmt\.Print.*$
+      - ^log\.Print.*$
+  sloglint:
+    context: "all"
   godox:
     keywords:
       - FIXME

--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -12,7 +12,6 @@ import (
 	"flex/internal/validate"
 	"flex/pgpool"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -384,7 +383,7 @@ func (auth *API) GetCallbackHandler(ctx *gin.Context) { //nolint:funlen,cyclop
 
 	pid := oidc.GetIdentifier(token)
 
-	slog.Debug("callback", "token", idToken, "pid", pid)
+	slog.DebugContext(ctx, "callback", "token", idToken, "pid", pid)
 
 	tx, err := auth.db.Begin(ctx)
 	if err != nil {
@@ -394,7 +393,7 @@ func (auth *API) GetCallbackHandler(ctx *gin.Context) { //nolint:funlen,cyclop
 
 	entityID, eid, _, err := models.GetEntityOfBusinessID(ctx, tx, pid, "pid")
 	if err != nil {
-		slog.Debug("getting identity of person identifier failed", "token", idToken, "pid", pid, "error", err)
+		slog.DebugContext(ctx, "getting identity of person identifier failed", "token", idToken, "pid", pid, "error", err)
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, oauthErrorMessage{
 			Error:            oauthErrorInvalidClient,
 			ErrorDescription: "invalid person identifier",
@@ -638,7 +637,7 @@ func (auth *API) clientCredentialsHandler( //nolint:funlen
 	ctx *gin.Context,
 	payload clientCredentialsPayload,
 ) {
-	log.Println("client credentials for client: ", payload.ClientID)
+	slog.InfoContext(ctx, "client credentials for client", "client", payload.ClientID)
 
 	err := payload.Validate()
 	if err != nil {
@@ -664,7 +663,7 @@ func (auth *API) clientCredentialsHandler( //nolint:funlen
 		ctx, tx, payload.ClientID, payload.ClientSecret,
 	)
 	if err != nil {
-		log.Println("getting identity of credentials failed: ", err)
+		slog.InfoContext(ctx, "getting identity of credentials failed: ", "error", err)
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, oauthErrorMessage{
 			Error:            oauthErrorInvalidClient,
 			ErrorDescription: "Invalid client_id or client_secret",

--- a/backend/auth/oidc/provider.go
+++ b/backend/auth/oidc/provider.go
@@ -69,7 +69,7 @@ func NewProvider( //nolint: funlen
 	issuerURL = strings.TrimSuffix(issuerURL, "/")
 	wellKnown := issuerURL + "/.well-known/openid-configuration"
 
-	slog.Debug("Fetching OIDC provider details from " + wellKnown)
+	slog.DebugContext(ctx, "Fetching OIDC provider details from "+wellKnown)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wellKnown, nil)
 	if err != nil {
@@ -82,7 +82,7 @@ func NewProvider( //nolint: funlen
 	}
 	defer resp.Body.Close()
 
-	slog.Debug("OIDC provider details fetched")
+	slog.DebugContext(ctx, "OIDC provider details fetched")
 
 	oc := new(openidConfiguration)
 	err = json.NewDecoder(resp.Body).Decode(oc)
@@ -90,14 +90,14 @@ func NewProvider( //nolint: funlen
 		return nil, fmt.Errorf("could not decode OIDC provider details: %w", err)
 	}
 
-	slog.Debug("Creating JWK cache")
+	slog.DebugContext(ctx, "Creating JWK cache")
 
 	jwksCache, err := jwk.NewCache(ctx, httprc.NewClient())
 	if err != nil {
 		return nil, fmt.Errorf("could not create JWK cache: %w", err)
 	}
 
-	slog.Debug("Registering URI in JWK cache: " + oc.JWKSURI)
+	slog.DebugContext(ctx, "Registering URI in JWK cache: "+oc.JWKSURI)
 	cacheRegisterCtx, cancel := context.WithTimeout(ctx, 10*time.Second) //nolint:mnd
 	defer cancel()
 	err = jwksCache.Register(cacheRegisterCtx, oc.JWKSURI)
@@ -105,7 +105,7 @@ func NewProvider( //nolint: funlen
 		return nil, fmt.Errorf("could not register JWK URI in cache: %w", err)
 	}
 
-	slog.Debug("Cache ready")
+	slog.DebugContext(ctx, "Cache ready")
 
 	return &Provider{
 		hashKey:               []byte(hashKey),

--- a/backend/flex.go
+++ b/backend/flex.go
@@ -9,7 +9,6 @@ import (
 	"flex/pgpool"
 	"flex/pgrepl"
 	"fmt"
-	"log"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -30,7 +29,6 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 	// Structured logging
 	logLevel, exists := lookupenv("FLEX_LOG_LEVEL")
 	if !exists {
-		log.Println("FLEX_LOG_LEVEL environment variable is not set, using default INFO")
 		logLevel = "INFO"
 	}
 
@@ -47,6 +45,11 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 		ReplaceAttr: nil,
 	}))
 	slog.SetDefault(logger)
+
+	// we report missing env variable after logger has been established
+	if !exists {
+		slog.InfoContext(ctx, "FLEX_LOG_LEVEL environment variable is not set, using default INFO")
+	}
 
 	// TODO we might want to put this in the cmd/flex package
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt)
@@ -69,7 +72,7 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 
 	port, exists := lookupenv("FLEX_PORT")
 	if !exists {
-		log.Println("FLEX_PORT environment variable is not set, using default port 7000")
+		slog.InfoContext(ctx, "FLEX_PORT environment variable is not set, using default port 7000")
 		port = "7000"
 	}
 
@@ -109,7 +112,7 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 	}
 
 	// first instantiate the database service implementation
-	log.Println("Connecting to the database...")
+	slog.InfoContext(ctx, "Connecting to the database...")
 
 	ebo := backoff.NewExponentialBackOff()
 	ebo.InitialInterval = 1 * time.Second
@@ -123,10 +126,10 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 	var dbPool *pgpool.Pool
 	err = backoff.Retry(func() error {
 		var err error
-		log.Println("Trying to connect...")
+		slog.InfoContext(ctx, "Trying to connect...")
 		dbPool, err = pgpool.New(ctx, dbURI, requestDetailsContextKey)
 		if err != nil {
-			log.Println("Failed: ", err.Error())
+			slog.InfoContext(ctx, "Failed: ", "error", err.Error())
 			return fmt.Errorf("could not connect to the database: %w", err)
 		}
 		return nil
@@ -134,14 +137,14 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 	if err != nil {
 		return fmt.Errorf("exhausted db connection retries: %w", err)
 	}
-	log.Println("Connected!")
+	slog.InfoContext(ctx, "Connected!")
 	defer dbPool.Close()
 
 	// Using the OIDC issuer as a "feature flag" to enable/disable OIDC stuff
 	// TODO remove once in production
 	oidcProvider := &oidc.Provider{}
 	if oidcIssuer != "" {
-		slog.Debug("Creating OIDC provider for issuer " + oidcIssuer)
+		slog.DebugContext(ctx, "Creating OIDC provider for issuer "+oidcIssuer)
 
 		oidcProvider, err = oidc.NewProvider(ctx, oidcIssuer, oidcClientID, oidcClientSecret, jwtSecret, oidcRedirectURL, postLogoutRedirectURI)
 		if err != nil {
@@ -149,19 +152,19 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 		}
 	}
 
-	slog.Debug("Creating auth API")
+	slog.DebugContext(ctx, "Creating auth API")
 	authAPI := auth.NewAPI(authAPIBaseURL, dbPool, jwtSecret, oidcProvider, requestDetailsContextKey)
 
 	// launch the event worker
 	go func() {
 		// loop in case the replication connection drops
 		for {
-			log.Println("Launching the event worker...")
+			slog.InfoContext(ctx, "Launching the event worker...")
 			backoffWithContext = backoff.WithContext(ebo, ctx)
 			var replConn *pgrepl.Connection
 			err = backoff.Retry(func() error {
 				var err error
-				log.Println("Trying to connect to the replication slot...")
+				slog.InfoContext(ctx, "Trying to connect to the replication slot...")
 				replConn, err = pgrepl.NewConnection(
 					ctx,
 					replURI,
@@ -170,35 +173,35 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 					"event-worker-replication",
 				)
 				if err != nil {
-					log.Printf("Failed: %s", err.Error())
+					slog.InfoContext(ctx, "Failed", "error", err.Error())
 					return fmt.Errorf("failed to create replication listener: %w", err)
 				}
 				return nil
 			}, backoffWithContext)
 			if err != nil {
-				log.Printf("exhausted db connection retries: %s", err.Error())
+				slog.InfoContext(ctx, "exhausted db connection retries", "error", err.Error())
 				return
 			}
-			log.Println("Connected to the replication slot!")
+			slog.InfoContext(ctx, "Connected to the replication slot!")
 			defer replConn.Close(ctx) //nolint:errcheck
 
 			eventWorker, err := event.NewWorker(
 				replConn, dbPool, requestDetailsContextKey, "event-worker",
 			)
 			if err != nil {
-				log.Printf("failed to create event worker: %s", err.Error())
+				slog.InfoContext(ctx, "failed to create event worker", "error", err.Error())
 			}
 			// this ends on error, so we loop and recreate the replication connection
 			err = eventWorker.Start(ctx)
 			if err != nil {
-				log.Printf("failure in event worker: %s", err.Error())
+				slog.InfoContext(ctx, "failure in event worker", "error", err.Error())
 
 				err = eventWorker.Stop(ctx)
 				if err != nil {
-					log.Printf("could not stop event worker: %s", err.Error())
+					slog.InfoContext(ctx, "could not stop event worker", "error", err.Error())
 				}
 
-				slog.Info("Waiting before retrying the event worker...")
+				slog.InfoContext(ctx, "Waiting before retrying the event worker...")
 				time.Sleep(15 * time.Second) //nolint:mnd
 			}
 		}
@@ -206,7 +209,7 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 
 	// finally the web server pointing to the handlers defined in the API service
 
-	slog.Info("Launching the web server... ")
+	slog.InfoContext(ctx, "Launching the web server... ")
 
 	router := gin.New()
 	slogginConfig := sloggin.Config{ //nolint:exhaustruct
@@ -242,7 +245,7 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 	}
 
 	addr := ":" + port
-	log.Println("Running server on server on", addr)
+	slog.InfoContext(ctx, "Running server on server on"+addr)
 	err = router.Run(addr)
 	if err != nil {
 		return fmt.Errorf("router failed: %w", err)

--- a/backend/pgpool/pool.go
+++ b/backend/pgpool/pool.go
@@ -20,7 +20,7 @@ package pgpool
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -46,7 +46,7 @@ func New(ctx context.Context, connString string, ctxKey string) (*Pool, error) {
 			"reset role",
 		)
 		if err != nil {
-			log.Println("failed to reset role:", err)
+			slog.InfoContext(ctx, "failed to reset role", "error", err)
 			// destroy the connection
 			return false
 		}
@@ -77,7 +77,7 @@ func (p *Pool) Acquire(ctx context.Context) (*Conn, error) {
 
 	role := userDetails.Role()
 
-	log.Println("acquiring connection for role", role)
+	slog.InfoContext(ctx, "acquiring connection for role", "role", role)
 
 	acquireCtx, cancel := context.WithTimeout(ctx, 5*time.Second) //nolint:mnd
 	defer cancel()

--- a/backend/pgrepl/connection.go
+++ b/backend/pgrepl/connection.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"strings"
 	"time"
@@ -124,7 +123,7 @@ func (replConn *Connection) ReceiveMessage(
 					return nil, lsnParseError(err)
 				}
 				if replConn.lsn > nextLSN {
-					slog.Info("replication skipping outdated message", "lsn", nextLSN)
+					slog.InfoContext(ctx, "replication skipping outdated message", "lsn", nextLSN)
 					continue
 				}
 				return &jsonWALMessage, nil
@@ -170,9 +169,9 @@ func (replConn *Connection) handlePrimaryKeepaliveMessage(
 		if err != nil {
 			return sendStandbyStatusUpdateError(err)
 		}
-		slog.Info("received PrimaryKeepaliveMessage and sent status update", "lsn", replConn.lsn.String())
+		slog.InfoContext(ctx, "received PrimaryKeepaliveMessage and sent status update", "lsn", replConn.lsn.String())
 	} else {
-		slog.Debug("received PrimaryKeepaliveMessage, no reply requested")
+		slog.DebugContext(ctx, "received PrimaryKeepaliveMessage, no reply requested")
 	}
 	return nil
 }
@@ -190,7 +189,7 @@ func (replConn *Connection) Acknowledge(msg *Message) error {
 
 // Close closes the replication connection.
 func (replConn *Connection) Close(ctx context.Context) error {
-	log.Printf("[%s] closing replication connection", replConn.logPrefix)
+	slog.InfoContext(ctx, "closing replication connection")
 	if err := replConn.conn.Close(ctx); err != nil {
 		return connectionCloseError(err)
 	}

--- a/docs-dev/logging.md
+++ b/docs-dev/logging.md
@@ -10,6 +10,8 @@ with formatting and structure, so this document will be updated as we go and a
 standard emerges. We should actively consider to add our own logging package or
 interface to bake in the practices we want to follow.
 
+Use of logging library is enforced via the `golangci-lint` config.
+
 ### Use context
 
 We should always log with context. This is future-proofing our logging in case


### PR DESCRIPTION
NOTE: I'm getting some false positives from sloglint which is annoying. If we keep on facing that we might need to disable and report a bug

> auth/auth.go:875:3: WarnContextContext should be used instead (sloglint)
>                slog.WarnContext(ctx, "error in get current user info", "error", err)

... WarnContextContext  is not a thing