### PR TITLE
fix(ui): change in identity party ID field name

### DIFF
--- a/frontend/src/controllable_unit/ControllableUnitList.tsx
+++ b/frontend/src/controllable_unit/ControllableUnitList.tsx
@@ -20,8 +20,8 @@ const CreateCUSPButton = () => (
     component={Link}
     to={`/controllable_unit_service_provider/create`}
     startIcon={<AddIcon />}
-    // used to be able to input a CU ID instead of picking from the known CUs
-    state={{ fromCUList: true }}
+    // input a CU ID instead of from a list of names (cf. CUSP input)
+    state={{ cuIDAsNumber: true }}
     label="Manage another controllable unit"
   />
 );

--- a/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderInput.tsx
+++ b/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderInput.tsx
@@ -40,16 +40,17 @@ export const ControllableUnitServiceProviderInput = () => {
   const { data: identity, isLoading: identityLoading } = useGetIdentity();
   if (identityLoading) return <>Loading...</>;
 
-  // if we came to this page from the CU list, we want to input a CU ID,
-  // instead of selecting it from a list of already readable CUs
-  const isCreateFromCUList: boolean = !!overrideRecord?.fromCUList;
+  // if we came to this page as a user who cannot see the CU, we want to input a
+  // CU ID, instead of using the autocomplete component that works from the list
+  // of readable CUs
+  const cuIDAsNumber: boolean = !!overrideRecord?.cuIDAsNumber;
 
   // priority to the restored values if they exist, otherwise normal edit mode
   const record = filterRecord({ ...actualRecord, ...overrideRecord });
 
   const isServiceProvider = identity?.role == "flex_service_provider";
   if (isServiceProvider) {
-    record["service_provider_id"] = identity?.party_id;
+    record.service_provider_id = identity?.partyID;
   }
 
   return (
@@ -69,7 +70,7 @@ export const ControllableUnitServiceProviderInput = () => {
           Basic information
         </Typography>
         <InputStack direction="row" flexWrap="wrap">
-          {isCreateFromCUList ? (
+          {cuIDAsNumber ? (
             <NumberInput source="controllable_unit_id" />
           ) : (
             <AutocompleteReferenceInput

--- a/frontend/src/notification/NotificationList.tsx
+++ b/frontend/src/notification/NotificationList.tsx
@@ -23,7 +23,7 @@ export const NotificationList = () => {
       key="party_id"
       source="party_id"
       label="Current party only"
-      defaultValue={identity?.party_id}
+      defaultValue={identity?.partyID}
     />,
   ];
 
@@ -35,7 +35,7 @@ export const NotificationList = () => {
       filters={notificationFilters}
       filterDefaultValues={{
         acknowledged: false,
-        party_id: identity?.party_id,
+        party_id: identity?.partyID,
       }}
     >
       <Datagrid>


### PR DESCRIPTION
Bug detected while working on CU lookup, also an isolated part of the other PR.

Basically we were extracting the party ID from identity with a wrong field name. It's called `partyID`, not `party_id`. I don't know when the bug dates back to, but this fixes it.