### PR TITLE
feat: remove end user ID from CU lookup response (FLEX-511)

### DIFF
--- a/backend/data/models.go
+++ b/backend/data/models.go
@@ -28,7 +28,6 @@ type ControllableUnitLookup struct {
 	BusinessID         string              `json:"business_id"`
 	Name               string              `json:"name"`
 	AccountingPointID  string              `json:"accounting_point_id"`
-	EndUserID          int                 `json:"end_user_id"`
 	TechnicalResources []technicalResource `json:"technical_resources"`
 }
 
@@ -60,7 +59,6 @@ func ReformatControllableUnitLookupResult(
 				BusinessID:         cuLookupRow.BusinessID,
 				Name:               cuLookupRow.Name,
 				AccountingPointID:  cuLookupRow.AccountingPointID,
-				EndUserID:          cuLookupRow.EndUserID,
 				TechnicalResources: technicalResources,
 			},
 		)

--- a/backend/data/models.sql
+++ b/backend/data/models.sql
@@ -4,7 +4,6 @@ SELECT
     business_id::text,
     name::text,
     accounting_point_id::text,
-    end_user_id::bigint,
     technical_resources::jsonb
 FROM controllable_unit_lookup(
   @end_user_business_id,

--- a/backend/data/models/models.sql.go
+++ b/backend/data/models/models.sql.go
@@ -15,7 +15,6 @@ SELECT
     business_id::text,
     name::text,
     accounting_point_id::text,
-    end_user_id::bigint,
     technical_resources::jsonb
 FROM controllable_unit_lookup(
   $1,
@@ -30,7 +29,6 @@ type ControllableUnitLookupRow struct {
 	BusinessID         string
 	Name               string
 	AccountingPointID  string
-	EndUserID          int
 	TechnicalResources []byte
 }
 
@@ -48,7 +46,6 @@ func (q *Queries) ControllableUnitLookup(ctx context.Context, endUserBusinessID 
 			&i.BusinessID,
 			&i.Name,
 			&i.AccountingPointID,
-			&i.EndUserID,
 			&i.TechnicalResources,
 		); err != nil {
 			return nil, err

--- a/db/api/controllable_unit_lookup.sql
+++ b/db/api/controllable_unit_lookup.sql
@@ -8,7 +8,6 @@ RETURNS TABLE (
     business_id text,
     name text,
     accounting_point_id text,
-    end_user_id bigint,
     technical_resources jsonb
 )
 SECURITY DEFINER
@@ -27,7 +26,6 @@ BEGIN
         business_id,
         name,
         accounting_point_id,
-        end_user_id,
         technical_resources
     IN (
         SELECT
@@ -35,7 +33,6 @@ BEGIN
             cu.business_id::text,
             cu.name,
             cu.accounting_point_id,
-            apeu.end_user_id,
             (
                 SELECT json_agg(row_to_json(tr))
                 FROM (

--- a/frontend/src/controllable_unit/lookup/ControllableUnitLookupResult.tsx
+++ b/frontend/src/controllable_unit/lookup/ControllableUnitLookupResult.tsx
@@ -5,7 +5,6 @@ import {
   RecordContextProvider,
   Button,
   useRecordContext,
-  ReferenceField,
 } from "react-admin";
 import { Link, useLocation } from "react-router-dom";
 import { Typography, Stack, Card, Box } from "@mui/material";
@@ -70,9 +69,6 @@ const ControllableUnitLookupResultItem = () => {
         <TextField source="business_id" label="Business ID" />
         <TextField source="accounting_point_id" label="Accounting point ID" />
         <TextField source="name" />
-        <ReferenceField source="end_user_id" reference="party">
-          <TextField source="name" />
-        </ReferenceField>
         <TechnicalResourceList
           source="technical_resources"
           data={record.technical_resources}

--- a/openapi/openapi-api-base.yml
+++ b/openapi/openapi-api-base.yml
@@ -102,12 +102,6 @@ components:
             type: string
             pattern: '^[1-9][0-9]{17}$'
             example: '709000000000000057'
-          end_user_id:
-            description: >-
-              The ID of the current end user on the controllable unit.
-            format: bigint
-            type: integer
-            example: 379
           technical_resources:
             description: >-
               The technical resources belonging to the controllable unit.

--- a/openapi/openapi-api-no-default.json
+++ b/openapi/openapi-api-no-default.json
@@ -199,12 +199,6 @@
                             "pattern": "^[1-9][0-9]{17}$",
                             "example": "709000000000000057"
                         },
-                        "end_user_id": {
-                            "description": "The ID of the current end user on the controllable unit.",
-                            "format": "bigint",
-                            "type": "integer",
-                            "example": 379
-                        },
                         "technical_resources": {
                             "description": "The technical resources belonging to the controllable unit.",
                             "type": "array",

--- a/openapi/openapi-api.json
+++ b/openapi/openapi-api.json
@@ -199,12 +199,6 @@
                             "pattern": "^[1-9][0-9]{17}$",
                             "example": "709000000000000057"
                         },
-                        "end_user_id": {
-                            "description": "The ID of the current end user on the controllable unit.",
-                            "format": "bigint",
-                            "type": "integer",
-                            "example": 379
-                        },
                         "technical_resources": {
                             "description": "The technical resources belonging to the controllable unit.",
                             "type": "array",

--- a/test/flex/models/controllable_unit_lookup_response_item.py
+++ b/test/flex/models/controllable_unit_lookup_response_item.py
@@ -20,7 +20,6 @@ class ControllableUnitLookupResponseItem:
         business_id (str): The business ID of the controllable unit. Example: 53919b79-876f-4dad-8bde-b29368367604.
         name (str): The name of the controllable unit. Example: Car Charger #54.
         accounting_point_id (str): The accounting point ID of the controllable unit. Example: 709000000000000057.
-        end_user_id (int): The ID of the current end user on the controllable unit. Example: 379.
         technical_resources (List['ControllableUnitLookupResponseItemTechnicalResourcesItem']): The technical resources
             belonging to the controllable unit.
     """
@@ -29,7 +28,6 @@ class ControllableUnitLookupResponseItem:
     business_id: str
     name: str
     accounting_point_id: str
-    end_user_id: int
     technical_resources: List["ControllableUnitLookupResponseItemTechnicalResourcesItem"]
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -41,8 +39,6 @@ class ControllableUnitLookupResponseItem:
         name = self.name
 
         accounting_point_id = self.accounting_point_id
-
-        end_user_id = self.end_user_id
 
         technical_resources = []
         for technical_resources_item_data in self.technical_resources:
@@ -57,7 +53,6 @@ class ControllableUnitLookupResponseItem:
                 "business_id": business_id,
                 "name": name,
                 "accounting_point_id": accounting_point_id,
-                "end_user_id": end_user_id,
                 "technical_resources": technical_resources,
             }
         )
@@ -79,8 +74,6 @@ class ControllableUnitLookupResponseItem:
 
         accounting_point_id = d.pop("accounting_point_id")
 
-        end_user_id = d.pop("end_user_id")
-
         technical_resources = []
         _technical_resources = d.pop("technical_resources")
         for technical_resources_item_data in _technical_resources:
@@ -95,7 +88,6 @@ class ControllableUnitLookupResponseItem:
             business_id=business_id,
             name=name,
             accounting_point_id=accounting_point_id,
-            end_user_id=end_user_id,
             technical_resources=technical_resources,
         )
 


### PR DESCRIPTION
This PR removes the `end_user_id` field of the CU lookup response.

First, it is unnecessary, because the user doing the lookup already knows their business ID, so they are likely to know their name. Second, it is a technical ID that does not mean much functionally, and if the user launching the lookup is not allowed to see the associated party, then they cannot even get the name from this ID.

Rød PR altså :wink: