### PR TITLE
fix(test): restore test idempotency for system operator (FLEX-616)

### DIFF
--- a/test/api_client_tests/test_cu.py
+++ b/test/api_client_tests/test_cu.py
@@ -146,11 +146,17 @@ def test_controllable_unit_so(sts):
     client_iso = sts.get_client(TestEntity.COMMON, "SO")
 
     # RLS: CU-SO001
-    # all test CUs are on APs within one MGA belonging to Test SO, so this
-    # SO should see all CUs
+    # all test CUs on APs > 1000 are within one MGA belonging to Test SO,
+    # so the test SO should see them all
+    n_cus_so = len([cu for cu in all_cus if cast(int, cu.accounting_point_id) > 1000])
+
     cus = list_controllable_unit.sync(client=client_so)
     assert isinstance(cus, list)
-    assert len(cus) == len(all_cus)
+
+    # greater or equal here, because it is possible that the SO can read more
+    # CUs due to SPG grid prequalification targeting them, opening visibility of
+    # what is in the SPG
+    assert len(cus) >= n_cus_so
 
     # check SO can update the last validation of a CU
     cu = cus[0]

--- a/test/api_client_tests/test_cusp.py
+++ b/test/api_client_tests/test_cusp.py
@@ -309,13 +309,20 @@ def test_cusp_so(data):
 
     # SO can read the CUs where they are CSO
     # Test SO manages all CUs in the test data so all CUSPs should be visible
+    # (excepted the ones created during the test runs on APs < 1000)
     cusps = list_controllable_unit_service_provider.sync(client=client_fiso)
     assert isinstance(cusps, list)
     for cusp in cusps:
         cu = read_controllable_unit.sync(
-            client=client_so, id=cast(int, cusp.controllable_unit_id)
+            client=client_fiso, id=cast(int, cusp.controllable_unit_id)
         )
         assert isinstance(cu, ControllableUnitResponse)
+
+        if cu.accounting_point_id > 1000:
+            cusp = read_controllable_unit_service_provider.sync(
+                client=client_so, id=cast(int, cusp.id)
+            )
+            assert isinstance(cusp, ControllableUnitServiceProviderResponse)
 
 
 # RLS: CUSP-FISO002


### PR DESCRIPTION
Running tests several times was failing because of wrong assumptions.

Explained in [FLEX-616](https://elhub.atlassian.net/browse/FLEX-616) and commented a bit more precisely in the test files.

[FLEX-616]: https://elhub.atlassian.net/browse/FLEX-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