### PR TITLE
feat(backend): PostgREST middleware as stdlib response modifier (FLEX-483)

### DIFF
--- a/backend/data/data.go
+++ b/backend/data/data.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"flex/pgpool"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -95,34 +97,9 @@ func (data *API) PostgRESTHandler(ctx *gin.Context) {
 		req.URL.Path = url
 		req.URL.RawQuery = query.Encode()
 	}
+	proxy.ModifyResponse = fixPostgRESTResponse
 
 	proxy.ServeHTTP(ctx.Writer, ctx.Request)
-}
-
-// Custom implementation of ResponseWriter. This allows us to have access to the
-// headers and response body before they are written, and possibly change them.
-type captureResponseWriter struct {
-	gin.ResponseWriter
-	body *bytes.Buffer
-}
-
-func newCaptureResponseWriter(w gin.ResponseWriter) captureResponseWriter {
-	return captureResponseWriter{
-		ResponseWriter: w,
-		body:           bytes.NewBufferString(""),
-	}
-}
-
-// This override writes the body to the buffer instead of the response. All the
-// other methods are left untouched, so the other parts of the response are
-// written normally.
-func (crw captureResponseWriter) Write(b []byte) (int, error) {
-	return crw.body.Write(b) //nolint:wrapcheck
-}
-
-func (crw captureResponseWriter) WriteHeaderNow() {
-	// turn WriteHeaderNow into a no-op so that headers remain changeable until
-	// the end of the middleware where the body is ready to be written
 }
 
 // errorMessage is the format of PostgREST error messages.
@@ -133,68 +110,70 @@ type errorMessage struct {
 	Hint    string `json:"hint,omitempty"`
 }
 
