### PR TITLE
feat(db): metering grid areas (FLEX-487)

### DIFF
--- a/db/flex/metering_grid_area.sql
+++ b/db/flex/metering_grid_area.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS metering_grid_area (
+    id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    business_id text UNIQUE NOT NULL CHECK (
+        validate_business_id(business_id, 'eic_x')
+    ),
+    name text NOT NULL CHECK ((char_length(name) <= 128)),
+    price_area text NOT NULL CHECK (
+        price_area IN ('NO1', 'NO2', 'NO3', 'NO4', 'NO5')
+    ),
+    system_operator_id bigint NOT NULL,
+    system_operator_party_type text GENERATED ALWAYS AS (
+        'system_operator'
+    ) STORED,
+    valid_time_range tstzrange CHECK (
+        valid_time_range IS null OR (
+            lower(valid_time_range) IS NOT null
+            AND lower_inc(valid_time_range)
+            AND NOT upper_inc(valid_time_range)
+        )
+    ),
+    record_time_range tstzrange NOT NULL DEFAULT tstzrange(
+        localtimestamp, null, '[)'
+    ),
+    recorded_by bigint NOT NULL DEFAULT current_identity(),
+
+    CONSTRAINT metering_grid_area_system_operator_fkey
+    FOREIGN KEY (
+        system_operator_id, system_operator_party_type
+    ) REFERENCES party (id, type),
+    CONSTRAINT metering_grid_area_valid_time_overlap
+    EXCLUDE USING gist (
+        business_id WITH =, valid_time_range WITH &&
+    ) WHERE (valid_time_range IS NOT null)
+);

--- a/db/flex/metering_grid_area_history_audit.sql
+++ b/db/flex/metering_grid_area_history_audit.sql
@@ -1,0 +1,44 @@
+--liquibase formatted sql
+-- GENERATED CODE -- DO NOT EDIT
+
+-- changeset flex:metering-grid-area-history-table-create endDelimiter:--
+CREATE TABLE IF NOT EXISTS
+flex.metering_grid_area_history (
+    history_id bigint PRIMARY KEY NOT NULL
+    DEFAULT nextval(
+        pg_get_serial_sequence(
+            'flex.metering_grid_area',
+            'id'
+        )
+    ),
+    LIKE flex.metering_grid_area,
+    replaced_by bigint NOT NULL
+);
+
+-- changeset flex:metering-grid-area-history-id-index endDelimiter:--
+CREATE INDEX IF NOT EXISTS
+metering_grid_area_history_id_idx
+ON flex.metering_grid_area_history (id);
+
+-- changeset flex:metering-grid-area-history-rls endDelimiter:--
+ALTER TABLE IF EXISTS
+flex.metering_grid_area_history
+ENABLE ROW LEVEL SECURITY;
+
+-- changeset flex:metering-grid-area-audit-current endDelimiter:--
+CREATE OR REPLACE TRIGGER
+metering_grid_area_audit_current
+BEFORE INSERT OR UPDATE
+ON flex.metering_grid_area
+FOR EACH ROW EXECUTE PROCEDURE audit.current(
+    'flex.current_identity'
+);
+
+-- changeset flex:metering-grid-area-audit-history endDelimiter:--
+CREATE OR REPLACE TRIGGER
+metering_grid_area_audit_history
+AFTER UPDATE OR DELETE
+ON flex.metering_grid_area
+FOR EACH ROW EXECUTE PROCEDURE audit.history(
+    'flex.current_identity'
+);

--- a/db/flex/metering_grid_area_rls.sql
+++ b/db/flex/metering_grid_area_rls.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS metering_grid_area
+ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT ON metering_grid_area
+TO flex_common;

--- a/db/flex_base.sql
+++ b/db/flex_base.sql
@@ -14,6 +14,8 @@ GRANT USAGE ON SCHEMA timeline TO flex_anonymous;
 GRANT USAGE ON SCHEMA gs1 TO flex_anonymous;
 
 
+\i pg_eic/pg_eic.sql
+GRANT USAGE ON SCHEMA eic TO flex_anonymous;
 
 --
 ---- Business Identifier Type
@@ -38,8 +40,13 @@ BEGIN
     END IF;
 
     IF business_id_type = 'eic_x' THEN
