### PR TITLE
feat(ui): add tooltips to input components (FLEX-456)

### DIFF
--- a/frontend/src/auth/FieldStack.tsx
+++ b/frontend/src/auth/FieldStack.tsx
@@ -1,6 +1,6 @@
 import { Children } from "react";
 import { useResourceContext, usePermissions, Labeled } from "react-admin";
-import { Stack as MUIStack, StackProps } from "@mui/material";
+import { Divider, Stack as MUIStack, StackProps } from "@mui/material";
 import { FieldTooltip } from "../tooltip/FieldTooltip";
 
 // custom Stack component forcing label display and hiding the underlying
@@ -19,7 +19,7 @@ export const FieldStack = (props: StackProps) => {
     );
 
   return (
-    <MUIStack {...rest}>
+    <MUIStack divider={<Divider flexItem orientation="vertical" />} {...rest}>
       {Children.map(children, (child: any) =>
         child.props.source ? addPermissionToField(child) : child,
       )}

--- a/frontend/src/auth/InputStack.tsx
+++ b/frontend/src/auth/InputStack.tsx
@@ -2,6 +2,7 @@ import { Children, cloneElement } from "react";
 import { useResourceContext, usePermissions } from "react-admin";
 import { Stack as MUIStack, StackProps } from "@mui/material";
 import { useCreateOrUpdate } from "../auth/useCreateOrUpdate";
+import { FieldTooltip } from "../tooltip/FieldTooltip";
 
 // custom Stack component disabling the underlying inputs based on permissions
 export const InputStack = (props: StackProps) => {
@@ -10,14 +11,18 @@ export const InputStack = (props: StackProps) => {
   const { permissions } = usePermissions();
   const createOrUpdate = useCreateOrUpdate();
 
-  const addPermissionToInput = (input: any) =>
-    cloneElement(input, {
-      disabled:
-        input.props.disabled ||
-        !permissions.includes(
-          `${resource}.${input.props.source}.${createOrUpdate}`,
-        ),
-    });
+  const addPermissionToInput = (input: any) => (
+    <>
+      <FieldTooltip resource={resource} field={input.props.source} />
+      {cloneElement(input, {
+        disabled:
+          input.props.disabled ||
+          !permissions.includes(
+            `${resource}.${input.props.source}.${createOrUpdate}`,
+          ),
+      })}
+    </>
+  );
 
   return (
     <MUIStack {...rest}>


### PR DESCRIPTION
Kind of 80/20 solution. Not perfect but very simple.

![Screenshot 2025-02-11 100648](https://github.com/user-attachments/assets/ffd59bfd-18db-4b38-a7b2-46cf819b1627)

Other options explored (but more complex and did not manage on the first try) :
- show the tooltip inside the input field, as a Material UI `InputAdornment` ;
- show the tooltip before or after the input field, on the same _horizontal_ line.

> [!NOTE]
> Side feature of this PR. Dividers between fields on show pages makes the UX of tooltips even better IMHO :
>
> ![Screenshot 2025-02-11 100922](https://github.com/user-attachments/assets/a470553a-2d87-4de1-b7ac-5083381a8896)
