### PR TITLE
feat(backend): notify SP on implicit CUSP termination (FLEX-531)

### DIFF
--- a/backend/event/models.sql
+++ b/backend/event/models.sql
@@ -116,6 +116,12 @@ AND apeu.valid_time_range && tstzrange(cusp.valid_from, cusp.valid_to, '[)');
 -- valid time check : notifying all end users that (up to the latest knowledge)
 --   are in charge of the AP during at least a part of the CU-SP validity period
 
+-- name: GetControllableUnitServiceProviderImplicitTerminationNotificationRecipients :many
+SELECT service_provider_id::bigint
+FROM controllable_unit_service_provider
+WHERE id = @resource_id;
+-- not using history on CU-SP because SP ID is stable
+
 -- name: GetServiceProviderProductApplicationNotificationRecipients :many
 SELECT unnest(array[system_operator_id, service_provider_id])::bigint
 FROM service_provider_product_application_history

--- a/backend/event/models/models.custom.go
+++ b/backend/event/models/models.custom.go
@@ -27,6 +27,10 @@ func (q *Queries) GetNotificationRecipients( //nolint:cyclop
 		return q.GetControllableUnitServiceProviderUpdateDeleteNotificationRecipients(
 			ctx, resourceID, recordedAt,
 		)
+	case "no.elhub.flex.controllable_unit_service_provider.implicit_termination":
+		return q.GetControllableUnitServiceProviderImplicitTerminationNotificationRecipients(
+			ctx, resourceID,
+		)
 	case "no.elhub.flex.system_operator_product_type.create":
 		return q.GetSystemOperatorProductTypeCreateNotificationRecipients(ctx, resourceID, recordedAt)
 	case "no.elhub.flex.system_operator_product_type.update",

--- a/db/flex/accounting_point_end_user.sql
+++ b/db/flex/accounting_point_end_user.sql
@@ -34,3 +34,56 @@ CREATE OR REPLACE TRIGGER accounting_point_end_user_timeline_midnight_aligned
 AFTER INSERT OR UPDATE ON accounting_point_end_user
 FOR EACH ROW
 EXECUTE FUNCTION timeline.midnight_aligned();
+
+CREATE OR REPLACE FUNCTION
+accounting_point_end_user_update_check_for_implicit_cusp_revocation()
+RETURNS trigger
+SECURITY DEFINER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    l_event_data jsonb :=
+        jsonb_build_object(
+            'termination_date',
+                timeline.timestamptz_to_text(upper(NEW.valid_time_range))
+        );
+    l_cusp_id bigint;
+BEGIN
+    FOR l_cusp_id IN (
+        -- infinite CUSPs behind the AP where the end user was terminated
+        SELECT cusp.id AS cusp_id
+        FROM flex.controllable_unit_service_provider AS cusp
+            INNER JOIN flex.controllable_unit AS cu
+                ON cusp.controllable_unit_id = cu.id
+            INNER JOIN flex.accounting_point AS ap
+                ON cu.accounting_point_id = ap.business_id
+        WHERE ap.id = OLD.accounting_point_id
+        AND upper(cusp.valid_time_range) IS null
+    )
+    LOOP
+        INSERT INTO flex.event (
+            type,
+            source,
+            data
+        ) VALUES (
+            text2ltree('no.elhub.flex.controllable_unit_service_provider.implicit_termination'),
+            '/controllable_unit_service_provider/' || l_cusp_id,
+            l_event_data
+        );
+    END LOOP;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER
+accounting_point_end_user_update_check_for_implicit_cusp_revocation
+AFTER UPDATE ON accounting_point_end_user
+FOR EACH ROW
+WHEN (
+    -- end user relation is terminated
+    upper(old.valid_time_range) IS null
+    AND upper(new.valid_time_range) IS NOT null
+)
+EXECUTE FUNCTION
+accounting_point_end_user_update_check_for_implicit_cusp_revocation();


### PR DESCRIPTION
This PR adds a notification for SP on implicit CUSP termination caused by end user termination.

I narrowed down the scope to the specific case of _termination_ : an _infinite_ CUSP (open-ended valid time), initially allowed by an infinite end user contract, gets implicitly terminated because an end was set to the valid time of the end user contract.

Indeed, there is a range of other cases of inconsistency that can be brought by an update to the end user timeline (basically any situation where the new timeline does not cover the whole CUSP contract), but these are not necessarily _terminations_ (_e.g._, start valid time moves forward in time so the beginning of the CUSP is no longer covered -- it is not a termination), and they could be associated to the lighter _notice_ instead of _notification_ ?

Not automatically tested, because accounting point end user is not available on the API. We do not yet have an easy way to test system updates to internal data. Tested manually by editing AP-EU and checking the right notification got generated.