### PR TITLE
chore: pin PostgREST version before v13 (FLEX-583)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       -c log_min_messages=debug1
       -c wal_level=logical
   postgrest:
-    image: postgrest/postgrest:latest
+    image: postgrest/postgrest:v12.2.12
     expose:
       - "3000"
     ports:


### PR DESCRIPTION
Since the latest major change introduced breaking changes for us, we first need to pin the version to the previous one so the system continues to work.