### PR TITLE
feat(db): add read-only role in local database (FLEX-606)

### DIFF
--- a/db/flex/changelog.yml
+++ b/db/flex/changelog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
       author: flex
       runAlways: true
       changes:
-        - sql: GRANT USAGE ON SCHEMA flex TO flex_anonymous, flex_internal, flex_inspect
+        - sql: GRANT USAGE ON SCHEMA flex TO flex_anonymous, flex_internal, flex_operation_readonly
   # Dropping policies to provide a clean slate on every migration
   - changeSet:
       id: drop-policies
@@ -194,8 +194,8 @@ databaseChangeLog:
       relativeToChangelogFile: true
 
   - changeSet:
-      id: flex-inspect-grant
+      id: flex-operation-readonly-grant
       author: flex
       runAlways: true
       changes:
-        - sql: GRANT SELECT ON ALL TABLES IN SCHEMA flex TO flex_inspect
+        - sql: GRANT SELECT ON ALL TABLES IN SCHEMA flex TO flex_operation_readonly

--- a/db/flex/changelog.yml
+++ b/db/flex/changelog.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
       author: flex
       runAlways: true
       changes:
-        - sql: GRANT USAGE ON SCHEMA flex TO flex_anonymous, flex_internal
+        - sql: GRANT USAGE ON SCHEMA flex TO flex_anonymous, flex_internal, flex_inspect
   # Dropping policies to provide a clean slate on every migration
   - changeSet:
       id: drop-policies
@@ -192,3 +192,10 @@ databaseChangeLog:
   - include:
       file: ./replication/slots.sql
       relativeToChangelogFile: true
+
+  - changeSet:
+      id: flex-inspect-grant
+      author: flex
+      runAlways: true
+      changes:
+        - sql: GRANT SELECT ON ALL TABLES IN SCHEMA flex TO flex_inspect

--- a/local/postgres/init.sql
+++ b/local/postgres/init.sql
@@ -42,9 +42,9 @@ WITH REPLICATION NOINHERIT LOGIN PASSWORD 'replication_password';
 -- without having to add them all-over-the-place.
 CREATE ROLE flex_internal WITH NOINHERIT NOLOGIN;
 
--- flex_inspect is used for read-only access to the production database, for
--- debug purposes, without risk of interfering with the production data.
-CREATE ROLE flex_inspect WITH NOINHERIT NOLOGIN BYPASSRLS;
+-- flex_operation_readonly is used for read-only access to the production
+-- database, for debug purposes, without risk of interfering with the data.
+CREATE ROLE flex_operation_readonly WITH NOINHERIT NOLOGIN BYPASSRLS;
 
 CREATE ROLE flex_internal_event_notification WITH NOLOGIN;
 GRANT flex_internal TO flex_internal_event_notification;

--- a/local/postgres/init.sql
+++ b/local/postgres/init.sql
@@ -42,6 +42,10 @@ WITH REPLICATION NOINHERIT LOGIN PASSWORD 'replication_password';
 -- without having to add them all-over-the-place.
 CREATE ROLE flex_internal WITH NOINHERIT NOLOGIN;
 
+-- flex_inspect is used for read-only access to the production database, for
+-- debug purposes, without risk of interfering with the production data.
+CREATE ROLE flex_inspect WITH NOINHERIT NOLOGIN BYPASSRLS;
+
 CREATE ROLE flex_internal_event_notification WITH NOLOGIN;
 GRANT flex_internal TO flex_internal_event_notification;
 


### PR DESCRIPTION
This PR adds a `flex_operation_readonly` role that can _only read_ the `flex` schema.