### PR TITLE
feat(backend): notify end user on CU-SP update (FLEX-469)

### DIFF
--- a/backend/event/models.sql
+++ b/backend/event/models.sql
@@ -57,13 +57,32 @@ AND tstzrange(cusph.recorded_at, cusph.replaced_at, '[)') @> @recorded_at::times
 AND tstzrange(cusph.valid_from, cusph.valid_to, '[)') @> @recorded_at::timestamptz;
 
 -- name: GetControllableUnitServiceProviderUpdateDeleteNotificationRecipients :many
-SELECT unnest(
-    array[cusp.service_provider_id, cu.connecting_system_operator_id]
+SELECT DISTINCT unnest(
+    array_remove(
+        array[
+            cusph.service_provider_id,
+            cu.connecting_system_operator_id,
+            apeu.end_user_id
+        ],
+        null
+    )
 )::bigint
-FROM controllable_unit_service_provider cusp
-INNER JOIN controllable_unit cu ON cu.id = cusp.controllable_unit_id
-WHERE cusp.id = @resource_id;
--- not using history on CU-SP for CU ID and SP ID because they are stable
+FROM (
+    SELECT
+        cusph.service_provider_id, cusph.controllable_unit_id,
+        cusph.valid_from, cusph.valid_to
+    FROM controllable_unit_service_provider_history AS cusph
+    WHERE cusph.controllable_unit_service_provider_id = @resource_id
+    AND cusph.recorded_at <= @recorded_at
+    ORDER BY cusph.recorded_at DESC LIMIT 2
+) AS cusph
+INNER JOIN controllable_unit AS cu ON cu.id = cusph.controllable_unit_id
+INNER JOIN accounting_point AS ap ON ap.business_id = cu.accounting_point_id
+LEFT JOIN accounting_point_end_user AS apeu ON apeu.accounting_point_id = ap.id
+WHERE apeu.valid_time_range && tstzrange(cusph.valid_from, cusph.valid_to, '[)');
+-- using history on CU-SP because EU depends on valid time
+--   the subquery allows us to get only the 2 latest versions of CU-SP at the
+--   time of the event (i.e., both versions before and after the update)
 -- not using history on CU because AP ID is stable
 
 -- name: GetControllableUnitServiceProviderCreateNotificationRecipients :many

--- a/backend/event/models.sql
+++ b/backend/event/models.sql
@@ -79,11 +79,15 @@ FROM (
 INNER JOIN controllable_unit AS cu ON cu.id = cusph.controllable_unit_id
 INNER JOIN accounting_point AS ap ON ap.business_id = cu.accounting_point_id
 LEFT JOIN accounting_point_end_user AS apeu ON apeu.accounting_point_id = ap.id
-WHERE apeu.valid_time_range && tstzrange(cusph.valid_from, cusph.valid_to, '[)');
+WHERE apeu.valid_time_range @> cusph.valid_from;
 -- using history on CU-SP because EU depends on valid time
 --   the subquery allows us to get only the 2 latest versions of CU-SP at the
 --   time of the event (i.e., both versions before and after the update)
 -- not using history on CU because AP ID is stable
+-- just checking the start of the CU-SP valid time because functionally
+--   speaking, this valid time should actually be aligned with the end user
+--   valid time, so it is a way to avoid notifying people that are not really
+--   concerned when we just correct a mistake
 
 -- name: GetControllableUnitServiceProviderCreateNotificationRecipients :many
 SELECT unnest(

--- a/backend/event/models/models.custom.go
+++ b/backend/event/models/models.custom.go
@@ -22,7 +22,9 @@ func (q *Queries) GetNotificationRecipients( //nolint:cyclop
 		return q.GetControllableUnitServiceProviderCreateNotificationRecipients(ctx, resourceID)
 	case "no.elhub.flex.controllable_unit_service_provider.update",
 		"no.elhub.flex.controllable_unit_service_provider.delete":
-		return q.GetControllableUnitServiceProviderUpdateDeleteNotificationRecipients(ctx, resourceID)
+		return q.GetControllableUnitServiceProviderUpdateDeleteNotificationRecipients(
+			ctx, resourceID, recordedAt,
+		)
 	case "no.elhub.flex.system_operator_product_type.create":
 		return q.GetSystemOperatorProductTypeCreateNotificationRecipients(ctx, resourceID, recordedAt)
 	case "no.elhub.flex.system_operator_product_type.update",

--- a/docs/resources/controllable_unit_service_provider.md
+++ b/docs/resources/controllable_unit_service_provider.md
@@ -45,7 +45,7 @@ No validation rules.
 |------------------------|-----------------------------------------------------------|---------|
 | create, update, delete | SP                                                        |         |
 | create, update, delete | Connecting SO                                             |         |
-| create                 | End user(s) in charge of the AP during the CU-SP contract |         |
+| create, update, delete | End user(s) in charge of the AP during the CU-SP contract |         |
 
 ## Authorization
 


### PR DESCRIPTION
This PR adds notifications for end users behind a controllable unit during the valid time period of a CU-SP contract when this contract changes. Both the end users _before and after_ the update are notified.

This change supports the delete operation on CU-SP because it is a soft delete, _i.e._, turned into an update.