### PR TITLE
feat(auth): use entity client resource in login (FLEX-521)

### DIFF
--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -879,7 +879,7 @@ func (auth *API) jwtBearerHandler(
 	entityID, externalID, pubKeyPEM, err := models.GetEntityClientByUUID(
 		ctx,
 		tx,
-		grant.Issuer.ClientID,
+		grant.Issuer,
 	)
 	if err != nil || pubKeyPEM == "" {
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, oauthErrorMessage{

--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -864,14 +864,6 @@ func (auth *API) jwtBearerHandler(
 		return
 	}
 
-	if grant.Issuer.IdentifierType != "uuid" {
-		ctx.AbortWithStatusJSON(http.StatusBadRequest, oauthErrorMessage{
-			Error:            oauthErrorInvalidRequest,
-			ErrorDescription: "invalid assertion payload: no entity client UUID in issuer",
-		})
-		return
-	}
-
 	// get entity of client
 	tx, err := auth.db.Begin(ctx)
 	if err != nil {
@@ -887,7 +879,7 @@ func (auth *API) jwtBearerHandler(
 	entityID, externalID, pubKeyPEM, err := models.GetEntityClientByUUID(
 		ctx,
 		tx,
-		grant.Issuer.Identifier,
+		grant.Issuer.ClientID,
 	)
 	if err != nil || pubKeyPEM == "" {
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, oauthErrorMessage{

--- a/backend/auth/models/models.go
+++ b/backend/auth/models/models.go
@@ -76,13 +76,11 @@ func GetEntityOfBusinessID(
 	return entityID, eid, nil
 }
 
-// GetEntityClientOfBusinessID gets the entity, external ID and PEM public key
-// of a entity business id for the required client.
-func GetEntityClientOfBusinessID(
+// GetEntityClientByUUID gets the entity, external ID and PEM public key of an
+// entity client identified by its UUID.
+func GetEntityClientByUUID(
 	ctx context.Context,
 	tx pgx.Tx,
-	businessID string,
-	businessIDType string,
 	clientID string,
 ) (int, string, string, error) {
 	var entityID int
@@ -91,9 +89,7 @@ func GetEntityClientOfBusinessID(
 	err := tx.QueryRow(
 		ctx,
 		"select entity_id, external_id, client_public_key"+
-			" from auth.entity_client_of_business_id($1, $2, $3)",
-		businessID,
-		businessIDType,
+			" from auth.entity_client_by_uuid($1)",
 		clientID,
 	).Scan(&entityID, &eid, &pubKeyPEM)
 	if err != nil {

--- a/backend/internal/trace/trace.go
+++ b/backend/internal/trace/trace.go
@@ -18,7 +18,9 @@ func Init() {
 }
 
 // Tracer returns the global otel tracer.
-func Tracer(name string) trace.Tracer { //nolint:ireturn
+//
+//nolint:ireturn
+func Tracer(name string) trace.Tracer {
 	return otel.Tracer(name)
 }
 

--- a/db/auth_base.sql
+++ b/db/auth_base.sql
@@ -54,12 +54,9 @@ AS $$
     WHERE e.business_id = in_business_id
 $$;
 
--- Gets entity details from the business id on the required client
-CREATE OR REPLACE FUNCTION entity_client_of_business_id(
-    in_business_id text,
-    in_business_id_type text,
-    in_client_id text
-) RETURNS TABLE (
+-- Gets entity details from the entity client uuid
+CREATE OR REPLACE FUNCTION entity_client_by_uuid(in_client_id text)
+RETURNS TABLE (
     entity_id bigint,
     external_id uuid,
     client_public_key text
@@ -73,9 +70,7 @@ AS $$
     FROM flex.entity e
     INNER JOIN flex.entity_client as clt
         ON e.id = clt.entity_id
-    WHERE e.business_id = in_business_id
-        AND e.business_id_type = in_business_id_type
-        AND clt.client_id::text = in_client_id
+    WHERE clt.client_id::text = in_client_id
 $$;
 
 CREATE OR REPLACE FUNCTION assume_party(_party_id bigint)

--- a/db/auth_base.sql
+++ b/db/auth_base.sql
@@ -25,16 +25,14 @@ RETURNS TABLE (
 SECURITY DEFINER VOLATILE
 LANGUAGE sql
 AS $$
-    select
-      e.id,
-      flex.identity_external_id(e.id, null) as external_id
-    from
-      flex.entity e
-    inner join flex.entity_client as clt
-      on e.id = clt.entity_id
-    where
-      clt.client_id = _client_id::uuid
-      and clt.client_secret = public.crypt(_client_secret, clt.client_secret)
+    SELECT
+        e.id,
+        flex.identity_external_id(e.id, null) AS external_id
+    FROM flex.entity e
+    INNER JOIN flex.entity_client AS clt
+        ON e.id = clt.entity_id
+    WHERE clt.client_id::text = _client_id
+        AND clt.client_secret = public.crypt(_client_secret, clt.client_secret)
 $$;
 
 GRANT EXECUTE ON FUNCTION entity_of_credentials TO flex_anonymous;

--- a/db/auth_base.sql
+++ b/db/auth_base.sql
@@ -30,9 +30,11 @@ AS $$
       flex.identity_external_id(e.id, null) as external_id
     from
       flex.entity e
+    inner join flex.entity_client as clt
+      on e.id = clt.entity_id
     where
-      e.client_id = _client_id
-      and e.client_secret = public.crypt(_client_secret, e.client_secret)
+      clt.client_id = _client_id::uuid
+      and clt.client_secret = public.crypt(_client_secret, clt.client_secret)
 $$;
 
 GRANT EXECUTE ON FUNCTION entity_of_credentials TO flex_anonymous;

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -215,13 +215,17 @@ Individuals what want to log into the portal will log in using the
 `OpenID Connect` protocol with an identity provider. In a production setting the
 identity provider will be IDPorten.
 
-Entities that want to use the API will have two ways of authenticating.
+Entities that want to use the API will have to create and attach clients to
+their entity resource in the system. Creating a client generates a unique
+identifier and allows setting a password and/or a public key associated to this
+client. From there, users have two ways of authenticating.
 
-* `JWT Bearer` - The entity uploads a public key to the portal and uses a
-  self-signed JWT Authorization grant to authenticate.
+* `JWT Bearer` - The entity uploads a public key to one of its clients and uses
+  a self-signed JWT Authorization grant to authenticate.
 * `Client Credentials` - The entity uses a client_id and client_secret to
-  authenticate. The client_secret is basically a password that must be set by
-  the entity in the portal.
+  authenticate. The client_id is the UUID of one of the clients added by the
+  entity in the system, and client_secret is basically a password that must be
+  set on this client.
 
 !!! note "Possible future use of enterprise certificates"
 
@@ -247,12 +251,14 @@ token for the portal.
     This is a temporary solution that will be removed in later versions of the
     FIS. Use the `JWT Bearer` method instead.
 
-To use this method, first log in to the portal and set the Client Secret on the
-entity. This should be a strong password. Consider generating a random password
-using some kind of online generator.
+To use this method, first log in to the portal and add a new client to the
+entity. Then, write down the generated Client ID on the created client, because
+you will need it to log in, and set the Client Secret on the client. This should
+be a strong password. Consider generating a random password using some kind of
+online generator.
 
-Once Client Secret is set in the portal, is established through basic
-authentication on the auth API's `/token` endpoint, using the
+Once Client Secret is set in the portal, the connection is established through
+basic authentication on the auth API's `/token` endpoint, using the
 [client_credentials](https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/)
 `grant_type` with
 [Client Password](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1),
@@ -263,14 +269,14 @@ Set `Content-Type` header as `application/x-www-form-urlencoded`.
 Example body:
 
 ```text
-grant_type=client_credentials&client_id=<email>&client_secret=<client_secret>
+grant_type=client_credentials&client_id=<client_id>&client_secret=<client_secret>
 ```
 
 The result is a JWT access token for the entity that can be used to access the API.
 
 ### JWT Bearer
 
-This is the preferred method for authenticating towards the API. The method is
+This is the preferred method for authenticating towards the API. The method
 uses
 [JWTs as authorization grants](https://datatracker.ietf.org/doc/html/rfc7523#section-2.1)
 as defined by RFC7523. This the same method as [used by Maskinporten](https://docs.digdir.no/docs/Maskinporten/maskinporten_auth_server-to-server-oauth2).
@@ -284,19 +290,19 @@ grant_type: urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<authorization
 
 The magic is in the assertion JWT. Use the following payload.
 
-| Claim | Name            | Description                                                                                                                                    | Example                               |
-|-------|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
-| `aud` | Audience        | The URL of the token endpoint.                                                                                                                 | `https://flex-test.elhub.no/auth/v0/` |
-| `exp` | Expiration Time | The expiration time of the JWT. Maximum 120 seconds after `iat`.                                                                               |                                       |
-| `iat` | Issued At       | The time the JWT was issued. Only tokens with `iat` within 10 seconds of server time will be accepted.                                         |                                       |
-| `iss` | Issuer          | The issuer of the token on the format. `no:entity:<id type>:<id>`. Id type is either `pid` or `org`.                                           | `no:entity:pid:111111111111`          |
-| `jti` | JWT             | A unique identifier for the JWT. For (future) protection against replay attacks.                                                               |                                       |
-| `sub` | Subject         | Optional. Use if the client wants to assume party as part of the request. Format `no:entity:<id type>:<id>`. Id type is either `uuid` or `gln` | `no:party:gln:1234567890123`          |
+| Claim | Name            | Description                                                                                                                                       | Example                                               |
+|-------|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `aud` | Audience        | The URL of the token endpoint.                                                                                                                    | `https://flex-test.elhub.no/auth/v0/`                 |
+| `exp` | Expiration Time | The expiration time of the JWT. Maximum 120 seconds after `iat`.                                                                                  |                                                       |
+| `iat` | Issued At       | The time the JWT was issued. Only tokens with `iat` within 10 seconds of server time will be accepted.                                            |                                                       |
+| `iss` | Issuer          | The issuer of the token on the format. `no:entity:uuid:<client_id>`. `client_id` is the UUID of the client whose key is used to sign the token.   | `no:entity:uuid:2fc014f2-e9b4-41d4-ad6b-c360b8ee6229` |
+| `jti` | JWT             | A unique identifier for the JWT. For (future) protection against replay attacks.                                                                  |                                                       |
+| `sub` | Subject         | Optional. Use if the client wants to assume party as part of the request. Format `no:entity:<id_type>:<id>`. `id_type` is either `uuid` or `gln`. | `no:party:gln:1234567890123`                          |
 
-The JWT must be signed by the entity's RSA private key. The public key must be
-uploaded to the entity in the portal prior to making the request. An example of
-how to generate a key pair is shown below. Upload the contents of the file
-`.flex.pub.pem` in the portal.
+The JWT must be signed by the entity client's RSA private key. The public key
+must be uploaded to the client in the portal prior to making the request. An
+example of how to generate a key pair is shown below. Upload the contents of the
+file `.flex.pub.pem` in the portal.
 
 ```bash
 openssl genrsa -out .flex.key.pem 3072

--- a/openapi/openapi-auth.yml
+++ b/openapi/openapi-auth.yml
@@ -94,13 +94,15 @@ components:
         client_id:
           type: string
           description: The identifier of the entity that logs in.
-          example: example@flex.test
+          # yamllint disable-line rule:line-length
+          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+          example: 2854fee6-4591-4b1f-8726-af04475ef047
         client_secret:
           type: string
           description: The password of the entity that logs in.
           example: '1234'
       # yamllint disable-line rule:line-length
-      example: grant_type=client_credentials&client_id=example@flex.test&client_secret=1234
+      example: grant_type=client_credentials&client_id=2854fee6-4591-4b1f-8726-af04475ef047&client_secret=1234
       required:
         - grant_type
         - client_id

--- a/test/auth_tests/test_client_credentials.py
+++ b/test/auth_tests/test_client_credentials.py
@@ -58,7 +58,7 @@ def test_wrong_password():
         headers=auth_headers,
         data={
             "grant_type": "client_credentials",
-            "client_id": "test.suite@flex.test",
+            "client_id": "3733e21b-5def-400d-8133-06bcda02465e",
             "client_secret": "wrong_pass",
         },
     )
@@ -79,7 +79,7 @@ def test_client_credentials_ok():
         headers=auth_headers,
         data={
             "grant_type": "client_credentials",
-            "client_id": "test.suite@flex.test",
+            "client_id": "3733e21b-5def-400d-8133-06bcda02465e",
             "client_secret": "87h87hijhulO",
         },
     )

--- a/test/auth_tests/test_jwt_bearer.py
+++ b/test/auth_tests/test_jwt_bearer.py
@@ -28,30 +28,27 @@ client_ids = {
 
 
 @pytest.mark.parametrize(
-    "key,idtype,client_id,expected_status,error",
+    "key,client_id,expected_status,error",
     [
-        ("test", "uuid", client_ids["test"], 200, ""),
-        ("common", "uuid", client_ids["common"], 200, ""),
-        ("common", "uuid", "malformed", 400, "invalid_request"),
-        ("common", "org", client_ids["common"], 400, "invalid_request"),
-        ("common", "malformed", client_ids["common"], 400, "invalid_request"),
-        ("common", "uuid", None, 400, "invalid_request"),
+        ("test", client_ids["test"], 200, ""),
+        ("common", client_ids["common"], 200, ""),
+        ("common", "malformed", 400, "invalid_request"),
+        ("common", "", 400, "invalid_request"),
+        ("common", None, 400, "invalid_request"),
         (
             "common",
-            "uuid",
             "0c799c4b-9a0e-4b52-a19d-44e18fbd2cd1",
             400,
             "invalid_client",
         ),
     ],
 )
-def test_entity(keys, key, idtype, client_id, expected_status, error):
-    iss = f"no:entity:{idtype}" + (":" + client_id) if client_id is not None else ""
+def test_entity(keys, key, client_id, expected_status, error):
     payload = {
         # Audience
         "aud": "https://test.flex.internal:6443/auth/v0/",
         # Issuer
-        "iss": iss,  # Test Suite
+        "iss": client_id,  # Test Suite
         # JWT ID
         "jti": str(uuid.uuid4()),
         # Issued at
@@ -120,7 +117,7 @@ def test_party(keys, key, gln, client_id, expected_status, error):
         # Audience
         "aud": "https://test.flex.internal:6443/auth/v0/",
         # Issuer
-        "iss": f"no:entity:uuid:{client_id}",  # Test Suite
+        "iss": client_id,  # Test Suite
         # JWT ID
         "jti": str(uuid.uuid4()),
         # Subject (the subject to get a token for)
@@ -152,52 +149,52 @@ def test_party(keys, key, gln, client_id, expected_status, error):
         # The only valid case
         (
             "https://test.flex.internal:6443/auth/v0/",
-            f"no:entity:uuid:{client_ids['test']}",
+            client_ids["test"],
             "no:party:gln:1337000100058",
             200,
         ),
         # Invalid audience
         (
             "https://test.flex.internal:6443/auth/v0",
-            f"no:entity:uuid:{client_ids['test']}",
+            client_ids["test"],
             "no:party:gln:1337000100058",
             400,
         ),
         (
             "https://flex.localost:6443/auth/v0/",
-            f"no:entity:uuid:{client_ids['test']}",
+            client_ids["test"],
             "no:party:gln:1337000100058",
             400,
         ),
         # Invalid issuer
         (
             "https://test.flex.internal:6443/auth/v0/",
-            f"no:entity:{client_ids['test']}",
+            "malformed",
             "no:party:gln:1337000100058",
             400,
         ),
         (
             "https://test.flex.internal:6443/auth/v0/",
-            f"no:party:uuid:{client_ids['test']}",
+            client_ids["common"],
             "no:party:gln:1337000100058",
             400,
         ),
         # Invalid subject
         (
             "https://test.flex.internal:6443/auth/v0/",
-            f"no:entity:uuid:{client_ids['test']}",
+            client_ids["test"],
             "no:entity:gln:1337000100058",
             400,
         ),
         (
             "https://test.flex.internal:6443/auth/v0/",
-            f"no:entity:uuid:{client_ids['test']}",
+            client_ids["test"],
             "party:gln:1337000100058",
             400,
         ),
         (
             "https://test.flex.internal:6443/auth/v0/",
-            f"no:entity:uuid:{client_ids['test']}",
+            client_ids["test"],
             "no:party:gln:337000100058",
             400,
         ),
@@ -262,7 +259,7 @@ def test_timing(keys, expected_status, iat, exp):
         # Audience
         "aud": "https://test.flex.internal:6443/auth/v0/",
         # Issuer
-        "iss": f"no:entity:uuid:{client_ids['test']}",  # Test Suite
+        "iss": client_ids["test"],  # Test Suite
         # Subject
         "sub": "no:party:gln:1337000100058",
         # JWT ID

--- a/test/inspect/assume_delete_entity.hurl
+++ b/test/inspect/assume_delete_entity.hurl
@@ -3,7 +3,7 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: test.suite@flex.test
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: 87h87hijhulO
 HTTP 200
 

--- a/test/inspect/assume_delete_success.hurl
+++ b/test/inspect/assume_delete_success.hurl
@@ -3,7 +3,7 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: test.suite@flex.test
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: 87h87hijhulO
 HTTP 200
 

--- a/test/inspect/assume_missing_party_id.hurl
+++ b/test/inspect/assume_missing_party_id.hurl
@@ -3,7 +3,7 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: test.suite@flex.test
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: 87h87hijhulO
 HTTP 200
 

--- a/test/inspect/assume_success.hurl
+++ b/test/inspect/assume_success.hurl
@@ -3,7 +3,7 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: test.suite@flex.test
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: 87h87hijhulO
 HTTP 200
 

--- a/test/inspect/gen_jwt.py
+++ b/test/inspect/gen_jwt.py
@@ -17,7 +17,7 @@ payload = {
     # Audience
     "aud": "https://test.flex.internal:6443/auth/v0/",
     # Issuer
-    "iss": "no:entity:pid:13370000001",  # Test Suite
+    "iss": "no:entity:uuid:3733e21b-5def-400d-8133-06bcda02465e",  # Test Suite
     # JWT ID
     "jti": str(uuid.uuid4()),
     # Subject (the subject to get a token for)

--- a/test/inspect/hurl.sh
+++ b/test/inspect/hurl.sh
@@ -9,10 +9,10 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 PRIVATE_KEY_FILE="${SCRIPT_DIR}/../keys/.test.key.pem"
 
 # HURL_ variables can be used in the hurl file
-HURL_grant_jwt=$("$SCRIPT_DIR/gen_jwt.py" "$PRIVATE_KEY_FILE")
+HURL_grant_jwt=$("$SCRIPT_DIR/../../.venv/bin/python3" "$SCRIPT_DIR/gen_jwt.py" "$PRIVATE_KEY_FILE")
 export HURL_grant_jwt
 
-hurl \
+hurl -k \
 	--variables-file "$1" \
 	--very-verbose \
 	--color \

--- a/test/inspect/session_success.hurl
+++ b/test/inspect/session_success.hurl
@@ -3,7 +3,7 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: test.suite@flex.test
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: 87h87hijhulO
 HTTP 200
 

--- a/test/inspect/token_client_credentials_incorrect_client.hurl
+++ b/test/inspect/token_client_credentials_incorrect_client.hurl
@@ -3,5 +3,5 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: "common.shared@notexists.test"
+client_id: 4fcc4592-678b-4901-96fd-8051092d8982
 client_secret: "87h87hijhulO"

--- a/test/inspect/token_client_credentials_incorrect_password.hurl
+++ b/test/inspect/token_client_credentials_incorrect_password.hurl
@@ -3,5 +3,5 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: "test.suite@flex.test"
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: "87h87hijhulO"

--- a/test/inspect/token_client_credentials_success.hurl
+++ b/test/inspect/token_client_credentials_success.hurl
@@ -3,5 +3,5 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: test.suite@flex.test
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: 87h87hijhulO

--- a/test/inspect/token_exchange_success.hurl
+++ b/test/inspect/token_exchange_success.hurl
@@ -3,7 +3,7 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: test.suite@flex.test
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: 87h87hijhulO
 HTTP 200
 [Captures]

--- a/test/inspect/token_exchange_unauthorized.hurl
+++ b/test/inspect/token_exchange_unauthorized.hurl
@@ -3,7 +3,7 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: test.suite@flex.test
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: 87h87hijhulO
 HTTP 200
 [Captures]

--- a/test/inspect/token_userinfo_bad_token.hurl
+++ b/test/inspect/token_userinfo_bad_token.hurl
@@ -3,7 +3,7 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: test.suite@flex.test
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: 87h87hijhulO
 HTTP 200
 

--- a/test/inspect/token_userinfo_entity.hurl
+++ b/test/inspect/token_userinfo_entity.hurl
@@ -3,7 +3,7 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: test.suite@flex.test
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: 87h87hijhulO
 HTTP 200
 

--- a/test/inspect/token_userinfo_party.hurl
+++ b/test/inspect/token_userinfo_party.hurl
@@ -3,7 +3,7 @@ POST {{ auth_url }}/token
 Content-Type: application/x-www-form-urlencoded
 [FormParams]
 grant_type: client_credentials
-client_id: test.suite@flex.test
+client_id: 3733e21b-5def-400d-8133-06bcda02465e
 client_secret: 87h87hijhulO
 HTTP 200
 [Captures]

--- a/test/security_token_service.py
+++ b/test/security_token_service.py
@@ -62,12 +62,12 @@ class TestEntity(Enum):
     # https://stackoverflow.com/questions/62460557/cannot-collect-test-class-testmain-because-it-has-a-init-constructor-from
     __test__ = False
 
-    def email(self):
+    def client_id(self):
         match self:
             case TestEntity.TEST:
-                return "test.suite@flex.test"
+                return "3733e21b-5def-400d-8133-06bcda02465e"
             case TestEntity.COMMON:
-                return "common.shared@flex.test"
+                return "df8bee5f-6e60-4a21-8927-e5bcdd4ce768"
 
 
 """
@@ -148,7 +148,7 @@ class SecurityTokenService:
 
     # network call for authentication
     def _get_client(self, entity: TestEntity, party_name=None):
-        entity_token = self._client_credentials(entity.email(), "87h87hijhulO")
+        entity_token = self._client_credentials(entity.client_id(), "87h87hijhulO")
         entity_client = AuthenticatedClient(
             base_url=self.api_url, token=entity_token, verify_ssl=False
         )
@@ -251,7 +251,7 @@ class SecurityTokenService:
 
         # now get a client for the new party
 
-        entity_token = self._client_credentials(entity.email(), "87h87hijhulO")
+        entity_token = self._client_credentials(entity.client_id(), "87h87hijhulO")
         token = self._token_exchange(entity_token, party.id)
 
         return AuthenticatedClient(


### PR DESCRIPTION
This PR makes use of the entity client resource in the actual authentication routes that were previously using client information stored in entity. Client credentials and JWT Bearer authentication methods are updated.