### PR TITLE
feat(backend): start design of custom server to replace gin (FLEX-483)

### DIFF
--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// custom response type
+
+type response struct {
+	header     http.Header
+	statusCode *int
+	body       *bytes.Buffer
+}
+
+// response can act as a responsewriter that actually fills itself.
+var _ http.ResponseWriter = &response{}
+
+func newResponse() *response {
+	return &response{
+		header:     make(http.Header),
+		statusCode: new(int),
+		body:       bytes.NewBufferString(""),
+	}
+}
+
+func (r *response) Header() http.Header {
+	return r.header
+}
+
+func (r *response) WriteHeader(statusCode int) {
+	*r.statusCode = statusCode
+}
+
+func (r *response) Write(b []byte) (int, error) {
+	return r.body.Write(b) //nolint:wrapcheck
+}
+
+// custom error type for API spec compatibility
+
+type apiError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Detail  string `json:"details,omitempty"`
+	Hint    string `json:"hint,omitempty"`
+}
+
+// -----------------------------------------------------------------------------
+
+// custom handler type
+
+type handler struct {
+	handle func(*http.Request) (response, *apiError)
+}
+
+func NewHandler(h func(*http.Request) (response, *apiError)) handler {
+	return handler{handle: h}
+}
+
+func NewHandlerFromStdHandler(stdH http.Handler) handler {
+	return NewHandler(
+		func(req *http.Request) (response, *apiError) {
+			// fill a custom response with the standard handler and check for errors
+			r := newResponse()
+			stdH.ServeHTTP(r, req)
+			if *r.statusCode >= http.StatusBadRequest {
+				return *r, &apiError{
+					Code:    fmt.Sprintf("HTTP%d", *r.statusCode),
+					Message: r.body.String(),
+				}
+			}
+			return *r, nil
+		},
+	)
+}
+
+// make the handler act as a standard handler.
+func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r, e := h.handle(req)
+
+	header := w.Header()
+	for k, v := range r.header {
+		header[k] = v
+	}
+	w.WriteHeader(*r.statusCode)
+
+	var body []byte
+	if e != nil {
+		header.Set("Content-Type", "application/json")
+		body, _ = json.Marshal(e)
+	} else {
+		body = r.body.Bytes()
+	}
+	w.Write(body)
+}
+
+// -----------------------------------------------------------------------------
+
+// custom middleware type
+
+type middleware struct {
+	adaptHandler func(handler) handler
+}
+
+func NewMiddleware(m func(handler) handler) middleware {
+	return middleware{adaptHandler: m}
+}
+
+func NewMiddlewareFromStdMiddleware(m func(http.Handler) http.Handler) middleware {
+	return NewMiddleware(
+		func(h handler) handler {
+			// m sees h as a standard handler because it implements the interface
+			return NewHandlerFromStdHandler(m(h))
+		},
+	)
+}
+
+// make the middleware act as a standard middleware.
+func (m middleware) ToStdMiddleware() func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		// the return value can be seen as a standard handler as well
+		return m.adaptHandler(NewHandlerFromStdHandler(h))
+	}
+}
+
+// -----------------------------------------------------------------------------
+
+// TODO
+// custom router/server type using custom handler/middleware


### PR DESCRIPTION
As a first step in replacing Gin, this PR proposes a design of custom server that will make it easier to write handlers adapted to our custom error format as well as middlewares without having to worry about capturing values here and there.

In this design :

- A handler is a function that takes a request and returns a response and an error. The type of the response is a custom type for which we implement the `ResponseWriter` interface for easy capture in the middlewares. The type of the error is our custom error message representation in the API.

- A middleware is a function from handlers to handlers, like in the standard library, except we use our custom handler type here. In this way, adding a middleware to a route will just take the existing handler for this route and apply the middleware to it to get the new wrapper handler.

> [!TIP]
> Not sure we need _all_ of the conversion functions between custom and standard types, but it can help build trust to show that things are compatible. In that way, we can _choose_ to write a handler in one style or the other if we prefer it, everything stays compatible in the end (even though we should generally strive towards a uniform style).

With this design, we can now write handlers with return values, allowing to return errors instead of having to write them manually in the response like we currently do ; we can also compose middlewares without worrying about side effects (_"have I already written the headers or can I still edit them ?"_ and the like).

> [!NOTE]
> Router or server types are still missing, but I'll work on that after discussion. IIUC we don't have custom implementation details to add at this level of the web server, so we can just rely on the stdlib `ServeMux` type for example. Basically once all the handlers have been created for all routes in our custom types, we just do one pass of conversion to turn everything into standard library things and rely on the stdlib features to launch the server.