### PR TITLE
fix(ui): wait for identity to be loaded before rendering notification list (FLEX-499)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -222,26 +222,26 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-            "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+            "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.0"
+                "@babel/template": "^7.26.9",
+                "@babel/types": "^7.26.10"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
-            "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+            "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.26.5"
+                "@babel/types": "^7.26.10"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -283,9 +283,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+            "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
             "license": "MIT",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -295,14 +295,14 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+            "version": "7.26.9",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+            "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/code-frame": "^7.26.2",
+                "@babel/parser": "^7.26.9",
+                "@babel/types": "^7.26.9"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -327,9 +327,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
-            "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+            "version": "7.26.10",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+            "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.25.9",

--- a/frontend/src/notification/NotificationList.tsx
+++ b/frontend/src/notification/NotificationList.tsx
@@ -10,7 +10,8 @@ import { DateField } from "../datetime";
 import { QuickFilter } from "../QuickFilter";
 
 export const NotificationList = () => {
-  const { identity } = useGetIdentity();
+  const { data: identity, isPending } = useGetIdentity();
+  if (isPending) return <p>Loading...</p>;
 
   const notificationFilters = [
     <QuickFilter


### PR DESCRIPTION
Could not reproduce the bug, but the error message suggests we were trying to use the identity even when it is undefined.

Following the [official docs](https://marmelab.com/react-admin/useGetIdentity.html), this PR makes the `NotificationList` component wait for the loading to be done before actually returning a component that uses the identity value as a filter.