### PR TITLE
chore: upgrade golangci-lint to v2.0.2 (FLEX-554)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,89 +1,97 @@
 ---
 # https://golangci-lint.run/usage/configuration/
 
-issues:
-  # don't skip warning about doc comments
-  # we can enable individual ones with
-  # https://golangci-lint.run/usage/false-positives/#default-exclusions
-  exclude-use-default: false
-  exclude:
-    - should have a package comment
-
+version: "2"
 linters:
-  # using enable-all since it allows us to get all new linters
+  # using default all since it allows us to get all new linters
   # without having to update this file
-  enable-all: true
+  default: all
   disable:
-    # deprecated linters
-    - tenv
     # depguard checks that package imports are in a
     # list of acceptable packages - not applicable at the moment
     - depguard
-    # nlreturn and wsl adds lots of whitespace rules that are annoying
+    # nlreturn and wsl add lots of whitespace rules that are annoying
     - nlreturn
     - wsl
-    # gci conflicts with gofumpt
-    - gci
-linters-settings:
-  ireturn:
-    allow:
-      - anon
-      - error
-      - empty
-      - stdlib
-      - github.com\/jackc\/pgx\/v5.Tx
-      - github.com\/jackc\/pgx\/v5.BatchResults
-      - github.com\/jackc\/pgx\/v5.Rows
-      - github.com\/jackc\/pgx\/v5.Row
-
-  lll:
-    line-length: 160
-  errcheck:
-    exclude-functions:
-      - (github.com/jackc/pgx/v5.Tx).Commit
-      - (github.com/jackc/pgx/v5.Tx).Rollback
-      - (io.Closer).Close
-      - (net/http.ResponseWriter).Write
-      - encoding/json.Marshal
-  errchkjson:
-    check-error-free-encoding: true
-  forbidigo:
-    forbid:
-      - ^fmt\.Print.*$
-      - ^log\.Print.*$
-      - ^slog\.(Debug|Warn|Info|Error)$
-  godox:
-    keywords:
-      - FIXME
-  gosec:
-    excludes:
-      - G104 # Audit errors not checked
-  tagliatelle:
-    case:
-      rules:
-        json: snake
-  mnd:
-    checks:
-      - argument
-      - case
-      - condition
+  settings:
+    errcheck:
+      exclude-functions:
+        - (github.com/jackc/pgx/v5.Tx).Commit
+        - (github.com/jackc/pgx/v5.Tx).Rollback
+        - (io.Closer).Close
+        - (net/http.ResponseWriter).Write
+        - encoding/json.Marshal
+    errchkjson:
+      check-error-free-encoding: true
+    forbidigo:
+      forbid:
+        - pattern: ^fmt\.Print.*$
+        - pattern: ^log\.Print.*$
+        - pattern: ^slog\.(Debug|Warn|Info|Error)$
+    godox:
+      keywords:
+        - FIXME
+    gosec:
+      excludes:
+        - G104 # Audit errors not checked
+    ireturn:
+      allow:
+        - anon
+        - error
+        - empty
+        - stdlib
+        - github.com\/jackc\/pgx\/v5.Tx
+        - github.com\/jackc\/pgx\/v5.BatchResults
+        - github.com\/jackc\/pgx\/v5.Rows
+        - github.com\/jackc\/pgx\/v5.Row
+    lll:
+      line-length: 160
+    mnd:
+      checks:
+        - argument
+        - case
+        - condition
       # - operation
-      - return
+        - return
       # - assign
-  varnamelen:
-    min-name-length: 2
-    ignore-decls:
-      - w http.ResponseWriter
-      - r *http.Request
-  wrapcheck:
-    ignoreSigs:
-      - .Error
-      - .Errorf(
-      - errors.New(
-      - errors.Unwrap(
-      - errors.Join(
-      - .Wrap(
-      - .Wrapf(
-      - .WithMessage(
-      - .WithMessagef(
-      - .WithStack(
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+    varnamelen:
+      min-name-length: 2
+      ignore-decls:
+        - w http.ResponseWriter
+        - r *http.Request
+    wrapcheck:
+      ignore-sigs:
+        - .Error
+        - .Errorf(
+        - errors.New(
+        - errors.Unwrap(
+        - errors.Join(
+        - .Wrap(
+        - .Wrapf(
+        - .WithMessage(
+        - .WithMessagef(
+        - .WithStack(
+  exclusions:
+    generated: lax
+    rules:
+      - path: (.+)\.go$
+        text: should have a package comment
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/docs-dev/index.md
+++ b/docs-dev/index.md
@@ -16,8 +16,6 @@ users/contributors.
 Some additional tools are required:
 
 ```bash
-# golangci-lint is used to lint go code
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 # go-licenses is used to vet go licenses
 go install github.com/google/go-licenses@latest
 #  govulncheck is used to check for vulnerabilities in go dependencies
@@ -31,6 +29,8 @@ go install github.com/air-verse/air@latest
 ```
 
 ```bash
+# golangci-lint is used to lint go code
+brew install golangci-lint
 brew install pandoc
 brew install ruff
 brew install sqlc


### PR DESCRIPTION
This PR updates the `golangci-lint` configuration to v2.0.2 (automated update with the `migrate` command, then manual copy of former comments) and updates our docs accordingly. After merging, we need to have an updated `golangci-lint` executable for everything to work.

I ran `cd backend && golangci-lint run` after the update, as pre-commit is configured to do, and it found no issue. So I guess it worked, but I wonder if there is something else to do.

> [!NOTE]
> It seems like uninstalling and re-running our previously documented `go install` command does not manage to get this new version. I checked the official docs and the method is actually [not recommended](https://golangci-lint.run/welcome/install/#install-from-sources) anyway.
>
> There are basically two alternatives : downloading the released executable with a *bash script* and going through a *package manager*. I like the package manager option better because we can then just ask it to upgrade the package if we want to switch to a later version.
>
> As we use `brew` for some other dependencies, I went for it and it worked. The [official docs](https://golangci-lint.run/welcome/install/#homebrew) recommend using the official formula, but they mention we have a tap available in case we really need an up-to-date version, so we're not in `apt` land where we risk being stuck with an older version.

