### PR TITLE
feat(backend): support subresource URLs in backend (FLEX-454)

### DIFF
--- a/backend/data/data.go
+++ b/backend/data/data.go
@@ -42,9 +42,9 @@ func NewAPI(
 
 // PostgRESTHandler forwards the request to the PostgREST API.
 func (data *API) PostgRESTHandler(ctx *gin.Context) {
-	// regex for calls targeting a single ID and history pages, which are not
-	// valid formats in PostgREST
-	regexIDHistory := regexp.MustCompile("^/([a-z_]+)/([0-9]+)(/history)?$")
+	// regex for calls targeting a single ID and subresource/history pages,
+	// which are not valid formats in PostgREST
+	regexIDSubHistory := regexp.MustCompile("^/([a-z_]+)/([0-9]+)(/[a-z_]+)?$")
 
 	url := ctx.Param("url")
 	query := ctx.Request.URL.Query()
@@ -61,13 +61,14 @@ func (data *API) PostgRESTHandler(ctx *gin.Context) {
 	}
 
 	// rewrite the URL and query to match the PostgREST format
-	if match := regexIDHistory.FindStringSubmatch(url); match != nil {
-		if match[3] != "" { // history
-			url = "/" + match[1] + "_history"
+	if match := regexIDSubHistory.FindStringSubmatch(url); match != nil {
+		if match[3] != "" { // subresource or history
+			url = fmt.Sprintf("/%s_%s", match[1], match[3][1:])
 			query.Set(match[1]+"_id", "eq."+match[2])
 			slog.InfoContext(
 				ctx,
-				"API call targeting a history resource. Rewriting into PostgREST format.",
+				"API call targeting a subresource or history resource. "+
+					"Rewriting into PostgREST format.",
 				"new url", url, "new query", query.Encode(),
 			)
 		} else { // single ID


### PR DESCRIPTION
Support for URLs like `/controllable_unit/3/service_provider` or `/controllable_unit/7/history`.