### PR TITLE
refactor: move db roles as prerequisites to db load

### DIFF
--- a/db/api_auth.sql
+++ b/db/api_auth.sql
@@ -1,5 +1,4 @@
 SET search_path TO api;
-SET role TO api;
 
 GRANT USAGE ON SCHEMA api TO flex_anonymous;
 GRANT USAGE ON SCHEMA api TO flex_balance_responsible_party;

--- a/db/api_field_level_authorization.sql
+++ b/db/api_field_level_authorization.sql
@@ -1,6 +1,5 @@
 -- AUTO-GENERATED FILE (just permissions-to-db)
 
-SET role TO api;
 SET search_path TO api;
 
 GRANT SELECT (

--- a/db/api_structure.sql
+++ b/db/api_structure.sql
@@ -1,4 +1,3 @@
-SET role TO api;
 SET search_path TO api;
 
 -- views

--- a/db/auth_base.sql
+++ b/db/auth_base.sql
@@ -1,5 +1,4 @@
 -- The auth schema is for the auth module
-SET role TO auth;
 SET search_path TO auth;
 
 -- grants for application roles

--- a/db/flex/entity_rls.sql
+++ b/db/flex/entity_rls.sql
@@ -34,10 +34,3 @@ CREATE POLICY "ENT_FISO001" ON entity
 FOR SELECT
 TO flex_flexibility_information_system_operator
 USING (true);
-
--- For "security definer" functions
-GRANT SELECT ON entity TO auth;
-CREATE POLICY entity_auth ON entity
-FOR SELECT
-TO auth
-USING (true);

--- a/db/flex/identity_rls.sql
+++ b/db/flex/identity_rls.sql
@@ -1,10 +1,5 @@
 ALTER TABLE IF EXISTS identity ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY identity_api ON identity
-FOR SELECT
-TO api
-USING (true);
-
 -- RLS: ID-ENT001
 GRANT SELECT ON identity TO flex_entity;
 CREATE POLICY "ID_ENT001" ON identity
@@ -17,11 +12,4 @@ GRANT SELECT ON identity TO flex_common;
 CREATE POLICY "ID_COM001" ON identity
 FOR SELECT
 TO flex_common
-USING (true);
-
--- For "security definer" functions
-GRANT SELECT ON identity TO auth;
-CREATE POLICY identity_auth ON identity
-FOR SELECT
-TO auth
 USING (true);

--- a/db/flex/notice.sql
+++ b/db/flex/notice.sql
@@ -56,8 +56,8 @@ CREATE OR REPLACE VIEW notice AS (
             'no.elhub.flex.service_providing_group_membership.valid_time.outside_contract' AS type, -- noqa
             '/service_providing_group_membership/' || spgm.id AS source,
             null AS data -- noqa
-        FROM service_providing_group_membership AS spgm -- noqa
-            INNER JOIN service_providing_group AS spg
+        FROM flex.service_providing_group_membership AS spgm -- noqa
+            INNER JOIN flex.service_providing_group AS spg
                 ON spg.id = spgm.service_providing_group_id
         WHERE NOT EXISTS (
                 SELECT 1 FROM (
@@ -65,7 +65,7 @@ CREATE OR REPLACE VIEW notice AS (
                         controllable_unit_id,
                         service_provider_id,
                         range_agg(valid_time_range) AS valid_timeline
-                    FROM controllable_unit_service_provider
+                    FROM flex.controllable_unit_service_provider
                     WHERE lower(valid_time_range) IS NOT null
                     GROUP BY controllable_unit_id, service_provider_id
                 ) AS cusp

--- a/db/flex/party_membership_rls.sql
+++ b/db/flex/party_membership_rls.sql
@@ -36,10 +36,3 @@ CREATE POLICY "PTYM_COM003" ON party_membership_history
 FOR SELECT
 TO flex_common
 USING (party_id = current_party());
-
--- For "security definer" functions
-GRANT SELECT ON party_membership TO auth;
-CREATE POLICY party_membership_api ON party_membership
-FOR SELECT
-TO auth
-USING (true);

--- a/db/flex/party_rls.sql
+++ b/db/flex/party_rls.sql
@@ -39,10 +39,3 @@ CREATE POLICY "PTY_FISO001" ON party
 FOR ALL
 TO flex_flexibility_information_system_operator
 USING (true);
-
--- For security definer stuff in the auth schema
-GRANT SELECT ON party TO auth;
-CREATE POLICY party_auth ON party
-FOR SELECT
-TO auth
-USING (true);

--- a/db/flex/service_providing_group.sql
+++ b/db/flex/service_providing_group.sql
@@ -49,15 +49,15 @@ BEGIN
         -- TODO: update when a grid model is implemented
         -- ISO are currently the CSO of the CUs currently in the updated SPG
         SELECT DISTINCT ap.system_operator_id
-        FROM service_providing_group_membership spgm
-        INNER JOIN controllable_unit cu
+        FROM flex.service_providing_group_membership spgm
+        INNER JOIN flex.controllable_unit cu
         ON spgm.controllable_unit_id = cu.id
-        INNER JOIN accounting_point ap
+        INNER JOIN flex.accounting_point ap
         ON ap.business_id = cu.accounting_point_id
         WHERE spgm.service_providing_group_id = NEW.id
         AND spgm.valid_time_range @> current_timestamp
     LOOP
-        INSERT INTO service_providing_group_grid_prequalification (
+        INSERT INTO flex.service_providing_group_grid_prequalification (
             service_providing_group_id,
             impacted_system_operator_id,
             recorded_by
@@ -96,7 +96,7 @@ DECLARE
     system_operator_id bigint;
 BEGIN
     IF NOT EXISTS (
-        SELECT 1 FROM service_providing_group_membership spgm
+        SELECT 1 FROM flex.service_providing_group_membership spgm
         WHERE spgm.service_providing_group_id = NEW.id
         AND spgm.valid_time_range @> current_timestamp
     ) THEN

--- a/db/flex_auth.sql
+++ b/db/flex_auth.sql
@@ -1,13 +1,5 @@
 -- authn
-SET role TO flex;
 SET search_path TO flex, public;
-
--- allow "interface schemas" to use the "flex" schema
-GRANT USAGE ON SCHEMA flex TO api;
-GRANT SELECT, UPDATE, INSERT, DELETE ON ALL TABLES IN SCHEMA flex TO api; -- for security definer functions
-
-GRANT USAGE ON SCHEMA flex TO auth;
-GRANT SELECT, UPDATE, INSERT, DELETE ON ALL TABLES IN SCHEMA flex TO auth; -- for security definer functions
 
 -- grants for application roles
 GRANT USAGE ON SCHEMA flex TO flex_anonymous;

--- a/db/flex_base.sql
+++ b/db/flex_base.sql
@@ -4,7 +4,6 @@
 -- public
 \i pgjwt/pgjwt.sql
 
-SET role TO flex;
 SET search_path TO flex, public;
 
 \i temporal_tables/temporal_tables.sql

--- a/db/flex_field_level_authorization.sql
+++ b/db/flex_field_level_authorization.sql
@@ -1,6 +1,5 @@
 -- AUTO-GENERATED FILE (just permissions-to-db)
 
-SET role TO flex;
 SET search_path TO flex, public;
 
 GRANT SELECT ON TABLE flex.entity

--- a/db/flex_reference_data.psql
+++ b/db/flex_reference_data.psql
@@ -1,7 +1,6 @@
 -- this file is just for copying data
 -- it will fail on consecutive runs
 -- TODO proper handling of data
-SET role TO flex;
 SET search_path TO flex, public;
 
 \COPY flex.business_id_type FROM './data/business_id_type.csv' WITH CSV HEADER;

--- a/db/flex_structure.sql
+++ b/db/flex_structure.sql
@@ -1,4 +1,3 @@
-SET role TO flex;
 SET search_path TO flex, public;
 
 COMMENT ON SCHEMA flex IS

--- a/db/flex_test.psql
+++ b/db/flex_test.psql
@@ -1,4 +1,3 @@
-SET role TO flex;
 SET search_path TO flex, public;
 
 \i test_data/test_data.sql

--- a/db/flex_users.sql
+++ b/db/flex_users.sql
@@ -1,4 +1,3 @@
-SET role TO flex;
 SET search_path TO flex, public;
 
 -- Set system identity

--- a/db/load.sh
+++ b/db/load.sh
@@ -15,21 +15,21 @@ db_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$db_dir"
 
 psql -X -v ON_ERROR_STOP=1 -d flex -U postgres -f pre.sql
-psql -X -v ON_ERROR_STOP=1 -d flex -U flex_migrator -f flex_base.sql
-psql -X -v ON_ERROR_STOP=1 -d flex -U flex_migrator -f flex_auth.sql
-psql -X -v ON_ERROR_STOP=1 -d flex -U flex_migrator -f flex_structure.sql
-psql -X -v ON_ERROR_STOP=1 -d flex -U flex_migrator -f flex_field_level_authorization.sql
-psql -X -v ON_ERROR_STOP=1 -d flex -U flex_migrator -f flex_reference_data.psql || true
-psql -X -v ON_ERROR_STOP=1 -d flex -U flex_migrator -f flex_test.psql
-psql -X -v ON_ERROR_STOP=1 -d flex -U flex_migrator -f flex_users.sql
+psql -X -v ON_ERROR_STOP=1 -d flex -U flex -f flex_base.sql
+psql -X -v ON_ERROR_STOP=1 -d flex -U flex -f flex_auth.sql
+psql -X -v ON_ERROR_STOP=1 -d flex -U flex -f flex_structure.sql
+psql -X -v ON_ERROR_STOP=1 -d flex -U flex -f flex_field_level_authorization.sql
+psql -X -v ON_ERROR_STOP=1 -d flex -U flex -f flex_reference_data.psql || true
+psql -X -v ON_ERROR_STOP=1 -d flex -U flex -f flex_test.psql
+psql -X -v ON_ERROR_STOP=1 -d flex -U flex -f flex_users.sql
 
 # api module
-psql -X -v ON_ERROR_STOP=1 -d flex -U flex_migrator -f api_auth.sql
-psql -X -v ON_ERROR_STOP=1 -d flex -U flex_migrator -f api_structure.sql
-psql -X -v ON_ERROR_STOP=1 -d flex -U flex_migrator -f api_field_level_authorization.sql
+psql -X -v ON_ERROR_STOP=1 -d flex -U flex -f api_auth.sql
+psql -X -v ON_ERROR_STOP=1 -d flex -U flex -f api_structure.sql
+psql -X -v ON_ERROR_STOP=1 -d flex -U flex -f api_field_level_authorization.sql
 
 # auth module
-psql -X -v ON_ERROR_STOP=1 -d flex -U flex_migrator -f auth_base.sql
+psql -X -v ON_ERROR_STOP=1 -d flex -U flex -f auth_base.sql
 
 # logical replication
 psql -X -v ON_ERROR_STOP=1 -d flex -U postgres -f replication.sql

--- a/db/pre.sql
+++ b/db/pre.sql
@@ -6,143 +6,27 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp"; -- noqa: RF05
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 CREATE EXTENSION IF NOT EXISTS ltree;
 
--- schemas
-DO
-$$
--- Create PostgreSQL ROLE (user) if it doesn't exist
--- https://stackoverflow.com/a/8099557
-BEGIN
-   IF EXISTS (
-      SELECT FROM pg_catalog.pg_roles
-      WHERE  rolname = 'flex') THEN
-
-      RAISE NOTICE 'Role "flex" already exists. Skipping.';
-   ELSE
-      BEGIN
-         CREATE ROLE flex NOLOGIN;
-      EXCEPTION
-         WHEN duplicate_object THEN
-            RAISE NOTICE 'Role "flex" was just created by a concurrent transaction. Skipping.';
-      END;
-   END IF;
-END
-$$;
+-- data schema
 CREATE SCHEMA IF NOT EXISTS flex AUTHORIZATION flex;
 
--- cleaup logic schemas
-DROP SCHEMA IF EXISTS api CASCADE;
-DROP SCHEMA IF EXISTS auth CASCADE;
+-- logic schemas
 
--- cheanup roles
+DROP SCHEMA IF EXISTS api CASCADE;
+CREATE SCHEMA IF NOT EXISTS api AUTHORIZATION flex;
+
+DROP SCHEMA IF EXISTS auth CASCADE;
+CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION flex;
+
+-- fresh start for policies
+-- TODO each policy should be dropped IF EXISTS separately?
 DO
 $$
-DECLARE
-   role_name TEXT;
-BEGIN
-   FOREACH role_name IN ARRAY ARRAY[
-      'api',
-      'auth',
-      'flex_anonymous',
-      'flex_common',
-      'flex_entity',
-      'flex_balance_responsible_party',
-      'flex_end_user',
-      'flex_energy_supplier',
-      'flex_flexibility_information_system_operator',
-      'flex_market_operator',
-      'flex_system_operator',
-      'flex_service_provider',
-      'flex_third_party',
-      'flex_internal_event_notification',
-      'flex_migrator']
-   LOOP
-      IF EXISTS (
-         SELECT FROM pg_catalog.pg_roles
-         WHERE  rolname = role_name) THEN
-
-         EXECUTE 'DROP OWNED BY ' || role_name;
-         EXECUTE 'DROP ROLE ' || role_name;
-      END IF;
-   END LOOP;
-END
+declare
+   rec record;
+begin
+   for rec in (SELECT tablename, schemaname, policyname FROM pg_policies)
+   loop
+     execute 'drop policy "'||rec.policyname||'" on '||rec.schemaname||'.'||rec.tablename;
+   end loop;
+end;
 $$;
-
--- create logic schemas
-CREATE ROLE api NOLOGIN;
-CREATE SCHEMA IF NOT EXISTS AUTHORIZATION api;
-
-CREATE ROLE auth NOLOGIN;
-CREATE SCHEMA IF NOT EXISTS AUTHORIZATION auth;
-
--- roles
-CREATE ROLE flex_anonymous NOINHERIT NOLOGIN;
-CREATE ROLE flex_common NOINHERIT NOLOGIN;
-CREATE ROLE flex_entity NOLOGIN;
-CREATE ROLE flex_balance_responsible_party NOLOGIN;
-CREATE ROLE flex_end_user NOLOGIN;
-CREATE ROLE flex_energy_supplier NOLOGIN;
-CREATE ROLE flex_flexibility_information_system_operator NOLOGIN;
-CREATE ROLE flex_market_operator NOLOGIN;
-CREATE ROLE flex_system_operator NOLOGIN;
-CREATE ROLE flex_service_provider NOLOGIN;
-CREATE ROLE flex_third_party NOLOGIN;
-
--- internal system roles
-CREATE ROLE flex_internal_event_notification;
-
-GRANT flex_anonymous TO
-flex_balance_responsible_party,
-flex_end_user,
-flex_energy_supplier,
-flex_entity,
-flex_flexibility_information_system_operator,
-flex_market_operator,
-flex_system_operator,
-flex_service_provider,
-flex_third_party;
-
-GRANT flex_common TO
-flex_balance_responsible_party,
-flex_end_user,
-flex_energy_supplier,
-flex_flexibility_information_system_operator,
-flex_market_operator,
-flex_system_operator,
-flex_service_provider,
-flex_third_party;
-
--- https://postgrest.org/en/v12/how-tos/sql-user-management.html#sql-user-management
--- authenticator is used by PostgREST to connect to the database
-DROP ROLE IF EXISTS postgrest_authenticator;
-CREATE ROLE postgrest_authenticator NOINHERIT LOGIN PASSWORD NULL;
-
-GRANT flex_anonymous TO postgrest_authenticator;
-GRANT flex_balance_responsible_party TO postgrest_authenticator;
-GRANT flex_end_user TO postgrest_authenticator;
-GRANT flex_energy_supplier TO postgrest_authenticator;
-GRANT flex_entity TO postgrest_authenticator;
-GRANT flex_flexibility_information_system_operator TO postgrest_authenticator;
-GRANT flex_market_operator TO postgrest_authenticator;
-GRANT flex_system_operator TO postgrest_authenticator;
-GRANT flex_service_provider TO postgrest_authenticator;
-GRANT flex_third_party TO postgrest_authenticator;
-
--- internal system roles
-GRANT flex_internal_event_notification TO postgrest_authenticator;
-
--- TODO Make functions non-public
--- https://postgrest.org/en/v12/explanations/db_authz.html#functions
--- ALTER DEFAULT PRIVILEGES REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
-
--- Replication user used by event worker
-DROP ROLE IF EXISTS flex_replication;
-CREATE ROLE flex_replication REPLICATION NOINHERIT LOGIN PASSWORD NULL;
-
--- migration user
-CREATE ROLE flex_migrator WITH NOINHERIT CREATEROLE LOGIN PASSWORD NULL;
-
-GRANT flex TO flex_migrator;
-GRANT api TO flex_migrator;
-GRANT auth TO flex_migrator;
-
-GRANT ALL ON SCHEMA public TO flex_migrator;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,10 @@ services:
       POSTGRES_PASSWORD: postgres_pwd
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_DB: flex
+    volumes:
+      - type: bind
+        source: ${PWD}/local/postgres/init.sql
+        target: /docker-entrypoint-initdb.d/init.sql
     command: >-
       -c log_statement=all
       -c log_min_messages=debug1
@@ -25,7 +29,7 @@ services:
     environment:
       # https://postgrest.org/en/latest/references/configuration.html
       PGRST_DB_URI: >-
-        postgres://postgrest_authenticator:rest_password@db:5432/flex
+        postgres://flex_authenticator:authenticator_password@db:5432/flex
       PGRST_DB_ANON_ROLE: flex_anonymous
       PGRST_DB_PRE_REQUEST: "flex.pre_request"
       PGRST_DB_SCHEMAS: api

--- a/justfile
+++ b/justfile
@@ -35,9 +35,9 @@ load:
     ./db/load.sh
 
     psql -X -v ON_ERROR_STOP=1 -d postgres -U postgres \
-        -c "ALTER USER postgrest_authenticator PASSWORD 'rest_password';"
+        -c "ALTER USER flex_authenticator PASSWORD 'authenticator_password';"
     psql -X -v ON_ERROR_STOP=1 -d postgres -U postgres \
-        -c "ALTER USER flex_replication PASSWORD 'repl_password';"
+        -c "ALTER USER flex_replication PASSWORD 'replication_password';"
 
     for entity in test common;
     do
@@ -442,10 +442,8 @@ permissions-to-db:
     echo "-- AUTO-GENERATED FILE (just permissions-to-db)\n" \
         | tee db/api_field_level_authorization.sql > db/flex_field_level_authorization.sql
 
-    echo "SET role TO api;" >> db/api_field_level_authorization.sql
     echo "SET search_path TO api;" >> db/api_field_level_authorization.sql
 
-    echo "SET role TO flex;" >> db/flex_field_level_authorization.sql
     echo "SET search_path TO flex, public;" >> db/flex_field_level_authorization.sql
 
 

--- a/justfile
+++ b/justfile
@@ -203,7 +203,8 @@ liquibase action='update':
     set -euo pipefail
     JAVA_HOME=.bin/java \
     LIQUIBASE_COMMAND_URL=jdbc:postgresql://localhost:5432/flex \
-    LIQUIBASE_COMMAND_USERNAME=postgres \
+    LIQUIBASE_COMMAND_USERNAME=flex \
+    LIQUIBASE_COMMAND_PASSWORD=flex_password \
     .bin/liquibase-{{ LIQUIBASE_VERSION }}/liquibase \
     --contexts=local \
     --liquibaseSchemaName=flex \

--- a/local/backend/dev.env
+++ b/local/backend/dev.env
@@ -1,8 +1,8 @@
 # Env file for dev
 FLEX_AUTH_API_BASE_URL=https://dev.flex.internal:5443/auth/v0/
 FLEX_DB_REPLICATION_SLOT_NAME=event_slot
-FLEX_DB_REPLICATION_URI=postgres://flex_replication:repl_password@localhost:5432/flex
-FLEX_DB_URI=postgres://postgrest_authenticator:rest_password@localhost:5432/flex?search_path=api,auth,public
+FLEX_DB_REPLICATION_URI=postgres://flex_replication:replication_password@localhost:5432/flex
+FLEX_DB_URI=postgres://flex_authenticator:authenticator_password@localhost:5432/flex?search_path=api,auth,public
 FLEX_JWT_SECRET=rqQHuW5MppUkriINN1gr1JWjftoJYWhn1234567890ohausd987ahf8a7hsf0a7shf0ash7f
 FLEX_LOG_LEVEL=DEBUG
 FLEX_OIDC_CLIENT_ID=flex_oidc_client_id_value

--- a/local/backend/test.env
+++ b/local/backend/test.env
@@ -1,8 +1,8 @@
 # Env file for test
 FLEX_AUTH_API_BASE_URL=https://test.flex.internal:6443/auth/v0/
 FLEX_DB_REPLICATION_SLOT_NAME=event_slot
-FLEX_DB_REPLICATION_URI=postgres://flex_replication:repl_password@db:5432/flex
-FLEX_DB_URI=postgres://postgrest_authenticator:rest_password@db:5432/flex?search_path=api,auth,public
+FLEX_DB_REPLICATION_URI=postgres://flex_replication:replication_password@db:5432/flex
+FLEX_DB_URI=postgres://flex_authenticator:authenticator_password@db:5432/flex?search_path=api,auth,public
 FLEX_JWT_SECRET=rqQHuW5MppUkriINN1gr1JWjftoJYWhn1234567890ohausd987ahf8a7hsf0a7shf0ash7f
 FLEX_LOG_LEVEL=DEBUG
 FLEX_OIDC_CLIENT_ID=flex_oidc_client_id_value

--- a/local/postgres/init.sql
+++ b/local/postgres/init.sql
@@ -1,0 +1,66 @@
+-- NOTE: Init scripts only runs on first start of the container
+-- It will NOT run on restarts
+
+-- flex is the main role for the application
+-- it owns all the schemas and objects in the database
+CREATE ROLE flex WITH NOINHERIT LOGIN PASSWORD NULL;
+
+-- authenticator is used by backend/postgREST to connect to the database
+CREATE ROLE flex_authenticator
+WITH NOINHERIT LOGIN PASSWORD 'authenticator_password';
+
+-- party roles
+CREATE ROLE flex_anonymous WITH NOINHERIT NOLOGIN;
+CREATE ROLE flex_balance_responsible_party WITH NOLOGIN;
+CREATE ROLE flex_common WITH NOLOGIN;
+CREATE ROLE flex_end_user WITH NOLOGIN;
+CREATE ROLE flex_energy_supplier WITH NOLOGIN;
+CREATE ROLE flex_entity WITH NOLOGIN;
+CREATE ROLE flex_flexibility_information_system_operator WITH NOLOGIN;
+CREATE ROLE flex_market_operator WITH NOLOGIN;
+CREATE ROLE flex_service_provider WITH NOLOGIN;
+CREATE ROLE flex_system_operator WITH NOLOGIN;
+CREATE ROLE flex_third_party WITH NOLOGIN;
+
+-- internal roles
+CREATE ROLE flex_replication
+WITH NOINHERIT LOGIN PASSWORD 'replication_password';
+CREATE ROLE flex_internal_event_notification WITH NOINHERIT NOLOGIN;
+
+
+-- authenticator will set role to any of the party and internal roles
+GRANT flex_anonymous TO flex_authenticator;
+GRANT flex_balance_responsible_party TO flex_authenticator;
+GRANT flex_end_user TO flex_authenticator;
+GRANT flex_energy_supplier TO flex_authenticator;
+GRANT flex_entity TO flex_authenticator;
+GRANT flex_flexibility_information_system_operator TO flex_authenticator;
+GRANT flex_market_operator TO flex_authenticator;
+GRANT flex_system_operator TO flex_authenticator;
+GRANT flex_service_provider TO flex_authenticator;
+GRANT flex_third_party TO flex_authenticator;
+
+-- internal system roles
+GRANT flex_internal_event_notification TO flex_authenticator;
+
+-- common and anonymous inherits from common
+GRANT flex_anonymous TO
+flex_balance_responsible_party,
+flex_end_user,
+flex_energy_supplier,
+flex_entity,
+flex_flexibility_information_system_operator,
+flex_market_operator,
+flex_system_operator,
+flex_service_provider,
+flex_third_party;
+
+GRANT flex_common TO
+flex_balance_responsible_party,
+flex_end_user,
+flex_energy_supplier,
+flex_flexibility_information_system_operator,
+flex_market_operator,
+flex_system_operator,
+flex_service_provider,
+flex_third_party;

--- a/local/postgres/init.sql
+++ b/local/postgres/init.sql
@@ -3,7 +3,9 @@
 
 -- flex is the main role for the application
 -- it owns all the schemas and objects in the database
-CREATE ROLE flex WITH NOINHERIT LOGIN PASSWORD NULL;
+CREATE ROLE flex WITH NOINHERIT LOGIN PASSWORD 'flex_password';
+-- the main schema must exist for liquibase to add its changelog tables
+CREATE SCHEMA flex AUTHORIZATION flex;
 
 -- authenticator is used by backend/postgREST to connect to the database
 CREATE ROLE flex_authenticator


### PR DESCRIPTION
This PR does a few things:

* cleans up role names
* moves role creation out of the db load scripts
* "flex" role now owns all-the-things in the database - no more grants between the schemas. This allows us to more freely chop up functionality into different extension/logic schemas.
* removes the "migrator" role - flex is the owner and will be used for migrations as well

The purpose is to go one step further to provide a good starting point for liquibase.

I'm opening this as a draft because it will break deployment (need to fix that in the flex repo), but it is ready for review.