### PR TITLE
fix(ui): make tooltips work on history pages (FLEX-550)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,10 +1,10 @@
 {
-    "name": "flex-admin",
+    "name": "flex-portal",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "flex-admin",
+            "name": "flex-portal",
             "dependencies": {
                 "@raphiniert/ra-data-postgrest": "^2.4.1",
                 "@tanstack/react-query-devtools": "^5.66.0",

--- a/frontend/src/tooltip/FieldTooltip.tsx
+++ b/frontend/src/tooltip/FieldTooltip.tsx
@@ -3,7 +3,8 @@ import HelpIcon from "@mui/icons-material/Help";
 import tooltips from "./tooltips.json";
 
 export const FieldTooltip = (props: any) => {
-  const title = (tooltips as any)[props.resource][props.field];
+  const resource = props.resource?.replace("_history", "");
+  const title = (tooltips as any)[resource][props.field];
   return title ? (
     <Tooltip title={title} arrow>
       <HelpIcon fontSize="small" color="disabled" />


### PR DESCRIPTION
Could not reproduce the exact same error message as in the ticket, but I also got an error on history pages, and according to the console it was related to tooltip components not working. At least this one is fixed.