### PR TITLE
fix: correct migration checksum after comment edit (FLEX-622)

### DIFF
--- a/db/flex/controllable_unit_service_provider_migrations.sql
+++ b/db/flex/controllable_unit_service_provider_migrations.sql
@@ -2,10 +2,9 @@
 -- Manually managed file
 
 -- changeset flex:cusp-add-end-user runOnChange:false endDelimiter:;
+--validCheckSum: 9:9ef9e5e878fc6955632e944e5692d295
 --preconditions onFail:MARK_RAN
 --precondition-sql-check expectedResult:0 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = 'flex' AND table_name = 'controllable_unit_service_provider' AND column_name = 'end_user_id'
-
--- SELECT set_config('flex.current_identity', '0', false);
 
 -- disable triggers to prevent the system from adding history/event records
 ALTER TABLE flex.controllable_unit_service_provider


### PR DESCRIPTION
Apparently, comments are counted when computing a checksum for a migration...

NB: this migration has already been run and won't run again thanks to the precondition. It's just to get the comment change accepted by liquibase.