### PR TITLE
feat(ui): link-to-resource buttons on notice list (FLEX-125)

### DIFF
--- a/frontend/src/ResourceButton.tsx
+++ b/frontend/src/ResourceButton.tsx
@@ -1,11 +1,12 @@
-import { Button, useGetOne, useRecordContext } from "react-admin";
+import { Button, useGetOne } from "react-admin";
 import { Link } from "react-router-dom";
 import DataObjectIcon from "@mui/icons-material/DataObject";
 import { CircularProgress } from "@mui/material";
 
-// Helper to build UI paths to subresource pages.
-// We need this because events follow the flat hierarchy of the database where
-// everything is a resource (subresources are only in the UI as a way to
+// Helper to build UI paths to subresource pages based on `source` fields in
+// events and notices, i.e., `resource/id` formats.
+// We need this because such fields follow the flat hierarchy of the database
+// where everything is a resource (subresources are only in the UI as a way to
 // organise and group pages together).
 const getSubResourceInformation = (resource: string) => {
   switch (resource) {
@@ -59,29 +60,24 @@ const getSubResourceInformation = (resource: string) => {
   }
 };
 
+// button to use as a link to a resource based on a source format (see above)
 export const ResourceButton = (props: any) => {
-  const eventRecord = useRecordContext()!;
+  const { source, ...rest } = props;
 
-  const {
-    data: event,
-    isPending: eventPending,
-    error: eventError,
-  } = useGetOne("event", { id: eventRecord.event_id });
-  const resource = event?.source.split("/")[1];
-  const id = event?.source.split("/")[2];
+  const resource = source.split("/")[1];
+  const id = source.split("/")[2];
   const {
     data: resourceRecord,
     isPending: resourcePending,
     error: resourceError,
   } = useGetOne(resource, { id: id });
   const subResourceInfo = getSubResourceInformation(resource);
-  const operation = event?.type.split(".").slice(-1);
 
-  if (eventPending || resourcePending) {
+  if (resourcePending) {
     return <CircularProgress size={25} thickness={2} />;
   }
 
-  if (eventError || resourceError) {
+  if (resourceError) {
     return null;
   }
 
@@ -97,8 +93,7 @@ export const ResourceButton = (props: any) => {
       }
       label="Go to resource"
       startIcon={<DataObjectIcon />}
-      disabled={operation == "delete"}
-      {...props}
+      {...rest}
     />
   );
 };

--- a/frontend/src/notice/NoticeList.tsx
+++ b/frontend/src/notice/NoticeList.tsx
@@ -1,5 +1,17 @@
-import { FunctionField, List, ReferenceField, TextField } from "react-admin";
+import {
+  FunctionField,
+  List,
+  ReferenceField,
+  TextField,
+  useRecordContext,
+} from "react-admin";
 import { Datagrid } from "../auth";
+import { ResourceButton } from "../ResourceButton";
+
+export const NoticeResourceButton = () => {
+  const noticeRecord = useRecordContext()!;
+  return <ResourceButton source={noticeRecord.source} />;
+};
 
 export const NoticeList = () => (
   <List perPage={25} sort={{ field: "id", order: "DESC" }} empty={false}>
@@ -14,6 +26,7 @@ export const NoticeList = () => (
         source="data"
         render={(record) => (record.data ? JSON.stringify(record.data) : "{}")}
       />
+      <NoticeResourceButton />
     </Datagrid>
   </List>
 );

--- a/frontend/src/notification/NotificationShow.tsx
+++ b/frontend/src/notification/NotificationShow.tsx
@@ -5,13 +5,38 @@ import {
   Show,
   SimpleShowLayout,
   TextField,
+  useGetOne,
+  useRecordContext,
 } from "react-admin";
-import { Typography, Stack } from "@mui/material";
+import { Typography, Stack, CircularProgress } from "@mui/material";
 import { FieldStack } from "../auth";
 import { DateField } from "../datetime";
 import { AcknowledgeButton } from "./AcknowledgeButton";
-import { ResourceButton } from "./ResourceButton";
+import { ResourceButton } from "../ResourceButton";
 import { IdentityField } from "../IdentityField";
+
+export const EventResourceButton = () => {
+  const eventRecord = useRecordContext()!;
+  const {
+    data: event,
+    isPending: eventPending,
+    error: eventError,
+  } = useGetOne("event", { id: eventRecord.event_id });
+
+  if (eventPending) {
+    return <CircularProgress size={25} thickness={2} />;
+  }
+
+  if (eventError) {
+    return null;
+  }
+
+  const operation = event?.type.split(".").slice(-1);
+
+  return (
+    <ResourceButton source={event?.source} disabled={operation == "delete"} />
+  );
+};
 
 export const NotificationShow = () => (
   <Show>
@@ -76,7 +101,7 @@ export const NotificationShow = () => (
           <IdentityField source="recorded_by" />
         </FieldStack>
       </Stack>
-      <ResourceButton />
+      <EventResourceButton />
       <AcknowledgeButton />
     </SimpleShowLayout>
   </Show>


### PR DESCRIPTION
This PR adds a button to link to the resource at the end of each line in the notice list.

As such buttons exploit the `source` field format which is the same in the `event` and `notice` resources, it made sense to refactor the button we had on the notification page so that it can be used in both use cases.

![Screenshot 2025-03-03 105249](https://github.com/user-attachments/assets/101b3433-1d97-4f3b-b472-c24be77fed9a)
