### PR TITLE
feat(backend): move URL rewrites from nginx to the backend (FLEX-454)

### DIFF
--- a/backend/data/data.go
+++ b/backend/data/data.go
@@ -51,20 +51,19 @@ func (data *API) PostgRESTHandler(ctx *gin.Context) {
 	header := ctx.Request.Header
 
 	// rewrite the URL and query to match the PostgREST format
-	matchIDHistory := regexIDHistory.FindStringSubmatch(url)
-	if matchIDHistory != nil {
-		slog.InfoContext(ctx, "sor", "url", url, "match", matchIDHistory)
-		if matchIDHistory[3] != "" { // history
-			url = "/" + matchIDHistory[1] + "_history"
-			query.Set(matchIDHistory[1]+"_id", "eq."+matchIDHistory[2])
+	if match := regexIDHistory.FindStringSubmatch(url); match != nil {
+		if match[3] != "" { // history
+			url = "/" + match[1] + "_history"
+			query.Set(match[1]+"_id", "eq."+match[2])
 			slog.InfoContext(
 				ctx,
 				"API call targeting a history resource. Rewriting into PostgREST format.",
 				"new url", url, "new query", query.Encode(),
 			)
 		} else { // single ID
-			url = "/" + matchIDHistory[1]
-			query.Set("id", "eq."+matchIDHistory[2])
+			url = "/" + match[1]
+			query.Set("id", "eq."+match[2])
+			// force PostgREST to return a single object
 			header.Set("Accept", "application/vnd.pgrst.object+json")
 			slog.InfoContext(
 				ctx,

--- a/local/nginx/templates/flex.conf
+++ b/local/nginx/templates/flex.conf
@@ -119,21 +119,6 @@ server {
         proxy_hide_header X-Powered-By;
         proxy_hide_header Server;
 
-        # Singular "by ID" endpoint rewrite
-        # This is because PostgREST does not support singular endpoints,
-        # but we want it in our API
-        location ~ ^/api/v0/([a-z_]+)/([0-9]+)$ {
-            proxy_set_header Accept 'application/vnd.pgrst.object+json';
-            proxy_pass ${NGINX_UPSTREAM_BACKEND}/api/v0/$1?id=eq.$2;
-        }
-
-        # Redirect history nested endpoint
-        # From <base>/<resource>/<id>/history
-        # To   <base>/<resource>_history?<resource>_id=eq.<id>
-        location ~ ^/api/v0/([a-z_]+)/([0-9]+)/history$ {
-            return 307 /api/v0/$1_history?$1_id=eq.$2;
-        }
-
         proxy_pass ${NGINX_UPSTREAM_BACKEND}/api/v0/;
 
         # We want response that matches the error_message schema in the OpenAPI spec

--- a/local/nginx/templates/local.conf
+++ b/local/nginx/templates/local.conf
@@ -122,21 +122,6 @@ server {
         proxy_hide_header X-Powered-By;
         proxy_hide_header Server;
 
-        # Singular "by ID" endpoint rewrite
-        # This is because PostgREST does not support singular endpoints,
-        # but we want it in our API
-        location ~ ^/api/v0/([a-z_]+)/([0-9]+)$ {
-            proxy_set_header Accept 'application/vnd.pgrst.object+json';
-            proxy_pass ${NGINX_UPSTREAM_BACKEND}/api/v0/$1?id=eq.$2;
-        }
-
-        # Redirect history nested endpoint
-        # From <base>/<resource>/<id>/history
-        # To   <base>/<resource>_history?<resource>_id=eq.<id>
-        location ~ ^/api/v0/([a-z_]+)/([0-9]+)/history$ {
-            return 307 /api/v0/$1_history?$1_id=eq.$2;
-        }
-
         proxy_pass ${NGINX_UPSTREAM_BACKEND}/api/v0/;
 
         # We want response that matches the error_message schema in the OpenAPI spec


### PR DESCRIPTION
Attempt at moving URL rewrites for single-ID and history pages from nginx to the backend.