### PR TITLE
fix(db): create replication "if not exists" (FLEX-602)

### DIFF
--- a/db/flex/replication/slots.sql
+++ b/db/flex/replication/slots.sql
@@ -2,4 +2,8 @@
 -- Manually managed file
 
 -- changeset flex:api-create-event-logical-replication-slot endDelimiter:-- runAlways:true
-SELECT pg_create_logical_replication_slot('event_slot', 'wal2json');
+SELECT pg_create_logical_replication_slot('event_slot', 'wal2json')
+WHERE NOT EXISTS (
+        SELECT 1 FROM pg_replication_slots
+        WHERE slot_name = 'event_slot'
+    );


### PR DESCRIPTION
Allows keeping the `runAlways` and running `just reload` without getting an error.