### PR TITLE
feat(db): allow multiple SP product application per SP & SO (FLEX-555)

### DIFF
--- a/db/flex/service_provider_product_application.sql
+++ b/db/flex/service_provider_product_application.sql
@@ -55,8 +55,6 @@ CREATE TABLE IF NOT EXISTS service_provider_product_application (
     ),
     recorded_by bigint NOT NULL DEFAULT current_identity(),
 
-    UNIQUE (service_provider_id, system_operator_id),
-
     CONSTRAINT service_provider_product_application_service_provider_fkey
     FOREIGN KEY (
         service_provider_id, service_provider_party_type


### PR DESCRIPTION
This PR allows an SP to create several product applications for the same SO. There is actually nothing else to do than lifting a constraint.

No additional constraint on the actual product types was added for now, but we could error if a product type was already applied for in a previous application.