### PR TITLE
fix(auth): bypass Authelia update to token claims (FLEX-510)

### DIFF
--- a/local/authelia/config/configuration.yml
+++ b/local/authelia/config/configuration.yml
@@ -97,10 +97,18 @@ identity_providers:
     # TODO proper cors
     cors:
       allowed_origins: "*"
+    # follows Authelia's changes to ID token content
+    # https://www.authelia.com/blog/4.39-release-notes/#id-token-changes
+    # TODO see if we want to keep using preferred_username
+    claims_policies:
+      default:
+        id_token: ['preferred_username']
     # https://www.authelia.com/configuration/identity-providers/openid-connect/clients/
     clients:
       - client_id: 'flex_oidc_client_id_value'
         client_name: 'Flex Portal'
+        # related to claims_policies above
+        claims_policy: 'default'
         # TODO secret file
         # This is the secret from the docker-compose.yml
         client_secret: '$argon2id$v=19$m=16,t=2,p=1$cmFuZG9tc2FsdA$5QIrCASIDQHP8kRK4XB4eA'
@@ -120,6 +128,8 @@ identity_providers:
         response_modes:
           - 'form_post'
           - 'query'
+
+
 notifier:
   filesystem:
     filename: '/config/.notification.txt'


### PR DESCRIPTION
Authelia just released a new version of their software with a breaking change in the claims of the authentication tokens. IIUC, basically they are removing claims from the tokens that are not strictly necessary in the OIDC standard by default. Options were added in the configuration to bypass this and keep tokens as they were in previous versions.

This PR sets such options so that we don't have to care about it for now. We can think about a better solution later, but the local environment is necessary for testing and doing our work, so this shouldn't be in our way IMO, especially given that we just use Authelia in the local environment.

https://www.authelia.com/blog/4.39-release-notes/#id-token-changes

> [!NOTE]
> Another option was to pin v4.38 in the Docker Compose configuration, but they also fixed some bugs along the way, so I thought why not just keep using the latest version.