### PR TITLE
feat(ui): allow creating a CU-SP from the CU ID (FLEX-470)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -576,6 +576,22 @@ export const App = () => (
             />
           </Resource>
         ) : null}
+        {permissions.includes("controllable_unit_service_provider.read") ? (
+          <Resource
+            name="controllable_unit_service_provider"
+            create={
+              permissions.includes(
+                "controllable_unit_service_provider.create",
+              ) ? (
+                <Create redirect={() => `controllable_unit`}>
+                  <ControllableUnitServiceProviderInput />
+                </Create>
+              ) : (
+                (null as any)
+              )
+            }
+          />
+        ) : null}
         {permissions.includes("service_providing_group.read") ? (
           <Resource
             name="service_providing_group"

--- a/frontend/src/controllable_unit/ControllableUnitList.tsx
+++ b/frontend/src/controllable_unit/ControllableUnitList.tsx
@@ -1,14 +1,34 @@
 import {
   List,
+  Button,
   BooleanField,
   ReferenceField,
   TextField,
   SelectArrayInput,
+  ExportButton,
+  CreateButton,
+  usePermissions,
+  TopToolbar,
 } from "react-admin";
 import { Datagrid } from "../auth";
 import { DateField } from "../datetime";
+import { Link } from "react-router-dom";
+import AddIcon from "@mui/icons-material/Add";
+
+const CreateCUSPButton = () => (
+  <Button
+    component={Link}
+    to={`/controllable_unit_service_provider/create`}
+    startIcon={<AddIcon />}
+    // used to be able to input a CU ID instead of picking from the known CUs
+    state={{ fromCUList: true }}
+    label="Manage another controllable unit"
+  />
+);
 
 export const ControllableUnitList = () => {
+  const { permissions } = usePermissions();
+
   const controllableUnitFilters = [
     <SelectArrayInput
       key="status"
@@ -19,12 +39,23 @@ export const ControllableUnitList = () => {
     />,
   ];
 
+  const ListActions = () => (
+    <TopToolbar>
+      {permissions.includes("controllable_unit_service_provider.create") && (
+        <CreateCUSPButton />
+      )}
+      {permissions.includes("controllable_unit.create") && <CreateButton />}
+      <ExportButton />
+    </TopToolbar>
+  );
+
   return (
     <List
       perPage={25}
       sort={{ field: "id", order: "DESC" }}
       empty={false}
       filters={controllableUnitFilters}
+      actions={<ListActions />}
     >
       <Datagrid>
         <TextField source="id" label="ID" />

--- a/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderInput.tsx
+++ b/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderInput.tsx
@@ -1,4 +1,5 @@
 import {
+  NumberInput,
   required,
   SimpleForm,
   TextInput,
@@ -39,6 +40,10 @@ export const ControllableUnitServiceProviderInput = () => {
   const { data: identity, isLoading: identityLoading } = useGetIdentity();
   if (identityLoading) return <>Loading...</>;
 
+  // if we came to this page from the CU list, we want to input a CU ID,
+  // instead of selecting it from a list of already readable CUs
+  const isCreateFromCUList: boolean = !!overrideRecord?.fromCUList;
+
   // priority to the restored values if they exist, otherwise normal edit mode
   const record = filterRecord({ ...actualRecord, ...overrideRecord });
 
@@ -64,11 +69,15 @@ export const ControllableUnitServiceProviderInput = () => {
           Basic information
         </Typography>
         <InputStack direction="row" flexWrap="wrap">
-          <AutocompleteReferenceInput
-            source="controllable_unit_id"
-            reference="controllable_unit"
-            readOnly
-          />
+          {isCreateFromCUList ? (
+            <NumberInput source="controllable_unit_id" />
+          ) : (
+            <AutocompleteReferenceInput
+              source="controllable_unit_id"
+              reference="controllable_unit"
+              readOnly
+            />
+          )}
           <PartyReferenceInput
             source="service_provider_id"
             readOnly={isServiceProvider}

--- a/test/api_client_tests/test_cusp.py
+++ b/test/api_client_tests/test_cusp.py
@@ -184,6 +184,10 @@ def test_cusp_sp(data):
     client_sp = sts.get_client(TestEntity.TEST, "SP")
     sp_id = sts.get_userinfo(client_sp)["party_id"]
 
+    # SP can do CU-SP without seeing the CU, they just need the ID
+    cu = read_controllable_unit.sync(client=client_sp, id=cu_id)
+    assert isinstance(cu, ErrorMessage)
+
     # check SP can read the CU-SP relations they are responsible for
 
     cusps_sp = list_controllable_unit_service_provider.sync(


### PR DESCRIPTION
This PR makes it possible to create a CU-SP contract in the portal without having to choose a CU from the readable ones.

> [!IMPORTANT]
> Funnily, this is only a UI update. CUSP-SP001 covers the need on the db side. Tests already work with SP not being able to read the CU as the added check to the test shows.