### PR TITLE
feat: limit CU-SP updates as SP to valid time within the 2 last weeks (FLEX-463)

### DIFF
--- a/db/flex/controllable_unit_service_provider.sql
+++ b/db/flex/controllable_unit_service_provider.sql
@@ -47,3 +47,32 @@ CREATE OR REPLACE TRIGGER controllable_unit_service_provider_event
 AFTER INSERT OR UPDATE OR DELETE ON controllable_unit_service_provider
 FOR EACH ROW
 EXECUTE FUNCTION capture_event('controllable_unit_service_provider');
+
+CREATE OR REPLACE FUNCTION controllable_unit_service_provider_sp_time_limit()
+RETURNS trigger
+SECURITY INVOKER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF (
+        upper(OLD.valid_time_range) IS NOT NULL
+        AND upper(OLD.valid_time_range) < current_timestamp - '2 weeks'::interval
+    ) THEN
+        RAISE sqlstate 'PT400' using
+            message = 'The contract is too old and cannot be modified';
+        RETURN null;
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN null;
+    ELSE
+        RETURN NEW;
+    END IF;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER controllable_unit_service_provider_sp_time_limit
+AFTER INSERT OR UPDATE OR DELETE ON controllable_unit_service_provider
+FOR EACH ROW
+WHEN (current_role = 'flex_service_provider')
+EXECUTE FUNCTION controllable_unit_service_provider_sp_time_limit();


### PR DESCRIPTION
With test dependent on today's date, so it does not become outdated.