### PR TITLE
fix: migration on history happens after history is defined (FLEX-622)

### DIFF
--- a/db/flex/changelog.yml
+++ b/db/flex/changelog.yml
@@ -99,9 +99,6 @@ databaseChangeLog:
       file: ./controllable_unit_service_provider.sql
       relativeToChangelogFile: true
   - include:
-      file: ./controllable_unit_service_provider_migrations.sql
-      relativeToChangelogFile: true
-  - include:
       file: ./notification.sql
       relativeToChangelogFile: true
   - include:
@@ -169,6 +166,11 @@ databaseChangeLog:
       path: ./grants/
       relativeToChangelogFile: true
       endsWithFilter: .sql
+
+
+  - include:
+      file: ./controllable_unit_service_provider_migrations.sql
+      relativeToChangelogFile: true
 
   # Reference Data
   - changeSet:


### PR DESCRIPTION
The precondition on the new migration cannot be computed if the history table is not defined.

As this won't ever run locally because of the precondition, I forgot to run `just reset` before pushing the last PR. I hope I did not forget something else and this is the last one before trying to deploy.