### PR TITLE
feat(db): implement AP(EU) RLS policies with a security definer view (FLEX-445)

### DIFF
--- a/db/authz/controllable_unit_accounting_point_end_user.sql
+++ b/db/authz/controllable_unit_accounting_point_end_user.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE VIEW controllable_unit_accounting_point_end_user AS (
+    SELECT
+        cu.id AS controllable_unit_id,
+        ap.id AS accounting_point_id,
+        ap.system_operator_id AS connecting_system_operator_id,
+        apeu.end_user_id,
+        apeu.valid_time_range AS end_user_valid_time_range
+    FROM flex.controllable_unit AS cu
+        INNER JOIN flex.accounting_point AS ap
+            ON cu.accounting_point_id = ap.business_id
+        LEFT JOIN flex.accounting_point_end_user AS apeu
+            ON ap.id = apeu.accounting_point_id
+);
+
+GRANT SELECT ON TABLE controllable_unit_accounting_point_end_user
+TO flex_common;
+
+GRANT SELECT ON TABLE controllable_unit_accounting_point_end_user
+TO flex_internal_event_notification;

--- a/db/authz/controllable_unit_end_user.sql
+++ b/db/authz/controllable_unit_end_user.sql
@@ -1,8 +1,6 @@
-CREATE OR REPLACE VIEW controllable_unit_accounting_point_end_user AS (
+CREATE OR REPLACE VIEW controllable_unit_end_user AS (
     SELECT
         cu.id AS controllable_unit_id,
-        ap.id AS accounting_point_id,
-        ap.system_operator_id AS connecting_system_operator_id,
         apeu.end_user_id,
         apeu.valid_time_range AS end_user_valid_time_range
     FROM flex.controllable_unit AS cu
@@ -12,8 +10,8 @@ CREATE OR REPLACE VIEW controllable_unit_accounting_point_end_user AS (
             ON ap.id = apeu.accounting_point_id
 );
 
-GRANT SELECT ON TABLE controllable_unit_accounting_point_end_user
+GRANT SELECT ON TABLE controllable_unit_end_user
 TO flex_common;
 
-GRANT SELECT ON TABLE controllable_unit_accounting_point_end_user
+GRANT SELECT ON TABLE controllable_unit_end_user
 TO flex_internal_event_notification;

--- a/db/flex/controllable_unit_rls.sql
+++ b/db/flex/controllable_unit_rls.sql
@@ -28,10 +28,10 @@ FOR ALL
 TO flex_system_operator
 USING (
     EXISTS (
-        SELECT 1
-        FROM controllable_unit_accounting_point_end_user AS cuapeu
-        WHERE cuapeu.controllable_unit_id = controllable_unit.id -- noqa
-            AND cuapeu.connecting_system_operator_id = current_party()
+        SELECT 1 FROM
+            accounting_point
+        WHERE accounting_point.business_id = controllable_unit.accounting_point_id --noqa
+            AND accounting_point.system_operator_id = current_party()
     )
 );
 
@@ -95,10 +95,10 @@ TO flex_end_user
 USING (
     EXISTS (
         SELECT 1
-        FROM controllable_unit_accounting_point_end_user AS cuapeu
-        WHERE cuapeu.controllable_unit_id = controllable_unit.id -- noqa
-            AND cuapeu.end_user_id = current_party()
-            AND cuapeu.end_user_valid_time_range @> current_timestamp
+        FROM controllable_unit_end_user AS cueu
+        WHERE cueu.controllable_unit_id = controllable_unit.id -- noqa
+            AND cueu.end_user_id = current_party()
+            AND cueu.end_user_valid_time_range @> current_timestamp
     )
 );
 
@@ -114,12 +114,12 @@ TO flex_end_user
 USING (
     EXISTS (
         SELECT 1
-        FROM controllable_unit_accounting_point_end_user AS cuapeu
-        WHERE cuapeu.controllable_unit_id = controllable_unit_history.id -- noqa
+        FROM controllable_unit_end_user AS cueu
+        WHERE cueu.controllable_unit_id = controllable_unit_history.id -- noqa
             -- this version of the CU in the history was in effect
             -- when the current party was the end user of its AP
-            AND cuapeu.end_user_id = current_party()
-            AND cuapeu.end_user_valid_time_range && controllable_unit_history.record_time_range -- noqa
+            AND cueu.end_user_id = current_party()
+            AND cueu.end_user_valid_time_range && controllable_unit_history.record_time_range -- noqa
     )
 );
 

--- a/db/flex/controllable_unit_rls.sql
+++ b/db/flex/controllable_unit_rls.sql
@@ -28,10 +28,10 @@ FOR ALL
 TO flex_system_operator
 USING (
     EXISTS (
-        SELECT 1 FROM
-            accounting_point
-        WHERE accounting_point.business_id = controllable_unit.accounting_point_id --noqa
-            AND accounting_point.system_operator_id = current_party()
+        SELECT 1
+        FROM controllable_unit_accounting_point_end_user AS cuapeu
+        WHERE cuapeu.controllable_unit_id = controllable_unit.id -- noqa
+            AND cuapeu.connecting_system_operator_id = current_party()
     )
 );
 
@@ -88,34 +88,17 @@ USING (
 );
 
 -- RLS: CU-EU001
-
--- check as a SECURITY DEFINER function because AP/APEU have restricted access
-CREATE OR REPLACE FUNCTION check_cu_eu001(
-    eu_id bigint, cu_ap_id text
-)
-RETURNS boolean
-SECURITY DEFINER
-LANGUAGE sql
-AS $$
-SELECT EXISTS (
-    SELECT 1
-        FROM accounting_point AS ap
-        INNER JOIN accounting_point_end_user AS apeu
-            ON apeu.accounting_point_id = ap.id
-    WHERE ap.business_id = cu_ap_id
-        AND apeu.end_user_id = eu_id
-        AND apeu.valid_time_range @> current_timestamp
-);
-$$;
-
 GRANT SELECT ON controllable_unit TO flex_end_user;
 CREATE POLICY "CU_EU001" ON controllable_unit
 FOR SELECT
 TO flex_end_user
 USING (
-    check_cu_eu001(
-        current_party(),
-        controllable_unit.accounting_point_id
+    EXISTS (
+        SELECT 1
+        FROM controllable_unit_accounting_point_end_user AS cuapeu
+        WHERE cuapeu.controllable_unit_id = controllable_unit.id -- noqa
+            AND cuapeu.end_user_id = current_party()
+            AND cuapeu.end_user_valid_time_range @> current_timestamp
     )
 );
 
@@ -123,38 +106,20 @@ ALTER TABLE IF EXISTS controllable_unit_history
 ENABLE ROW LEVEL SECURITY;
 
 -- RLS: CU-EU002
-
--- check as a SECURITY DEFINER function because AP/APEU have restricted access
-CREATE OR REPLACE FUNCTION check_cu_eu002(
-    eu_id bigint, cuh_ap_id text, cuh_record_time_range tstzrange
-)
-RETURNS boolean
-SECURITY DEFINER
-LANGUAGE sql
-AS $$
-SELECT EXISTS (
-    SELECT 1
-        FROM accounting_point AS ap
-        INNER JOIN accounting_point_end_user AS apeu
-            ON apeu.accounting_point_id = ap.id
-    WHERE ap.business_id = cuh_ap_id
-        -- this version of the CU in the history was in effect
-        -- when the current party was the end user of its AP
-        AND apeu.end_user_id = eu_id
-        AND apeu.valid_time_range && cuh_record_time_range
-);
-$$;
-
 GRANT SELECT ON controllable_unit_history TO flex_end_user;
 CREATE POLICY "CU_EU002"
 ON controllable_unit_history
 FOR SELECT
 TO flex_end_user
 USING (
-    check_cu_eu002(
-        current_party(),
-        controllable_unit_history.accounting_point_id,
-        controllable_unit_history.record_time_range
+    EXISTS (
+        SELECT 1
+        FROM controllable_unit_accounting_point_end_user AS cuapeu
+        WHERE cuapeu.controllable_unit_id = controllable_unit_history.id -- noqa
+            -- this version of the CU in the history was in effect
+            -- when the current party was the end user of its AP
+            AND cuapeu.end_user_id = current_party()
+            AND cuapeu.end_user_valid_time_range && controllable_unit_history.record_time_range -- noqa
     )
 );
 

--- a/db/flex/controllable_unit_service_provider_rls.sql
+++ b/db/flex/controllable_unit_service_provider_rls.sql
@@ -61,10 +61,10 @@ TO flex_end_user
 USING (
     EXISTS (
         SELECT 1
-        FROM controllable_unit_accounting_point_end_user AS cuapeu
-        WHERE cuapeu.controllable_unit_id = controllable_unit_service_provider.controllable_unit_id -- noqa
-            AND cuapeu.end_user_id = current_party()
-            AND cuapeu.end_user_valid_time_range && controllable_unit_service_provider.valid_time_range -- noqa
+        FROM controllable_unit_end_user AS cueu
+        WHERE cueu.controllable_unit_id = controllable_unit_service_provider.controllable_unit_id -- noqa
+            AND cueu.end_user_id = current_party()
+            AND cueu.end_user_valid_time_range && controllable_unit_service_provider.valid_time_range -- noqa
     )
 );
 
@@ -81,12 +81,12 @@ TO flex_end_user
 USING (
     EXISTS (
         SELECT 1
-        FROM controllable_unit_accounting_point_end_user AS cuapeu
-        WHERE cuapeu.controllable_unit_id = controllable_unit_service_provider_history.controllable_unit_id -- noqa
+        FROM controllable_unit_end_user AS cueu
+        WHERE cueu.controllable_unit_id = controllable_unit_service_provider_history.controllable_unit_id -- noqa
             -- this version of the CUSP in the history puts the contract in the
             -- period when the current party is the end user of the AP
-            AND cuapeu.end_user_id = current_party()
-            AND cuapeu.end_user_valid_time_range && controllable_unit_service_provider_history.valid_time_range -- noqa
+            AND cueu.end_user_id = current_party()
+            AND cueu.end_user_valid_time_range && controllable_unit_service_provider_history.valid_time_range -- noqa
     )
 );
 

--- a/db/flex_structure.sql
+++ b/db/flex_structure.sql
@@ -48,6 +48,10 @@ and support the processes in the value chain.$$;
 \i flex/system_operator_product_type_history_audit.sql
 \i flex/technical_resource_history_audit.sql
 
+-- security definer views for RLS
+
+\i authz/controllable_unit_accounting_point_end_user.sql
+
 -- RLS
 
 \i flex/accounting_point_rls.sql

--- a/db/flex_structure.sql
+++ b/db/flex_structure.sql
@@ -50,7 +50,7 @@ and support the processes in the value chain.$$;
 
 -- security definer views for RLS
 
-\i authz/controllable_unit_accounting_point_end_user.sql
+\i authz/controllable_unit_end_user.sql
 
 -- RLS
 

--- a/justfile
+++ b/justfile
@@ -259,8 +259,20 @@ openapi-to-db:
     imports=$(ls db/flex | grep history_audit | sed -e 's|.*|\\i flex/&|')
 
     ed -s "./db/flex_structure.sql" <<EOF
-    /-- history and audit/+,/-- RLS/-d
+    /-- history and audit/+,/-- security/-d
     /-- history and audit/a
+
+    ${imports}
+
+    .
+    wq
+    EOF
+
+    imports=$(ls db/authz | sed -e 's|.*|\\i authz/&|')
+
+    ed -s "./db/flex_structure.sql" <<EOF
+    /-- security/+,/-- RLS/-d
+    /-- security/a
 
     ${imports}
 


### PR DESCRIPTION
This PR reimplements the RLS using `accounting_point` and `accounting_point_end_user` with an internal security definer view. First experimentation before further refactoring in our database architecture.

> [!NOTE]
> The view is in a distinct `authz` folder with already some logic in the scripts to be able to declare several of them later on. The intent is to isolate such _internal views_ from both _internal tables_ in the `flex` schema and _exposed views_ in the `api` schema.
>
> However, as the added internal view is used to define RLS policies, it still technically belongs to the `flex` schema. We can decide to change that later, but currently the architecture creates a mutual dependency between the `flex` schema and the (potential, future) `authz` schema.