### PR TITLE
fix(backend): set Authorization header from cookie in backend (FLEX-497)

### DIFF
--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -112,7 +112,8 @@ func (auth *API) TokenDecodingMiddleware(
 		} else { // no authorization header means we must use the cookie
 			tokenStr = sessionCookie.Value
 
-			// we set the header for cases where the request is sent to PostgREST
+			// we set the header for cases where the request is proxied or forwarded
+			// to another upstream service
 			req.Header.Set("Authorization", "Bearer "+tokenStr)
 		}
 

--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -111,6 +111,9 @@ func (auth *API) TokenDecodingMiddleware(
 			}
 		} else { // no authorization header means we must use the cookie
 			tokenStr = sessionCookie.Value
+
+			// we set the header for cases where the request is sent to PostgREST
+			req.Header.Set("Authorization", "Bearer "+tokenStr)
 		}
 
 		token, err := auth.decodeTokenString(tokenStr)


### PR DESCRIPTION
This transfer of the token from cookie to `Authorization` header was in the former PostgREST handler, and when transitioning to a stdlib format we removed it because this should belong to the token middleware. We just forgot to add it in the other place.

This got under the radar because tests kept working : they don't use the cookie as the OpenAPI client sets the header, so we are never in the problematic situation, as opposed to the frontend app.