### PR TITLE
feat: set explicit cache headers on all-the-things (FLEX-512)

### DIFF
--- a/local/nginx/templates/flex.conf
+++ b/local/nginx/templates/flex.conf
@@ -70,28 +70,31 @@ server {
     root /usr/share/nginx/html/flex;
     gzip_static on;
 
-    # /docs/ is where we serve the mkdocs documentation
-    location /docs/ {
-        add_header 'Cache-Control' 'private, max-age=1200, must-revalidate';
+    etag on;
+    add_header 'Cache-Control' 'private, must-revalidate';
+
+    location / {
+        expires 30m;
     }
 
     # Serving Elements OpenAPI documentation for the auth and data APIs
 
     location ~ ^/(api|auth)/v0/$ {
-        add_header 'Cache-Control' 'no-cache';
+        expires -1;
     }
 
     location ~ ^/(api|auth)/v0/index.html$ {
-        add_header 'Cache-Control' 'no-cache';
+        expires -1;
     }
 
     location ~ ^/(api|auth)/v0/openapi.json$ {
-        add_header 'Cache-Control' 'no-cache';
+        expires -1;
     }
 
     # Proper API endpoints
 
     location ~ ^/(api|auth)/v0/ {
+        expires -1;
 
         # Actually do some proxying
         proxy_set_header Host $host;


### PR DESCRIPTION
This _should_ make browsers less prone to cache older versions of our portal.

The behaviour in FLEX-512 is still a bit mysterious to me, but at least now we are returning explicit cache headers/etags all over the place.