### PR TITLE
Disable dependency analysis in NpmProject configuration

### DIFF
--- a/.teamcity/_Self/NpmProject.kt
+++ b/.teamcity/_Self/NpmProject.kt
@@ -19,6 +19,7 @@ object NpmProject : TeamcityProject({
                     sonarProjectTests = null // no tests in frontend
                 }
                 disableLint = true
+                analyzeDependencies = false // will be solved by TDX-587
             }
         }
     }


### PR DESCRIPTION
The OWASP dependency analysis is currently not working. Temporarily disabling and will re-enable this when the associated Jira task is resolved ([TDX-587](https://elhub.atlassian.net/browse/TDX-587))

[TDX-587]: https://elhub.atlassian.net/browse/TDX-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