### PR TITLE
fix(db): override checksum for DB table definition (FLEX-588)

### DIFF
--- a/db/flex/controllable_unit.sql
+++ b/db/flex/controllable_unit.sql
@@ -2,6 +2,7 @@
 -- Manually managed file
 
 -- changeset flex:controllable-unit-create runOnChange:false endDelimiter:--
+--validCheckSum: 9:054c5c4905551cea0bb2299fd88b8fdf
 CREATE TABLE IF NOT EXISTS controllable_unit (
     id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     business_id uuid UNIQUE NOT NULL DEFAULT (public.uuid_generate_v4()) CHECK (


### PR DESCRIPTION
This PR overrides the checksum for the CU table definition, so that Liquibase ignores the change (the definition is there only for documentation anyway, because only the migration is run).

I moved before the migration and ran Liquibase with both the migration and the update in the table definition, in order to get the error message that gives us the checksum we need to use.