### PR TITLE
feat(db): associate BRPs to metering grid areas (FLEX-486)

### DIFF
--- a/db/flex/balance_responsible_party_metering_grid_area.sql
+++ b/db/flex/balance_responsible_party_metering_grid_area.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS balance_responsible_party_metering_grid_area (
+    id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    balance_responsible_party_id bigint NOT NULL,
+    balance_responsible_party_type text GENERATED ALWAYS AS (
+        'balance_responsible_party'
+    ) STORED,
+    metering_grid_area_id text NOT NULL CHECK (
+        validate_business_id(metering_grid_area_id, 'eic_x')
+    ),
+
+    UNIQUE (balance_responsible_party_id, metering_grid_area_id),
+
+    CONSTRAINT brp_mga_balance_responsible_party_fkey
+    FOREIGN KEY (
+        balance_responsible_party_id, balance_responsible_party_type
+    ) REFERENCES party (id, type),
+    CONSTRAINT brp_mga_metering_grid_area_fkey
+    FOREIGN KEY (metering_grid_area_id)
+    REFERENCES metering_grid_area (business_id)
+);

--- a/db/flex/balance_responsible_party_metering_grid_area_rls.sql
+++ b/db/flex/balance_responsible_party_metering_grid_area_rls.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS balance_responsible_party_metering_grid_area
+ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT ON balance_responsible_party_metering_grid_area
+TO flex_common;

--- a/db/flex_structure.sql
+++ b/db/flex_structure.sql
@@ -16,6 +16,7 @@ and support the processes in the value chain.$$;
 \i flex/grid_node.sql
 \i flex/grid_edge.sql
 \i flex/metering_grid_area.sql
+\i flex/balance_responsible_party_metering_grid_area.sql
 \i flex/accounting_point.sql
 \i flex/accounting_point_balance_responsible_party.sql
 \i flex/accounting_point_end_user.sql
@@ -69,6 +70,7 @@ and support the processes in the value chain.$$;
 \i flex/accounting_point_balance_responsible_party_rls.sql
 \i flex/accounting_point_end_user_rls.sql
 \i flex/accounting_point_energy_supplier_rls.sql
+\i flex/balance_responsible_party_metering_grid_area_rls.sql
 \i flex/controllable_unit_rls.sql
 \i flex/controllable_unit_service_provider_rls.sql
 \i flex/entity_rls.sql

--- a/db/test_data/test_data.sql
+++ b/db/test_data/test_data.sql
@@ -594,6 +594,15 @@ BEGIN
     0
   );
 
+  -- add BRP to one of the MGAs
+  INSERT INTO flex.balance_responsible_party_metering_grid_area (
+    balance_responsible_party_id,
+    metering_grid_area_id
+  ) VALUES (
+    brp_id,
+    so_mga_id
+  );
+
   if not in_add_data then
     PERFORM test_data.add_accounting_points(
       accounting_point_prefix,


### PR DESCRIPTION
This PR adds the link corresponding to the [eSett data linked in the ticket](https://opendata.esett.com/rbr).

For now, no valid time, no history : as simple as possible...

After discussion, "retailer" sounded like an eSett-specific name and quite unclear in our context. For now I am keeping the naming trivial from the content of the table. Can be renamed later.