### PR TITLE
feat: better handling of slashless api paths

### DIFF
--- a/local/nginx/templates/flex.conf
+++ b/local/nginx/templates/flex.conf
@@ -4,6 +4,7 @@ server {
     listen       [::]:${NGINX_PORT_PLAIN} default_server;
 
     server_name  ${NGINX_SERVER_NAME};
+    absolute_redirect off;
 
     # We generally don't want to redirect to HTTPS in case clients are including sensitive information like credentials.
     # It is better to return an error message to make the client aware.
@@ -88,20 +89,33 @@ server {
         return 301 https://elhub.github.io/flex-information-system$1$is_args$args;
     }
 
+    # Actually do some proxying
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    # 2.5.4 Ensure the NGINX reverse proxy does not enable information disclosure
+    proxy_hide_header X-Powered-By;
+    proxy_hide_header Server;
+
     # Proper API endpoints handed to backend
-    location ~ ^/(api/v0/|auth/v0/|readyz$) {
-
-        # Actually do some proxying
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-        # 2.5.4 Ensure the NGINX reverse proxy does not enable information disclosure
-        proxy_hide_header X-Powered-By;
-        proxy_hide_header Server;
-
+    location /readyz {
         proxy_pass ${NGINX_UPSTREAM_BACKEND};
-
     }
 
+    location /api/v0/ {
+        proxy_pass ${NGINX_UPSTREAM_BACKEND};
+    }
+
+    location /api/v0 {
+        proxy_pass ${NGINX_UPSTREAM_BACKEND};
+    }
+
+    location /auth/v0/ {
+        proxy_pass ${NGINX_UPSTREAM_BACKEND};
+    }
+
+    location /auth/v0 {
+        proxy_pass ${NGINX_UPSTREAM_BACKEND};
+    }
 }


### PR DESCRIPTION
This PR adds a little bit of explicit handling of the bare api url w/ no trailing slash.

Basically it goes from

* /api/v0 -> 404

to

* /api/v0 -> 301 -> /api/v0/

If the health check does not like the 301 then I'll try to move it to use some other path