-// PostgRESTResponseMiddleware returns a middleware that logs the error
-// messages, and possibly rewrites them when not informative enough. It also
-// makes sure the responses abide by our OpenAPI specification.
-func (data *API) PostgRESTResponseMiddleware(ctx *gin.Context) {
-	// change the writer to capture the response body while the handler runs
-	rw := ctx.Writer
-	crw := newCaptureResponseWriter(rw)
-	ctx.Writer = crw
+// fixPostgRESTResponse logs the error message from PostgREST and possibly
+// rewrites it when not informative enough. It also makes sure the responses
+// abide by our OpenAPI specification.
+func fixPostgRESTResponse(rsp *http.Response) error {
+	rsp.Header.Set("Content-Type", "application/json")
 
-	ctx.Header("Content-Type", "application/json")
-
-	// ↑ before the handler
-
-	ctx.Next()
-
-	// ↓ after the handler
-
-	ctx.Writer = rw
-	// NB: so far, the actual response body is still empty
-
-	if ctx.Writer.Status() >= http.StatusBadRequest { //nolint:nestif
-		// error => parse the body, modify it, and write it to the actual response
-		var errorBody errorMessage
-		if err := json.Unmarshal(crw.body.Bytes(), &errorBody); err != nil || errorBody.Code == "" {
-			slog.InfoContext(
-				ctx,
-				"data API failure (not in PostgREST format)",
-				"error", crw.body.String(),
-			)
-			errorBody.Code = fmt.Sprintf("HTTP%d", ctx.Writer.Status())
-			errorBody.Message = http.StatusText(ctx.Writer.Status())
-		}
-
-		// general error message rewrites to hide the default PostgREST ones
-		switch ctx.Request.Method {
-		case http.MethodPatch:
-			if strings.HasPrefix(errorBody.Message, "JSON object requested") {
-				errorBody.Message = "User cannot update this resource"
-			}
-		case http.MethodPost:
-			if strings.HasPrefix(
-				errorBody.Message, "new row violates row-level security",
-			) {
-				errorBody.Message = "User cannot create this resource"
-			} else if strings.HasPrefix(errorBody.Message, "duplicate key value") {
-				errorBody.Message = "Duplicate found, " +
-					"please try to update the existing resource instead"
-			}
-		}
-
-		ctx.JSON(ctx.Writer.Status(), errorBody)
-		slog.InfoContext(
-			ctx,
-			"data API failure",
-			"code", errorBody.Code,
-			"message", errorBody.Message,
-			"detail", errorBody.Detail,
-			"hint", errorBody.Hint,
-		)
-	} else {
-		// no error => just write the body to the actual response
-		ctx.Writer.WriteHeaderNow()
-		ctx.Writer.Write(crw.body.Bytes())
+	if rsp.StatusCode < http.StatusBadRequest {
+		return nil
 	}
+
+	// error => parse the body, modify it, and write it to the actual response
+	body, err := io.ReadAll(rsp.Body)
+	if err != nil {
+		writeErrorResponse(rsp, errorMessage{ //nolint:exhaustruct
+			Code:    fmt.Sprintf("HTTP%d", http.StatusInternalServerError),
+			Message: "could not read PostgREST response body",
+		})
+		return nil
+	}
+	defer rsp.Body.Close()
+
+	var errorBody errorMessage
+	if err := json.Unmarshal(body, &errorBody); err != nil || errorBody.Code == "" {
+		slog.InfoContext(
+			rsp.Request.Context(),
+			"data API failure (not in PostgREST format)",
+			"error", body,
+		)
+		errorBody.Code = fmt.Sprintf("HTTP%d", rsp.StatusCode)
+		errorBody.Message = rsp.Status
+	}
+
+	// general error message rewrites to hide the default PostgREST ones
+	switch rsp.Request.Method {
+	case http.MethodPatch:
+		if strings.HasPrefix(errorBody.Message, "JSON object requested") {
+			errorBody.Message = "User cannot update this resource"
+		}
+	case http.MethodPost:
+		if strings.HasPrefix(
+			errorBody.Message, "new row violates row-level security",
+		) {
+			errorBody.Message = "User cannot create this resource"
+		} else if strings.HasPrefix(errorBody.Message, "duplicate key value") {
+			errorBody.Message = "Duplicate found, " +
+				"please try to update the existing resource instead"
+		}
+	}
+
+	writeErrorResponse(rsp, errorBody)
+	slog.InfoContext(
+		rsp.Request.Context(),
+		"data API failure",
+		"code", errorBody.Code,
+		"message", errorBody.Message,
+		"detail", errorBody.Detail,
+		"hint", errorBody.Hint,
+	)
+	return nil
+}
+
+func writeErrorResponse(rsp *http.Response, msg errorMessage) {
+	body, _ := json.Marshal(msg)
+	rsp.Body = io.NopCloser(bytes.NewReader(body))
+	rsp.ContentLength = int64(len(body))
+	rsp.Header.Set("Content-Length", strconv.Itoa(len(body)))
 }

--- a/backend/data/data.go
+++ b/backend/data/data.go
@@ -171,6 +171,7 @@ func fixPostgRESTResponse(rsp *http.Response) error {
 	return nil
 }
 
+// writeErrorResponse writes an error message as JSON in the response body.
 func writeErrorResponse(rsp *http.Response, msg errorMessage) {
 	body, _ := json.Marshal(msg)
 	rsp.Body = io.NopCloser(bytes.NewReader(body))

--- a/backend/flex.go
+++ b/backend/flex.go
@@ -304,7 +304,6 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 	// data API endpoints
 	// by default, just act as a reverse proxy for PostgREST
 	dataRouter := router.Group("/api/v0")
-	dataRouter.Use(dataAPI.PostgRESTResponseMiddleware)
 	dataRouter.Match(
 		[]string{"GET", "POST", "PATCH", "DELETE", "OPTIONS"},
 		"/*url",


### PR DESCRIPTION
This PR turns the response-rewriting mechanism that runs when coming back from PostgREST into a standard library `ReverseProxy` response modifier.

It means it is no longer a middleware but a part of the PostgREST handler, and we no longer rely on a custom body capture mechanism.