### PR TITLE
feat(backend): lower log level on primary keepalive replication messages (FLEX-464)

### DIFF
--- a/backend/pgrepl/connection.go
+++ b/backend/pgrepl/connection.go
@@ -169,9 +169,14 @@ func (replConn *Connection) handlePrimaryKeepaliveMessage(
 		if err != nil {
 			return sendStandbyStatusUpdateError(err)
 		}
-		slog.InfoContext(ctx, "received PrimaryKeepaliveMessage and sent status update", "lsn", replConn.lsn.String())
+		slog.DebugContext(
+			ctx, "received PrimaryKeepaliveMessage and sent status update",
+			"lsn", replConn.lsn.String(),
+		)
 	} else {
-		slog.DebugContext(ctx, "received PrimaryKeepaliveMessage, no reply requested")
+		slog.DebugContext(
+			ctx, "received PrimaryKeepaliveMessage, no reply requested",
+		)
 	}
 	return nil
 }

--- a/backend/pgrepl/connection.go
+++ b/backend/pgrepl/connection.go
@@ -169,6 +169,9 @@ func (replConn *Connection) handlePrimaryKeepaliveMessage(
 		if err != nil {
 			return sendStandbyStatusUpdateError(err)
 		}
+		slog.InfoContext(ctx, "received PrimaryKeepaliveMessage and sent status update", "lsn", replConn.lsn.String())
+	} else {
+		slog.DebugContext(ctx, "received PrimaryKeepaliveMessage, no reply requested")
 	}
 	return nil
 }

--- a/backend/pgrepl/connection.go
+++ b/backend/pgrepl/connection.go
@@ -169,9 +169,6 @@ func (replConn *Connection) handlePrimaryKeepaliveMessage(
 		if err != nil {
 			return sendStandbyStatusUpdateError(err)
 		}
-		slog.InfoContext(ctx, "received PrimaryKeepaliveMessage and sent status update", "lsn", replConn.lsn.String())
-	} else {
-		slog.DebugContext(ctx, "received PrimaryKeepaliveMessage, no reply requested")
 	}
 	return nil
 }


### PR DESCRIPTION
This small change reduces the noise in the backend logs. We can do more or less than that :

⏫ A _harder_ approach would be to also hide the specific log of the event worker acquiring a connection everytime it wants to check the events, but it requires a bit more work because this log is actually useful for other roles in the system.

⏬ A _softer_ approach would be to keep the keepalive logs, but only at the `DEBUG` level, so we can filter this out when checking the logs.