### PR TITLE
feat(backend): stdlib signature for token middleware (FLEX-483)

### DIFF
--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	callbackPath = "/auth/v0/callback"
+	callbackPath     = "/auth/v0/callback"
+	sessionCookieKey = "__Host-flex_session"
 )
 
 // API holds the authentication API handlers.
@@ -72,70 +73,74 @@ func (auth *API) decodeTokenString(tokenStr string) (*accessToken, error) {
 }
 
 // TokenDecodingMiddleware decodes the token and sets it as RequestDetails in the context.
-func (auth *API) TokenDecodingMiddleware() gin.HandlerFunc {
-	return func(ctx *gin.Context) {
-		authHeader := ctx.GetHeader("Authorization")
-		sessionCookie, err := ctx.Cookie("__Host-flex_session")
+func (auth *API) TokenDecodingMiddleware(w http.ResponseWriter, req *http.Request) {
+	authHeader := req.Header.Get("Authorization")
+	sessionCookie, err := req.Cookie(sessionCookieKey)
 
-		if authHeader == "" && err != nil {
-			// Empty auth header and missing cookie means anonymous user.
-			rd := &RequestDetails{role: "flex_anonymous", externalID: ""}
-			ctx.Set(auth.ctxKey, rd)
-			return
-		}
+	ctx := req.Context().(*gin.Context) //nolint:forcetypeassert
 
-		// the authorization header takes presedence over the cookie
-		var tokenStr string
-		if authHeader != "" {
-			var found bool
-			tokenStr, found = strings.CutPrefix(authHeader, "Bearer ")
-			if !found {
-				ctx.Header(
-					wwwAuthenticateKey,
-					wwwAuthenticate{
-						Error:            wwwInvalidRequest,
-						ErrorDescription: "missing Bearer in Authorization header",
-					}.String(),
-				)
-				ctx.AbortWithStatusJSON(
-					http.StatusBadRequest,
-					oauthErrorMessage{
-						Error:            oauthErrorInvalidRequest,
-						ErrorDescription: "missing Bearer in Authorization header",
-					},
-				)
-				return
-			}
-		} else { // no authorization header means we must use the cookie
-			tokenStr = sessionCookie
-		}
+	if authHeader == "" && err != nil {
+		// Empty auth header and missing cookie means anonymous user.
+		rd := &RequestDetails{role: "flex_anonymous", externalID: ""}
+		ctx.Set(auth.ctxKey, rd)
+		return
+	}
 
-		token, err := auth.decodeTokenString(tokenStr)
-		if err != nil {
-			ctx.Header(
+	// the authorization header takes presedence over the cookie
+	var tokenStr string
+	if authHeader != "" {
+		var found bool
+		tokenStr, found = strings.CutPrefix(authHeader, "Bearer ")
+		if !found {
+			w.Header().Set(
 				wwwAuthenticateKey,
 				wwwAuthenticate{
-					Error: wwwInvalidToken,
-					// TODO the error messages here is incorrect if we are using a session
-					ErrorDescription: "invalid bearer token",
+					Error:            wwwInvalidRequest,
+					ErrorDescription: "missing Bearer in Authorization header",
 				}.String(),
 			)
-			ctx.AbortWithStatusJSON(
-				http.StatusBadRequest,
-				oauthErrorMessage{
-					Error:            oauthErrorInvalidRequest,
-					ErrorDescription: "unable to verify and validate token",
-				},
-			)
+			ctx.Abort()
+			writeJSON(w, http.StatusBadRequest, oauthErrorMessage{
+				Error:            oauthErrorInvalidRequest,
+				ErrorDescription: "missing Bearer in Authorization header",
+			})
 			return
 		}
-
-		rd := &RequestDetails{
-			role:       token.Role,
-			externalID: token.ExternalID,
-		}
-		ctx.Set(auth.ctxKey, rd)
+	} else { // no authorization header means we must use the cookie
+		tokenStr = sessionCookie.Value
 	}
+
+	token, err := auth.decodeTokenString(tokenStr)
+	if err != nil {
+		w.Header().Set(
+			wwwAuthenticateKey,
+			wwwAuthenticate{
+				Error: wwwInvalidToken,
+				// TODO the error messages here is incorrect if we are using a session
+				ErrorDescription: "invalid bearer token",
+			}.String(),
+		)
+		ctx.Abort()
+		writeJSON(w, http.StatusBadRequest, oauthErrorMessage{
+			Error:            oauthErrorInvalidRequest,
+			ErrorDescription: "unable to verify and validate token",
+		})
+		return
+	}
+
+	rd := &RequestDetails{
+		role:       token.Role,
+		externalID: token.ExternalID,
+	}
+	ctx.Set(auth.ctxKey, rd)
+}
+
+// writeJSON writes a JSON response with the given object as body.
+func writeJSON(w http.ResponseWriter, statusCode int, obj any) {
+	w.Header().Set("Content-Type", "application/json")
+	body, _ := json.Marshal(obj) //nolint:errchkjson
+	w.WriteHeader(statusCode)
+	w.Write(body)
 }
 
 // tokenPayload is used to inspect the grant type in the token request.
@@ -209,7 +214,7 @@ func (auth *API) PostTokenHandler(ctx *gin.Context) {
 //
 //nolint:funlen
 func (auth *API) GetSessionHandler(w http.ResponseWriter, r *http.Request) {
-	sessionCookie, err := r.Cookie("__Host-flex_session")
+	sessionCookie, err := r.Cookie(sessionCookieKey)
 	if err != nil {
 		if errors.Is(err, http.ErrNoCookie) {
 			// Missing cookie just means that there is no session,
@@ -234,7 +239,7 @@ func (auth *API) GetSessionHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// Unset the session cookie
 		http.SetCookie(w, &http.Cookie{ //nolint:exhaustruct
-			Name:     "__Host-flex_session",
+			Name:     sessionCookieKey,
 			Value:    "not.a.session",
 			MaxAge:   -1,
 			Path:     "/",
@@ -467,7 +472,7 @@ func (auth *API) GetCallbackHandler(ctx *gin.Context) { //nolint:funlen,cyclop
 	}
 
 	ctx.SetSameSite(http.SameSiteStrictMode)
-	ctx.SetCookie("__Host-flex_session", string(signedAccessToken), auth.tokenDurationSeconds, "/", "", true, true)
+	ctx.SetCookie(sessionCookieKey, string(signedAccessToken), auth.tokenDurationSeconds, "/", "", true, true)
 	ctx.SetCookie("flex_login", "not.a.login", -1, callbackPath, "", true, true)
 
 	ctx.Redirect(http.StatusFound, loginCookie.ReturnURL)
@@ -476,7 +481,7 @@ func (auth *API) GetCallbackHandler(ctx *gin.Context) { //nolint:funlen,cyclop
 // GetLogoutHandler unsets the __Host-flex_session cookie.
 func (auth *API) GetLogoutHandler(ctx *gin.Context) {
 	ctx.SetSameSite(http.SameSiteStrictMode)
-	ctx.SetCookie("__Host-flex_session", "not.a.session", -1, "/", "", true, true)
+	ctx.SetCookie(sessionCookieKey, "not.a.session", -1, "/", "", true, true)
 	endSessionURL := auth.oidcProvider.EndSessionURL()
 	ctx.Redirect(http.StatusFound, endSessionURL)
 }
@@ -570,7 +575,7 @@ func (auth *API) PostAssumeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	accessTokenCookie, err := r.Cookie("__Host-flex_session")
+	accessTokenCookie, err := r.Cookie(sessionCookieKey)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		body, _ := json.Marshal(oauthErrorMessage{
@@ -645,7 +650,7 @@ func (auth *API) PostAssumeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.SetCookie(w, &http.Cookie{ //nolint:exhaustruct
-		Name:     "__Host-flex_session",
+		Name:     sessionCookieKey,
 		Value:    string(signedPartyToken),
 		Path:     "/",
 		MaxAge:   auth.tokenDurationSeconds,
@@ -670,7 +675,7 @@ func (auth *API) PostAssumeHandler(w http.ResponseWriter, r *http.Request) {
 //nolint:funlen
 func (auth *API) DeleteAssumeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	accessTokenCookie, err := r.Cookie("__Host-flex_session")
+	accessTokenCookie, err := r.Cookie(sessionCookieKey)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		body, _ := json.Marshal(oauthErrorMessage{
@@ -757,7 +762,7 @@ func (auth *API) DeleteAssumeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.SetCookie(w, &http.Cookie{ //nolint:exhaustruct
-		Name:     "__Host-flex_session",
+		Name:     sessionCookieKey,
 		Value:    string(signedEntityToken),
 		Path:     "/",
 		MaxAge:   auth.tokenDurationSeconds,

--- a/backend/flex.go
+++ b/backend/flex.go
@@ -288,7 +288,7 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 	corsConfig.AllowHeaders = []string{"Authorization"}
 
 	router.Use(cors.New(corsConfig))
-	router.Use(authAPI.TokenDecodingMiddleware())
+	router.Use(WrapHandlerFunc(authAPI.TokenDecodingMiddleware)) //nolint:contextcheck
 
 	// auth API endpoints
 	authRouter := router.Group("/auth/v0")

--- a/backend/flex.go
+++ b/backend/flex.go
@@ -29,7 +29,7 @@ var errMissingEnv = errors.New("environment variable not set")
 
 const requestDetailsContextKey = "_flex/auth"
 
-// WrapHandlerFunc is a helper function for wrapping http.HandlerFunc and returns a Gin middleware.
+// WrapHandlerFunc is a helper function for wrapping http.HandlerFunc and returns a Gin handler.
 // Is is basically gin.WrapF but explicitly passing the full gin.Context.
 // This is necessary because we are using gin.Contexts in our middleware.
 // The intended use of this function is to allow us to move away fron gin-gonic/gin,
@@ -37,6 +37,51 @@ const requestDetailsContextKey = "_flex/auth"
 func WrapHandlerFunc(f http.HandlerFunc) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		f(ctx.Writer, ctx.Request.WithContext(ctx))
+	}
+}
+
+// WrapMiddleware takes a standard library function-based middleware and turns
+// it into a Gin middleware.
+func WrapMiddleware(mid func(http.Handler) http.Handler) gin.HandlerFunc {
+	// The Gin engine finds the list of handlers corresponding to the request and
+	// calls ctx.Next to execute them all in a loop.
+	// cf https://github.com/gin-gonic/gin/blob/75ccf94d605a05fe24817fc2f166f6f2959d5cea/gin.go#L630-L636
+
+	// By default, this loop runs automatically until the last handler is called,
+	// unless we stop the loop manually by calling ctx.Abort.
+	// cf https://github.com/gin-gonic/gin/blob/75ccf94d605a05fe24817fc2f166f6f2959d5cea/context.go#L182-L188
+
+	// We need to turn this logic of iteration into a logic of wrapping,
+	// where the remaining handlers are represented as a function passed to the
+	// outermost (earliest running) middleware, that can choose to call them or
+	// discard them. In iteration-based design, continuing the loop is the default
+	// and we need to be explicit if we want to stop it (ctx.Abort), whereas in
+	// wrapping-based design, stopping the loop is the default and we need to be
+	// explicit if we want to continue it (call the next handler).
+
+	// We do this by storing this information in a boolean.
+
+	return func(ctx *gin.Context) {
+		// flag to know whether the next handlers were called (default false).
+		nextCalled := new(bool)
+		*nextCalled = false
+
+		// NB: we ignore the arguments because we know f is going to be called with
+		// request and writer from ctx below, so we are sure ctx.Next will also
+		// apply to them.
+		next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			// when the next handler is called, we set the flag
+			*nextCalled = true
+			ctx.Next()
+		})
+
+		// run the wrapped handler
+		mid(next).ServeHTTP(ctx.Writer, ctx.Request.WithContext(ctx))
+
+		// if next was called, we now know it and can stop the Gin loop
+		if !*nextCalled {
+			ctx.Abort()
+		}
 	}
 }
 
@@ -288,7 +333,7 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 	corsConfig.AllowHeaders = []string{"Authorization"}
 
 	router.Use(cors.New(corsConfig))
-	router.Use(WrapHandlerFunc(authAPI.TokenDecodingMiddleware)) //nolint:contextcheck
+	router.Use(WrapMiddleware(authAPI.TokenDecodingMiddleware)) //nolint:contextcheck
 
 	// auth API endpoints
 	authRouter := router.Group("/auth/v0")

--- a/backend/internal/trace/trace.go
+++ b/backend/internal/trace/trace.go
@@ -18,9 +18,7 @@ func Init() {
 }
 
 // Tracer returns the global otel tracer.
-//
-//nolint:ireturn
-func Tracer(name string) trace.Tracer {
+func Tracer(name string) trace.Tracer { //nolint:ireturn
 	return otel.Tracer(name)
 }
 


### PR DESCRIPTION
This PR makes the token middleware use a stdlib signature, going through the wrapper function to remain compatible with Gin.

The middleware still depends on Gin for now, ~~for the abort feature to disable further handling, and~~ to store the decoded token in the context.