### PR TITLE
fix: use alpinejs/csp to avoid unsafe-eval (FLEX-517)

### DIFF
--- a/docs/test-data.md
+++ b/docs/test-data.md
@@ -1,6 +1,4 @@
 <!-- markdownlint-disable MD033 MD041 MD013-->
-<script src="https://unpkg.com/alpinejs@3/dist/cdn.min.js"></script>
-
 # Test data
 
 Each test user has its own set of test data generated into the system. This includes:
@@ -45,30 +43,53 @@ Your test data will show up below.
 
 > [!TIP]
 > The values for the common test user is `0` and `Felles`.
-
 <script type="text/javascript">
-    function calculateCheckDigit(code) {
-        const sum = code.split('')
-            .reverse()
-            .map((n, i) => n * (i % 2 ? 1 : 3))
-            .reduce((sum, n) => sum + n, 0)
 
-        const roundedUp = Math.ceil(sum / 10) * 10;
+    // https://alpinejs.dev/advanced/csp
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('testdatainfo', () => {
+            return {
+                suffix: 0,
+                firstName: 'Felles',
+                parties: ['BRP','EU','ES','MO','SO','SP','TP','FISO'],
+                numAccountingPoints: 1000,
+                calculateCheckDigit(code) {
+                    const sum = code.split('')
+                        .reverse()
+                        .map((n, i) => n * (i % 2 ? 1 : 3))
+                        .reduce((sum, n) => sum + n, 0)
 
-        const checkDigit = roundedUp - sum;
+                    const roundedUp = Math.ceil(sum / 10) * 10;
 
-        return checkDigit;
-    }
-    function generateGLN(ssnSuffix, index) {
-        const base = '13370' + ssnSuffix.toString().padStart(3, '0') + index.toString().padStart(4, '0');
-        return base + calculateCheckDigit(base);
-    }
-    function generateGSRN(ssnSuffix, index) {
-        const base = '13370000000' + ssnSuffix.toString().padStart(3, '0') + index.toString().padStart(3, '0');
-        return base + calculateCheckDigit(base);
-    }
+                    const checkDigit = roundedUp - sum;
+
+                    return checkDigit;
+                },
+                generateGLN() {
+                    var index = this.$data.index;
+                    const base = '13370' + this.suffix.toString().padStart(3, '0') + index.toString().padStart(4, '0');
+                    return base + this.calculateCheckDigit(base);
+                },
+                generateGSRN() {
+                    var index = this.$data.index - 1;
+                    const base = '13370000000' + this.suffix.toString().padStart(3, '0') + index.toString().padStart(3, '0');
+                    return base + this.calculateCheckDigit(base);
+                },
+                setFirstName(event) {
+                    this.firstName = event.target.value;
+                },
+                setSuffix(event) {
+                    this.suffix = event.target.value;
+                },
+                partyName() {
+                    var party = this.$data.party;
+                    return this.firstName + ' ' + party;
+                }
+            }
+        })
+    })
 </script>
-<div id="testdata-gen" x-data="{ ssnSuffix: 0, userFirstname: 'Felles', parties: ['BRP','EU','ES','MO','SO','SP','TP','FISO'] }">
+<div id="testdata-gen" x-data="testdatainfo">
     <style type="text/css">
         #testdata-gen input{
             background: transparent;
@@ -76,30 +97,30 @@ Your test data will show up below.
             border-bottom: solid 1px #ccc;
             padding: 5px;
             transition: padding 0.4s;
-
+        }
         #testdata-gen .input-box {
             margin-bottom: 10px;
         }
     </style>
     <div class="input-box">
-        <label for="ssnSuffix">SSN Suffix:</label>
-        <input id="ssnSuffix" type="number" x-model="ssnSuffix" min="0" max="999" />
+        <label for="suffix">SSN Suffix:</label>
+        <input id="suffix" type="number" :value="suffix" @input="setSuffix" min="0" max="999" />
     </div>
     <div class="input-box">
-        <label for="userFirstname">User Firstname:</label>
-        <input id="userFirstname" type="text" x-model="userFirstname" pattern="[A-Za-z]+" />
+        <label for="firstName">User Firstname:</label>
+        <input id="firstName" type="text" :value="firstName" @input="setFirstName" pattern="[A-Za-z]+" />
     </div>
 
     <h3>Parties</h3>
     <p>
-        These are the test parties for <em x-text="userFirstname"></em>.
+        These are the test parties for <em x-text="firstName"></em>.
     </p>
     <ul>
-        <template x-for="(abbr, index) in parties">
+        <template x-for="(party, index) in parties">
             <li>
-                <span x-text="generateGLN(ssnSuffix, index)"></span>
+                <span x-text="generateGLN"></span>
                 -
-                <span x-text="userFirstname + ' ' + abbr"></span>
+                <span x-text="partyName"></span>
             </li>
 
         </template>
@@ -107,12 +128,13 @@ Your test data will show up below.
     <h3>Accounting points</h3>
     <p>
         This list contains 1000 accounting points where
-        <em x-text="userFirstname + ' SO'"></em> is the connecting system operator.
+        <em x-text="firstName"></em> is the connecting system operator.
     </p>
     <ul>
-        <template x-for="index in 1000">
+        <template x-for="index in numAccountingPoints">
             <li>
-                <span x-text="generateGSRN(ssnSuffix, index-1)"></span>
+                <span x-text="generateGSRN"></span>
             </li>
         </template>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/@alpinejs/csp@3/dist/cdn.min.js"></script>

--- a/local/elements/index.html
+++ b/local/elements/index.html
@@ -8,10 +8,10 @@
     />
     <title>API_TITLE</title>
     <!-- Embed elements Elements via Web Component -->
-    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@stoplight/elements/web-components.min.js"></script>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@stoplight/elements/styles.min.css"
+      href="https://cdn.jsdelivr.net/npm/@stoplight/elements/styles.min.css"
     />
   </head>
   <body>

--- a/local/nginx/templates/flex.conf
+++ b/local/nginx/templates/flex.conf
@@ -61,8 +61,8 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
 
     # CIS 5.3.3 Ensure that Content Security Policy (CSP) is enabled and configured properly
-    # TODO unpkg.com is used for the OpenAPI UI, but we should consider hosting/bundling it ourselves
-    add_header Content-Security-Policy "default-src 'self' data:; script-src 'self' https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://unpkg.com; font-src 'self' https://fonts.gstatic.com;" always;
+    # TODO cdn.jsdelivr.net is used for the OpenAPI UI, but we should consider hosting/bundling it ourselves
+    add_header Content-Security-Policy "default-src 'self' data:; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.gstatic.com;" always;
 
     # 5.3.4 Ensure the Referrer Policy is enabled and configured properly (Manual)
     add_header Referrer-Policy "no-referrer" always;


### PR DESCRIPTION
Switching to jsdelivr because alpinejs/csp is not available on unpkg