### PR TITLE
fix(db): no generated field in CUSP history (FLEX-622)

### DIFF
--- a/db/flex/controllable_unit_service_provider_migrations.sql
+++ b/db/flex/controllable_unit_service_provider_migrations.sql
@@ -21,6 +21,8 @@ ADD COLUMN end_user_party_type text GENERATED ALWAYS AS ('end_user') STORED;
 ALTER TABLE flex.controllable_unit_service_provider_history
 ADD COLUMN end_user_id bigint;
 
+-- NB: this should not have been GENERATED because the trigger inserting in
+--     history copies all the fields, see next changeset
 ALTER TABLE flex.controllable_unit_service_provider_history
 ADD COLUMN end_user_party_type text GENERATED ALWAYS AS ('end_user') STORED;
 
@@ -62,3 +64,9 @@ FOREIGN KEY (
 
 ALTER TABLE flex.controllable_unit_service_provider
 ENABLE TRIGGER USER;
+
+-- changeset flex:cusp-correct-end-user-party-type runOnChange:false endDelimiter:;
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:'ALWAYS' SELECT is_generated FROM information_schema.columns WHERE table_schema = 'flex' AND table_name = 'controllable_unit_service_provider_history' AND column_name = 'end_user_party_type';
+ALTER TABLE flex.controllable_unit_service_provider_history
+ALTER COLUMN end_user_party_type DROP EXPRESSION;


### PR DESCRIPTION
This PR fixes the next part of the CUSP delete bug.

The previous migration set a field as generated, but fields in the history table should not have any of these mechanisms, because all fields just get copied from the main table. The trigger inserting in history on CUSP delete is therefore failing on prod ATM.

I tested the additional SQL line and the precondition on a dummy table with a generated field, but it is harder to test than the previous migrations we have written because the state in which we want to test this does not exist on local. Indeed, locally, the reset defines the table with the extra field and the history is created with `LIKE`, without constraints. So locally the problem cannot show.