### PR TITLE
fix: tokens must use HS256 alg for PostgREST v13 (FLEX-583)

### DIFF
--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -461,7 +461,7 @@ func (auth *API) GetCallbackHandler(ctx *gin.Context) { //nolint:funlen,cyclop
 		Role:           "flex_entity",
 	}
 
-	signedAccessToken, err := accessToken.Sign(jws.WithKey(jwa.HS384(), auth.jwtSecret))
+	signedAccessToken, err := accessToken.Sign(jws.WithKey(jwa.HS256(), auth.jwtSecret))
 	if err != nil {
 		ctx.AbortWithStatusJSON(http.StatusInternalServerError, newErrorMessage(http.StatusInternalServerError, "could not sign access token", err))
 		return
@@ -568,7 +568,7 @@ func (auth *API) PostAssumeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	entityToken := new(accessToken)
-	err = verifyTokenString(accessTokenCookie.Value, entityToken, jws.WithKey(jwa.HS384(), auth.jwtSecret))
+	err = verifyTokenString(accessTokenCookie.Value, entityToken, jws.WithKey(jwa.HS256(), auth.jwtSecret))
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		body, _ := json.Marshal(oauthErrorMessage{
@@ -587,7 +587,7 @@ func (auth *API) PostAssumeHandler(w http.ResponseWriter, r *http.Request) {
 		ExternalID:     eid,
 	}
 
-	signedPartyToken, err := partyToken.Sign(jws.WithKey(jwa.HS384(), auth.jwtSecret))
+	signedPartyToken, err := partyToken.Sign(jws.WithKey(jwa.HS256(), auth.jwtSecret))
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		body, _ := json.Marshal(oauthErrorMessage{
@@ -668,7 +668,7 @@ func (auth *API) DeleteAssumeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	recievedToken := new(accessToken)
-	err = verifyTokenString(accessTokenCookie.Value, recievedToken, jws.WithKey(jwa.HS384(), auth.jwtSecret))
+	err = verifyTokenString(accessTokenCookie.Value, recievedToken, jws.WithKey(jwa.HS256(), auth.jwtSecret))
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		body, _ := json.Marshal(oauthErrorMessage{
@@ -731,7 +731,7 @@ func (auth *API) DeleteAssumeHandler(w http.ResponseWriter, r *http.Request) {
 		ExternalID:     externalID,
 	}
 
-	signedEntityToken, err := entityToken.Sign(jws.WithKey(jwa.HS384(), auth.jwtSecret))
+	signedEntityToken, err := entityToken.Sign(jws.WithKey(jwa.HS256(), auth.jwtSecret))
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		body, _ := json.Marshal(oauthErrorMessage{
@@ -829,7 +829,7 @@ func (auth *API) GetUserInfoHandler(ctx *gin.Context) {
 // Returns an error if the token was not verified or validated.
 func (auth *API) decodeTokenString(tokenStr string) (*accessToken, error) {
 	token := new(accessToken)
-	err := verifyTokenString(tokenStr, token, jws.WithKey(jwa.HS384(), auth.jwtSecret))
+	err := verifyTokenString(tokenStr, token, jws.WithKey(jwa.HS256(), auth.jwtSecret))
 	if err != nil {
 		return nil, fmt.Errorf("error in verifying access token: %w", err)
 	}
@@ -905,7 +905,7 @@ func (auth *API) clientCredentialsHandler( //nolint:funlen
 		Role:           "flex_entity",
 	}
 
-	signedAccessToken, err := accessToken.Sign(jws.WithKey(jwa.HS384(), auth.jwtSecret))
+	signedAccessToken, err := accessToken.Sign(jws.WithKey(jwa.HS256(), auth.jwtSecret))
 	if err != nil {
 		ctx.AbortWithStatusJSON(http.StatusInternalServerError, newErrorMessage(
 			http.StatusInternalServerError,
@@ -981,7 +981,7 @@ func (auth *API) tokenExchangeHandler( //nolint:funlen
 	}
 
 	entityToken := new(accessToken)
-	err = verifyTokenString(payload.ActorToken, entityToken, jws.WithKey(jwa.HS384(), auth.jwtSecret))
+	err = verifyTokenString(payload.ActorToken, entityToken, jws.WithKey(jwa.HS256(), auth.jwtSecret))
 	if err != nil {
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, oauthErrorMessage{
 			Error:            oauthErrorInvalidRequest,
@@ -1035,7 +1035,7 @@ func (auth *API) tokenExchangeHandler( //nolint:funlen
 		ExternalID:     eid,
 	}
 
-	signedPartyToken, err := partyToken.Sign(jws.WithKey(jwa.HS384(), auth.jwtSecret))
+	signedPartyToken, err := partyToken.Sign(jws.WithKey(jwa.HS256(), auth.jwtSecret))
 	if err != nil {
 		ctx.AbortWithStatusJSON(http.StatusInternalServerError, newErrorMessage(
 			http.StatusInternalServerError,
@@ -1224,7 +1224,7 @@ func (auth *API) jwtBearerHandler(
 		Role:           "flex_entity",
 	}
 
-	signedAccessToken, err := accessToken.Sign(jws.WithKey(jwa.HS384(), auth.jwtSecret))
+	signedAccessToken, err := accessToken.Sign(jws.WithKey(jwa.HS256(), auth.jwtSecret))
 	if err != nil {
 		ctx.AbortWithStatusJSON(http.StatusInternalServerError, newErrorMessage(
 			http.StatusInternalServerError,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,7 @@ services:
       -c log_min_messages=debug1
       -c wal_level=logical
   postgrest:
-    # TODO: fix issues with v13 to allow using the latest version again
-    image: postgrest/postgrest:v12.2.12
+    image: postgrest/postgrest:latest
     expose:
       - "3000"
     ports:

--- a/test/other_tests/test_jwt_crypto.py
+++ b/test/other_tests/test_jwt_crypto.py
@@ -18,4 +18,4 @@ def test_token_alg():
 
         # We should be using minimum 384 bits on SHA
         alg = unverified_header["alg"].upper()
-        assert alg in ["HS384", "HS512"]
+        assert alg in ["HS256"]


### PR DESCRIPTION
So it turns out that PostgREST prior to v13 had _undocumented_ support for HS384. v13 swithches underlying jwt handling lib and lost that support.

Docs are very clear (and have always been).

https://docs.postgrest.org/en/v13/references/auth.html

>  jwt-secret. If it is set to a simple string value like “reallyreallyreallyreallyverysafe” then PostgREST interprets it as an HMAC-SHA256 passphrase.

So we then just go with HS256 which is actually good enough for us.

Got to read some haskell so this was a fun bughunt 🚀