### PR TITLE
feat(db): ensure SPGM/CU-SP consistency on SPGM insert/update (FLEX-125)

### DIFF
--- a/db/flex/service_providing_group_membership.sql
+++ b/db/flex/service_providing_group_membership.sql
@@ -56,7 +56,8 @@ BEGIN
 
     IF lv_match_count = 0 THEN
       RAISE 'The CU must be managed by the SP from % to %',
-        lower(NEW.valid_time_range), upper(NEW.valid_time_range);
+        timeline_timestamptz_to_text(lower(NEW.valid_time_range)),
+        timeline_timestamptz_to_text(upper(NEW.valid_time_range));
     END IF;
 
     RETURN NEW;

--- a/db/flex/service_providing_group_membership_rls.sql
+++ b/db/flex/service_providing_group_membership_rls.sql
@@ -46,13 +46,13 @@ USING (EXISTS (
 WITH CHECK (
     EXISTS (
         SELECT 1
-        FROM service_providing_group, controllable_unit_service_provider
-        WHERE service_providing_group_membership.service_providing_group_id = service_providing_group.id -- noqa
-            AND service_providing_group.service_provider_id = current_party()
-            AND service_providing_group_membership.controllable_unit_id --noqa
-            = controllable_unit_service_provider.controllable_unit_id
-            AND controllable_unit_service_provider.service_provider_id
-            = current_party()
+        FROM controllable_unit_service_provider AS cusp
+            INNER JOIN service_providing_group AS spg
+                ON cusp.service_provider_id = spg.service_provider_id
+        WHERE spg.service_provider_id = current_party()
+            AND cusp.controllable_unit_id = service_providing_group_membership.controllable_unit_id -- noqa
+            AND spg.id = service_providing_group_membership.service_providing_group_id -- noqa
+            AND cusp.valid_time_range @> service_providing_group_membership.valid_time_range -- noqa
     )
 );
 


### PR DESCRIPTION
SPGM-only part of https://github.com/elhub/flex-information-system/pull/53 because it is the part we are sure about for now.

Basically not much to change here, just a better join and an additional constraint on the valid time range, which was missing. Indeed, the former policy was wrong because it authorised the operation as soon as there is one contract, it did not check _when_.

The tests, which were already good for our current needs, were only green by chance, so nothing changes on that side.