-        -- TODO: include an EIC check character validation function
-        RETURN (business_id ~ '^[0-9]{2}X[0-9A-Z-]{12}[0-9A-Z]$');
+        IF business_id !~ '^[0-9]{2}X[0-9A-Z-]{12}[0-9A-Z]$' THEN
+            RETURN false;
+        END IF;
+
+        RETURN (
+            eic.validate_check_char(business_id)
+        );
     ELSIF business_id_type = 'uuid' THEN
         RETURN (
             business_id ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[47][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'

--- a/db/flex_structure.sql
+++ b/db/flex_structure.sql
@@ -21,6 +21,7 @@ and support the processes in the value chain.$$;
 \i flex/accounting_point_energy_supplier.sql
 \i flex/controllable_unit.sql
 \i flex/controllable_unit_service_provider.sql
+\i flex/metering_grid_area.sql
 \i flex/notification.sql
 \i flex/product_type.sql
 \i flex/service_provider_product_application.sql
@@ -43,6 +44,7 @@ and support the processes in the value chain.$$;
 \i flex/controllable_unit_history_audit.sql
 \i flex/controllable_unit_service_provider_history_audit.sql
 \i flex/entity_client_history_audit.sql
+\i flex/metering_grid_area_history_audit.sql
 \i flex/notification_history_audit.sql
 \i flex/party_history_audit.sql
 \i flex/party_membership_history_audit.sql
@@ -73,6 +75,7 @@ and support the processes in the value chain.$$;
 \i flex/entity_client_rls.sql
 \i flex/event_rls.sql
 \i flex/identity_rls.sql
+\i flex/metering_grid_area_rls.sql
 \i flex/notification_rls.sql
 \i flex/party_membership_rls.sql
 \i flex/party_rls.sql

--- a/db/pg_eic/README.md
+++ b/db/pg_eic/README.md
@@ -1,0 +1,11 @@
+# eic
+
+This extension equips PostgreSQL with functions to validate EIC identification
+codes. The implementation is based on [this document](https://eepublicdownloads.entsoe.eu/clean-documents/EDI/Library/cim_based/EIC_Data_Exchange_IG_v1.2.pdf).
+
+We use these features to handle MGA identifiers in the Flexibility Information
+System.
+
+## Test
+
+Testing is done with [pgTap](https://pgtap.org/documentation.html).

--- a/db/pg_eic/pg_eic.sql
+++ b/db/pg_eic/pg_eic.sql
@@ -1,0 +1,76 @@
+CREATE SCHEMA IF NOT EXISTS eic;
+
+-- convert a character to its EIC numeric value
+CREATE OR REPLACE FUNCTION eic.char_to_code(c text)
+RETURNS integer AS $$
+BEGIN
+    IF c ~ '^[0-9]$' THEN
+        RETURN c::integer;
+    ELSIF c ~ '^[A-Z]$' THEN
+        RETURN ascii(c) - ascii('A') + 10;
+    ELSIF c = '-' THEN
+        RETURN 36;
+    ELSE
+        RAISE EXCEPTION 'EIC char to code: invalid character %', c;
+    END IF;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- convert an EIC numeric value to a character
+CREATE OR REPLACE FUNCTION eic.code_to_char(code integer)
+RETURNS text AS $$
+BEGIN
+    IF code BETWEEN 0 AND 9 THEN
+        RETURN code::text;
+    ELSIF code BETWEEN 10 AND 35 THEN
+        RETURN chr(code + ascii('A') - 10);
+    ELSIF code = 36 THEN
+        RETURN '-';
+    ELSE
+        RAISE EXCEPTION 'EIC code to char: invalid code %', code;
+    END IF;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- compute the check character of an EIC prefix
+CREATE OR REPLACE FUNCTION eic.compute_check_char(partial_eic text)
+RETURNS text AS $$
+DECLARE
+    sum        integer := 0;
+    weight     integer := 16;
+BEGIN
+    IF char_length(partial_eic) != 15 THEN
+        RAISE EXCEPTION 'EIC compute check digit: invalid prefix length';
+    END IF;
+
+    FOR i IN 1..15 LOOP
+        sum :=
+            sum +
+            weight * eic.char_to_code(substring(partial_eic FROM i FOR 1));
+        weight := weight - 1;
+    END LOOP;
+
+    RETURN eic.code_to_char(36 - ((sum - 1) % 37));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- compute and add the check character to an EIC prefix to form a full EIC
+-- identifier
+CREATE OR REPLACE FUNCTION eic.add_check_char(partial_eic text)
+RETURNS text AS $$
+BEGIN
+    RETURN partial_eic || eic.compute_check_char(partial_eic);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- validate an EIC identifier
+CREATE OR REPLACE FUNCTION eic.validate_check_char(eic text)
+RETURNS boolean
+SECURITY DEFINER
+AS $$
+DECLARE
+    partial_eic text := left(eic, -1);
+BEGIN
+    RETURN (right(eic, 1) = eic.compute_check_char(partial_eic));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/db/pg_eic/test/00_setup.sql
+++ b/db/pg_eic/test/00_setup.sql
@@ -1,0 +1,17 @@
+set client_min_messages to warning;
+set search_path to gs1, public;
+create extension if not exists pgtap;
+
+-- lets verify that pgtap works
+begin;
+select plan(1);
+
+select ok(
+    now() = now(), -- noqa: ST10
+    'now() = now() should return true'
+);
+select finish();
+rollback;
+
+-- load our functions
+\i /db/pg_eic/pg_eic.sql

--- a/db/pg_eic/test/05_code_char.sql
+++ b/db/pg_eic/test/05_code_char.sql
@@ -1,0 +1,27 @@
+SET client_min_messages TO notice;
+SET search_path TO eic, public;
+
+BEGIN;
+SELECT plan(16);
+
+SELECT is(code_to_char(0), '0');
+SELECT is(code_to_char(7), '7');
+SELECT is(code_to_char(9), '9');
+SELECT is(code_to_char(10), 'A');
+SELECT is(code_to_char(17), 'H');
+SELECT is(code_to_char(21), 'L');
+SELECT is(code_to_char(35), 'Z');
+SELECT is(code_to_char(36), '-');
+
+SELECT is(char_to_code('0'), 0);
+SELECT is(char_to_code('4'), 4);
+SELECT is(char_to_code('9'), 9);
+SELECT is(char_to_code('A'), 10);
+SELECT is(char_to_code('E'), 14);
+SELECT is(char_to_code('Q'), 26);
+SELECT is(char_to_code('Z'), 35);
+SELECT is(char_to_code('-'), 36);
+
+SELECT finish();
+
+ROLLBACK;

--- a/db/pg_eic/test/10_compute_validate_check_char.sql
+++ b/db/pg_eic/test/10_compute_validate_check_char.sql
@@ -1,0 +1,28 @@
+SET client_min_messages TO notice;
+SET search_path TO eic, public;
+
+BEGIN;
+SELECT plan(17);
+
+SELECT is(compute_check_char('12X1-2-3-4-5-6-'), 'U');
+SELECT is(compute_check_char('13X1-2-3-4-5-6-'), 'F');
+SELECT is(compute_check_char('27X1-2-3-4-5-6-'), 'D');
+SELECT is(compute_check_char('27X9-8-7-654321'), 'D');
+SELECT is(compute_check_char('31XABCDEFGHIJK0'), '4');
+SELECT is(compute_check_char('31XLMNOPQRSTUVW'), '8');
+SELECT is(compute_check_char('31XXXX---YY---Z'), 'Y');
+
+SELECT ok(validate_check_char('12X1-2-3-4-5-6-U'));
+SELECT ok(NOT validate_check_char('12X1-2-3-4-5-6-Z'));
+SELECT ok(validate_check_char('13X1-2-3-4-5-6-F'));
+SELECT ok(NOT validate_check_char('13X1-2-3-4-5-6-2'));
+SELECT ok(validate_check_char('27X1-2-3-4-5-6-D'));
+SELECT ok(validate_check_char('27X9-8-7-654321D'));
+SELECT ok(validate_check_char('31XABCDEFGHIJK04'));
+SELECT ok(validate_check_char('31XLMNOPQRSTUVW8'));
+SELECT ok(NOT validate_check_char('31XLMNOPQRSTUVW5'));
+SELECT ok(validate_check_char('31XXXX---YY---ZY'));
+
+SELECT finish();
+
+ROLLBACK;

--- a/db/test_data/test_data.sql
+++ b/db/test_data/test_data.sql
@@ -43,6 +43,38 @@ BEGIN
 
   INSERT INTO flex.party_membership (entity_id, party_id) VALUES (member_entity_id, party_id);
 
+  -- if SO, associate a few metering grid areas
+  IF party_type = 'system_operator' THEN
+    INSERT INTO flex.metering_grid_area (
+      business_id,
+      name,
+      price_area,
+      system_operator_id,
+      valid_time_range,
+      recorded_by
+    ) VALUES (
+      eic.add_check_char('31X-' || upper(replace(rpad(left(party_name, 10), 10), ' ', '-')) || '-'),
+      party_name || ' AREA 1',
+      'NO4',
+      party_id,
+      tstzrange(
+        '2023-10-01 Europe/Oslo',
+        null, '[)'
+      ),
+      0
+    ), (
+      eic.add_check_char('42X-' || upper(replace(rpad(left(party_name, 10), 10), ' ', '-')) || '-'),
+      party_name || ' AREA 2',
+      'NO4',
+      party_id,
+      tstzrange(
+        '2023-10-01 Europe/Oslo',
+        null, '[)'
+      ),
+      0
+    );
+  END IF;
+
   RETURN party_id;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER VOLATILE;

--- a/local/scripts/internal_resources_to_db.py
+++ b/local/scripts/internal_resources_to_db.py
@@ -14,6 +14,7 @@ if __name__ == "__main__":
             "accounting_point_balance_responsible_party",
             "accounting_point_end_user",
             "accounting_point_energy_supplier",
+            "metering_grid_area",
         ]
     ]
 


### PR DESCRIPTION
This PR adds metering grid areas as an internal resource. It comes with some EIC code validation and generation functionality for test data.

From what I understood, a MGA is created by a SO to divide their concession area into several areas in case of bottlenecks. Therefore I added SO as a field there so we can track who created the MGA. It aligns with the examples on the eSett website.

I did not add status because we already have valid time and I thought this was redundant.

No RLS, no grants, no UI, etc. For now it is only an internal resource.