### PR TITLE
feat: make notice.data an object, specified in OpenAPI docs (FLEX-634)

### DIFF
--- a/backend/data/models/models.go
+++ b/backend/data/models/models.go
@@ -145,7 +145,7 @@ type Notice struct {
 	PartyID int
 	Type    string
 	Source  string
-	Data    *string
+	Data    []byte
 }
 
 type Notification struct {

--- a/backend/event/models/models.go
+++ b/backend/event/models/models.go
@@ -154,7 +154,7 @@ type Notice struct {
 	PartyID int
 	Type    string
 	Source  string
-	Data    *string
+	Data    []byte
 }
 
 type Notification struct {

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -361,5 +361,5 @@ CREATE TABLE notice (
     party_id bigint NOT NULL,
     type text NOT NULL,
     source text NOT NULL,
-    data text NULL
+    data jsonb NULL
 );

--- a/db/flex/notice.sql
+++ b/db/flex/notice.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE VIEW notice AS (
         ap_so.system_operator_id AS party_id,
         'no.elhub.flex.controllable_unit.grid_node_id.missing' AS type, -- noqa
         '/controllable_unit/' || cu.id AS source,
-        null AS data -- noqa
+        null::jsonb AS data -- noqa
     FROM controllable_unit AS cu
         INNER JOIN accounting_point_system_operator AS ap_so
             ON cu.accounting_point_id = ap_so.accounting_point_id
@@ -21,7 +21,7 @@ CREATE OR REPLACE VIEW notice AS (
         ap_so.system_operator_id AS party_id,
         'no.elhub.flex.controllable_unit.grid_validation_status.pending' AS type, -- noqa
         '/controllable_unit/' || cu.id AS source,
-        null AS data -- noqa
+        null::jsonb AS data -- noqa
     FROM controllable_unit AS cu
         INNER JOIN accounting_point_system_operator AS ap_so
             ON cu.accounting_point_id = ap_so.accounting_point_id
@@ -34,7 +34,7 @@ CREATE OR REPLACE VIEW notice AS (
         cusp.service_provider_id AS party_id,
         'no.elhub.flex.controllable_unit.grid_validation_status.incomplete_information' AS type, -- noqa
         '/controllable_unit/' || cu.id AS source,
-        null AS data -- noqa
+        null::jsonb AS data -- noqa
     FROM controllable_unit AS cu
         INNER JOIN controllable_unit_service_provider AS cusp
             ON cu.id = cusp.controllable_unit_id
@@ -47,7 +47,7 @@ CREATE OR REPLACE VIEW notice AS (
         sppa.system_operator_id AS party_id,
         'no.elhub.flex.service_provider_product_application.status.requested' AS type, -- noqa
         '/service_provider_product_application/' || sppa.id AS source,
-        null AS data -- noqa
+        null::jsonb AS data -- noqa
     FROM service_provider_product_application AS sppa
     WHERE sppa.status = 'requested'
 
@@ -57,7 +57,7 @@ CREATE OR REPLACE VIEW notice AS (
         spg.service_provider_id AS party_id,
         'no.elhub.flex.service_providing_group_membership.valid_time.outside_contract' AS type, -- noqa
         '/service_providing_group_membership/' || spgm.id AS source,
-        null AS data -- noqa
+        null::jsonb AS data -- noqa
     FROM flex.service_providing_group_membership AS spgm -- noqa
         INNER JOIN flex.service_providing_group AS spg
             ON spg.id = spgm.service_providing_group_id
@@ -82,7 +82,7 @@ CREATE OR REPLACE VIEW notice AS (
         spgpa.procuring_system_operator_id AS party_id,
         'no.elhub.flex.service_providing_group_product_application.status.requested' AS type, -- noqa
         '/service_providing_group_product_application/' || spgpa.id AS source, -- noqa
-        null AS data -- noqa
+        null::jsonb AS data -- noqa
     FROM service_providing_group_product_application AS spgpa
     WHERE spgpa.status = 'requested'
 
@@ -92,7 +92,7 @@ CREATE OR REPLACE VIEW notice AS (
         spggp.impacted_system_operator_id AS party_id,
         'no.elhub.flex.service_providing_group_grid_prequalification.status.requested' AS type, -- noqa
         '/service_providing_group_grid_prequalification/' || spggp.id AS source, -- noqa
-        null AS data -- noqa
+        null::jsonb AS data -- noqa
     FROM service_providing_group_grid_prequalification AS spggp
     WHERE spggp.status = 'requested'
 
@@ -104,7 +104,7 @@ CREATE OR REPLACE VIEW notice AS (
         sp_id AS party_id,
         'no.elhub.flex.service_providing_group.balance_responsible_party.multiple' AS type, -- noqa
         '/service_providing_group/' || spg_id AS source,
-        null AS data -- noqa
+        null::jsonb AS data -- noqa
     FROM (
         SELECT
             spg.id AS spg_id,
@@ -133,7 +133,7 @@ CREATE OR REPLACE VIEW notice AS (
         jsonb_build_object(
             'invalid_timeline',
             valid_time_range - end_user_timeline
-        )::text AS data -- noqa
+        ) AS data -- noqa
     FROM (
         SELECT
             cusp.id,
@@ -165,7 +165,7 @@ CREATE OR REPLACE VIEW notice AS (
             'entity_id', e_stg.id,
             'name', p_stg.name,
             'type', p_stg.type
-        )::text AS data -- noqa
+        ) AS data -- noqa
     FROM flex.party_staging AS p_stg -- noqa
         LEFT JOIN flex.entity AS e_stg
             ON e_stg.business_id = p_stg.org
@@ -193,7 +193,7 @@ CREATE OR REPLACE VIEW notice AS (
                     THEN jsonb_build_object('entity_id', e_stg.id)
                 ELSE '{}'::jsonb
             END
-        ))::text AS data -- noqa
+        )) AS data -- noqa
     FROM flex.party AS p -- noqa
         INNER JOIN flex.entity AS e
             ON p.entity_id = e.id
@@ -213,7 +213,7 @@ CREATE OR REPLACE VIEW notice AS (
         p_fiso.id AS party_id,
         'no.elhub.flex.party.residual' AS type, -- noqa
         '/party/' || p.id AS source,
-        null AS data -- noqa
+        null::jsonb AS data -- noqa
     FROM flex.party AS p -- noqa
         -- warn all FISOs
         INNER JOIN flex.party AS p_fiso

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 <!-- markdownlint-disable MD013 -->
 
+## 19.06.2025
+
+* **Added specification for the `data` field for notices.**  
+  The field has turned from a generic `string` into an `object` and has now a
+  documented format in the OpenAPI specification.
+
 ## 03.06.2025
 
 * **Added _Accounting Point Energy Supplier_ resource.**

--- a/docs/resources/notice.md
+++ b/docs/resources/notice.md
@@ -22,6 +22,19 @@ from the responsible party.
 | no.elhub.flex.service_providing_group_membership.valid_time.outside_contract  | Inconsistency: SPG contains expired CU(s)                            | SP                | Validate and update SPG membership                                                                |
 | no.elhub.flex.service_providing_group_product_application.status.requested    | SPG product application status requested                             | PSO               | Initiate SPG product prequalification and update status                                           |
 
+## Data
+
+This resource may contain data to better describe the database inconsistency
+that lead to the creation of the notice, and guide the user in resolving it.
+When such information is present, it is given in the `data` field of the notice,
+and its format depends on the type of notice.
+
+| Type                                     | Attached data                        |
+|------------------------------------------|--------------------------------------|
+| `[resource].valid_time.outside_contract` | Part of the timeline that is invalid |
+| `[resource].missing`                     | Missing record                       |
+| `[resource].outdated`                    | Updated fields                       |
+
 ## Relevant links
 
 * [API Documentation](../api/v0/index.html#/operations/list_notice)
@@ -29,12 +42,12 @@ from the responsible party.
 
 ## Fields
 
-| Name                                                         | Description                                     | Format                                                          | Reference                     |
-|--------------------------------------------------------------|-------------------------------------------------|-----------------------------------------------------------------|-------------------------------|
-| <a name="field-party_id" href="#field-party_id">party_id</a> | Reference to the party targeted by the notice.  | bigint<br/>Read only                                            | [party.id](party.md#field-id) |
-| <a name="field-type" href="#field-type">type</a>             | The type of the notice.                         | text<br/>Pattern: `^no.elhub.flex.`<br/>Read only               |                               |
-| <a name="field-source" href="#field-source">source</a>       | The URI of the resource concerned by the event. | text<br/>Pattern: `^(\/([a-z][a-z_]*\|[0-9]+))+$`<br/>Read only |                               |
-| <a name="field-data" href="#field-data">data</a>             | The data of the notice.                         | text<br/>Read only                                              |                               |
+| Name                                                         | Description                                                       | Format                                                          | Reference                     |
+|--------------------------------------------------------------|-------------------------------------------------------------------|-----------------------------------------------------------------|-------------------------------|
+| <a name="field-party_id" href="#field-party_id">party_id</a> | Reference to the party targeted by the notice.                    | bigint<br/>Read only                                            | [party.id](party.md#field-id) |
+| <a name="field-type" href="#field-type">type</a>             | The type of the notice.                                           | text<br/>Pattern: `^no.elhub.flex.`<br/>Read only               |                               |
+| <a name="field-source" href="#field-source">source</a>       | The URI of the resource concerned by the event.                   | text<br/>Pattern: `^(\/([a-z][a-z_]*\|[0-9]+))+$`<br/>Read only |                               |
+| <a name="field-data" href="#field-data">data</a>             | The data of the notice. The format depends on the type of notice. | <br/>Read only                                                  |                               |
 
 ## Validation Rules
 

--- a/frontend/src/notice/NoticeList.tsx
+++ b/frontend/src/notice/NoticeList.tsx
@@ -29,7 +29,7 @@ const NoticeActionButton = () => {
           component={Link}
           to="/party/create"
           label="Create party"
-          state={JSON.parse(noticeRecord.data)}
+          state={noticeRecord.data}
           startIcon={<PersonAddIcon />}
         />
       );
@@ -39,7 +39,7 @@ const NoticeActionButton = () => {
           component={Link}
           to={`/party/${noticeRecord.source.split("/")[2]}`}
           label="Update party"
-          state={JSON.parse(noticeRecord.data)}
+          state={noticeRecord.data}
           startIcon={<EditIcon />}
         />
       );
@@ -60,9 +60,7 @@ export const NoticeList = () => (
       <TextField source="source" />
       <FunctionField
         source="data"
-        render={(record) =>
-          record.data ? JSON.stringify(JSON.parse(record.data)) : "{}"
-        }
+        render={(record) => (record.data ? JSON.stringify(record.data) : "{}")}
       />
       <NoticeActionButton />
       <NoticeResourceButton />

--- a/frontend/src/tooltip/tooltips.json
+++ b/frontend/src/tooltip/tooltips.json
@@ -167,7 +167,7 @@
         "party_id": "Reference to the party targeted by the notice.",
         "type": "The type of the notice.",
         "source": "The URI of the resource concerned by the event.",
-        "data": "The data of the notice."
+        "data": "The data of the notice. The format depends on the type of notice."
     },
     "error_message": {
         "code": "The error code.",

--- a/local/scripts/openapi_to_db.py
+++ b/local/scripts/openapi_to_db.py
@@ -23,8 +23,12 @@ output_file_backend_schema = "backend/schema.sql"
 
 def sql_type_of_field_attr(attr):
     if attr["type"] == "array":
+        if "format" not in attr["items"]:
+            return "jsonb []"
         return attr["items"]["format"] + " []"
     else:
+        if "format" not in attr:
+            return "jsonb"
         return attr["format"]
 
 

--- a/openapi/openapi-api-no-default.json
+++ b/openapi/openapi-api-no-default.json
@@ -2165,12 +2165,37 @@
                                 "example": "/service_providing_group_membership/4"
                             },
                             "data": {
-                                "description": "The data of the notice.",
-                                "format": "text",
-                                "type": "string",
+                                "description": "The data of the notice. The format depends on the type of notice.",
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "invalid_timeline": {
+                                                "description": "Section of the resource's valid time that is not covered by a required contract.",
+                                                "format": "text",
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "properties": {
+                                            "missing_record": {
+                                                "type": "object",
+                                                "description": "Data of the record missing in the database."
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "properties": {
+                                            "updated_fields": {
+                                                "type": "object",
+                                                "description": "Values of fields that have been updated in a later version of the resource."
+                                            }
+                                        }
+                                    }
+                                ],
                                 "readOnly": true,
-                                "nullable": true,
-                                "example": null
+                                "nullable": true
                             }
                         }
                     }

--- a/openapi/openapi-api.json
+++ b/openapi/openapi-api.json
@@ -2175,12 +2175,37 @@
                                 "example": "/service_providing_group_membership/4"
                             },
                             "data": {
-                                "description": "The data of the notice.",
-                                "format": "text",
-                                "type": "string",
+                                "description": "The data of the notice. The format depends on the type of notice.",
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "invalid_timeline": {
+                                                "description": "Section of the resource's valid time that is not covered by a required contract.",
+                                                "format": "text",
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "properties": {
+                                            "missing_record": {
+                                                "type": "object",
+                                                "description": "Data of the record missing in the database."
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "properties": {
+                                            "updated_fields": {
+                                                "type": "object",
+                                                "description": "Values of fields that have been updated in a later version of the resource."
+                                            }
+                                        }
+                                    }
+                                ],
                                 "readOnly": true,
-                                "nullable": true,
-                                "example": null
+                                "nullable": true
                             }
                         }
                     }

--- a/openapi/resources.yml
+++ b/openapi/resources.yml
@@ -1414,9 +1414,26 @@ resources:
         readOnly: true
         example: '/service_providing_group_membership/4'
       data:
-        description: The data of the notice.
-        format: text
-        type: string
+        description: >-
+          The data of the notice. The format depends on the type of notice.
+        type: object
+        oneOf:
+          - properties:
+              invalid_timeline:
+                description: >-
+                  Section of the resource's valid time that is not covered by a
+                  required contract.
+                format: text
+                type: string
+          - properties:
+              missing_record:
+                type: object
+                description: Data of the record missing in the database.
+          - properties:
+              updated_fields:
+                type: object
+                description: >-
+                  Values of fields that have been updated in a later version of
+                  the resource.
         readOnly: true
         nullable: true
-        example: null

--- a/test/flex/models/__init__.py
+++ b/test/flex/models/__init__.py
@@ -81,6 +81,21 @@ from .list_system_operator_product_type_prefer import ListSystemOperatorProductT
 from .list_technical_resource_history_prefer import ListTechnicalResourceHistoryPrefer
 from .list_technical_resource_prefer import ListTechnicalResourcePrefer
 from .notice_response import NoticeResponse
+from .notice_response_data_type_0 import NoticeResponseDataType0
+from .notice_response_data_type_1 import NoticeResponseDataType1
+from .notice_response_data_type_1_missing_record import NoticeResponseDataType1MissingRecord
+from .notice_response_data_type_2 import NoticeResponseDataType2
+from .notice_response_data_type_2_updated_fields import NoticeResponseDataType2UpdatedFields
+from .notice_response_data_type_3_type_0 import NoticeResponseDataType3Type0
+from .notice_response_data_type_3_type_1 import NoticeResponseDataType3Type1
+from .notice_response_data_type_3_type_1_missing_record import NoticeResponseDataType3Type1MissingRecord
+from .notice_response_data_type_3_type_2 import NoticeResponseDataType3Type2
+from .notice_response_data_type_3_type_2_updated_fields import NoticeResponseDataType3Type2UpdatedFields
+from .notice_response_data_type_4_type_0 import NoticeResponseDataType4Type0
+from .notice_response_data_type_4_type_1 import NoticeResponseDataType4Type1
+from .notice_response_data_type_4_type_1_missing_record import NoticeResponseDataType4Type1MissingRecord
+from .notice_response_data_type_4_type_2 import NoticeResponseDataType4Type2
+from .notice_response_data_type_4_type_2_updated_fields import NoticeResponseDataType4Type2UpdatedFields
 from .notice_update_request import NoticeUpdateRequest
 from .notification_response import NotificationResponse
 from .notification_update_request import NotificationUpdateRequest
@@ -222,6 +237,21 @@ __all__ = (
     "ListTechnicalResourceHistoryPrefer",
     "ListTechnicalResourcePrefer",
     "NoticeResponse",
+    "NoticeResponseDataType0",
+    "NoticeResponseDataType1",
+    "NoticeResponseDataType1MissingRecord",
+    "NoticeResponseDataType2",
+    "NoticeResponseDataType2UpdatedFields",
+    "NoticeResponseDataType3Type0",
+    "NoticeResponseDataType3Type1",
+    "NoticeResponseDataType3Type1MissingRecord",
+    "NoticeResponseDataType3Type2",
+    "NoticeResponseDataType3Type2UpdatedFields",
+    "NoticeResponseDataType4Type0",
+    "NoticeResponseDataType4Type1",
+    "NoticeResponseDataType4Type1MissingRecord",
+    "NoticeResponseDataType4Type2",
+    "NoticeResponseDataType4Type2UpdatedFields",
     "NoticeUpdateRequest",
     "NotificationResponse",
     "NotificationUpdateRequest",

--- a/test/flex/models/notice_response.py
+++ b/test/flex/models/notice_response.py
@@ -1,9 +1,21 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.notice_response_data_type_0 import NoticeResponseDataType0
+    from ..models.notice_response_data_type_1 import NoticeResponseDataType1
+    from ..models.notice_response_data_type_2 import NoticeResponseDataType2
+    from ..models.notice_response_data_type_3_type_0 import NoticeResponseDataType3Type0
+    from ..models.notice_response_data_type_3_type_1 import NoticeResponseDataType3Type1
+    from ..models.notice_response_data_type_3_type_2 import NoticeResponseDataType3Type2
+    from ..models.notice_response_data_type_4_type_0 import NoticeResponseDataType4Type0
+    from ..models.notice_response_data_type_4_type_1 import NoticeResponseDataType4Type1
+    from ..models.notice_response_data_type_4_type_2 import NoticeResponseDataType4Type2
+
 
 T = TypeVar("T", bound="NoticeResponse")
 
@@ -19,27 +31,66 @@ class NoticeResponse:
                 no.elhub.flex.service_providing_group_membership.valid_time.outside_contract.
             source (Union[Unset, str]): The URI of the resource concerned by the event. Example:
                 /service_providing_group_membership/4.
-            data (Union[None, Unset, str]): The data of the notice.
+            data (Union['NoticeResponseDataType0', 'NoticeResponseDataType1', 'NoticeResponseDataType2',
+                'NoticeResponseDataType3Type0', 'NoticeResponseDataType3Type1', 'NoticeResponseDataType3Type2',
+                'NoticeResponseDataType4Type0', 'NoticeResponseDataType4Type1', 'NoticeResponseDataType4Type2', Unset]): The
+                data of the notice. The format depends on the type of notice.
     """
 
     party_id: Union[Unset, int] = UNSET
     type: Union[Unset, str] = UNSET
     source: Union[Unset, str] = UNSET
-    data: Union[None, Unset, str] = UNSET
+    data: Union[
+        "NoticeResponseDataType0",
+        "NoticeResponseDataType1",
+        "NoticeResponseDataType2",
+        "NoticeResponseDataType3Type0",
+        "NoticeResponseDataType3Type1",
+        "NoticeResponseDataType3Type2",
+        "NoticeResponseDataType4Type0",
+        "NoticeResponseDataType4Type1",
+        "NoticeResponseDataType4Type2",
+        Unset,
+    ] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
+        from ..models.notice_response_data_type_0 import NoticeResponseDataType0
+        from ..models.notice_response_data_type_1 import NoticeResponseDataType1
+        from ..models.notice_response_data_type_2 import NoticeResponseDataType2
+        from ..models.notice_response_data_type_3_type_0 import NoticeResponseDataType3Type0
+        from ..models.notice_response_data_type_3_type_1 import NoticeResponseDataType3Type1
+        from ..models.notice_response_data_type_3_type_2 import NoticeResponseDataType3Type2
+        from ..models.notice_response_data_type_4_type_0 import NoticeResponseDataType4Type0
+        from ..models.notice_response_data_type_4_type_1 import NoticeResponseDataType4Type1
+
         party_id = self.party_id
 
         type = self.type
 
         source = self.source
 
-        data: Union[None, Unset, str]
+        data: Union[Dict[str, Any], Unset]
         if isinstance(self.data, Unset):
             data = UNSET
+        elif isinstance(self.data, NoticeResponseDataType0):
+            data = self.data.to_dict()
+        elif isinstance(self.data, NoticeResponseDataType1):
+            data = self.data.to_dict()
+        elif isinstance(self.data, NoticeResponseDataType2):
+            data = self.data.to_dict()
+        elif isinstance(self.data, NoticeResponseDataType3Type0):
+            data = self.data.to_dict()
+        elif isinstance(self.data, NoticeResponseDataType3Type1):
+            data = self.data.to_dict()
+        elif isinstance(self.data, NoticeResponseDataType3Type2):
+            data = self.data.to_dict()
+        elif isinstance(self.data, NoticeResponseDataType4Type0):
+            data = self.data.to_dict()
+        elif isinstance(self.data, NoticeResponseDataType4Type1):
+            data = self.data.to_dict()
         else:
-            data = self.data
+            data = self.data.to_dict()
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -57,6 +108,16 @@ class NoticeResponse:
 
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.notice_response_data_type_0 import NoticeResponseDataType0
+        from ..models.notice_response_data_type_1 import NoticeResponseDataType1
+        from ..models.notice_response_data_type_2 import NoticeResponseDataType2
+        from ..models.notice_response_data_type_3_type_0 import NoticeResponseDataType3Type0
+        from ..models.notice_response_data_type_3_type_1 import NoticeResponseDataType3Type1
+        from ..models.notice_response_data_type_3_type_2 import NoticeResponseDataType3Type2
+        from ..models.notice_response_data_type_4_type_0 import NoticeResponseDataType4Type0
+        from ..models.notice_response_data_type_4_type_1 import NoticeResponseDataType4Type1
+        from ..models.notice_response_data_type_4_type_2 import NoticeResponseDataType4Type2
+
         d = src_dict.copy()
         party_id = d.pop("party_id", UNSET)
 
@@ -64,12 +125,91 @@ class NoticeResponse:
 
         source = d.pop("source", UNSET)
 
-        def _parse_data(data: object) -> Union[None, Unset, str]:
-            if data is None:
-                return data
+        def _parse_data(
+            data: object,
+        ) -> Union[
+            "NoticeResponseDataType0",
+            "NoticeResponseDataType1",
+            "NoticeResponseDataType2",
+            "NoticeResponseDataType3Type0",
+            "NoticeResponseDataType3Type1",
+            "NoticeResponseDataType3Type2",
+            "NoticeResponseDataType4Type0",
+            "NoticeResponseDataType4Type1",
+            "NoticeResponseDataType4Type2",
+            Unset,
+        ]:
             if isinstance(data, Unset):
                 return data
-            return cast(Union[None, Unset, str], data)
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_type_0 = NoticeResponseDataType0.from_dict(data)
+
+                return data_type_0
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_type_1 = NoticeResponseDataType1.from_dict(data)
+
+                return data_type_1
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_type_2 = NoticeResponseDataType2.from_dict(data)
+
+                return data_type_2
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_type_3_type_0 = NoticeResponseDataType3Type0.from_dict(data)
+
+                return data_type_3_type_0
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_type_3_type_1 = NoticeResponseDataType3Type1.from_dict(data)
+
+                return data_type_3_type_1
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_type_3_type_2 = NoticeResponseDataType3Type2.from_dict(data)
+
+                return data_type_3_type_2
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_type_4_type_0 = NoticeResponseDataType4Type0.from_dict(data)
+
+                return data_type_4_type_0
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_type_4_type_1 = NoticeResponseDataType4Type1.from_dict(data)
+
+                return data_type_4_type_1
+            except:  # noqa: E722
+                pass
+            if not isinstance(data, dict):
+                raise TypeError()
+            data_type_4_type_2 = NoticeResponseDataType4Type2.from_dict(data)
+
+            return data_type_4_type_2
 
         data = _parse_data(d.pop("data", UNSET))
 

--- a/test/flex/models/notice_response_data_type_0.py
+++ b/test/flex/models/notice_response_data_type_0.py
@@ -1,0 +1,59 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="NoticeResponseDataType0")
+
+
+@_attrs_define
+class NoticeResponseDataType0:
+    """
+    Attributes:
+        invalid_timeline (Union[Unset, str]): Section of the resource's valid time that is not covered by a required
+            contract.
+    """
+
+    invalid_timeline: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        invalid_timeline = self.invalid_timeline
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if invalid_timeline is not UNSET:
+            field_dict["invalid_timeline"] = invalid_timeline
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        invalid_timeline = d.pop("invalid_timeline", UNSET)
+
+        notice_response_data_type_0 = cls(
+            invalid_timeline=invalid_timeline,
+        )
+
+        notice_response_data_type_0.additional_properties = d
+        return notice_response_data_type_0
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_1.py
+++ b/test/flex/models/notice_response_data_type_1.py
@@ -1,0 +1,71 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.notice_response_data_type_1_missing_record import NoticeResponseDataType1MissingRecord
+
+
+T = TypeVar("T", bound="NoticeResponseDataType1")
+
+
+@_attrs_define
+class NoticeResponseDataType1:
+    """
+    Attributes:
+        missing_record (Union[Unset, NoticeResponseDataType1MissingRecord]): Data of the record missing in the database.
+    """
+
+    missing_record: Union[Unset, "NoticeResponseDataType1MissingRecord"] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        missing_record: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.missing_record, Unset):
+            missing_record = self.missing_record.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if missing_record is not UNSET:
+            field_dict["missing_record"] = missing_record
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.notice_response_data_type_1_missing_record import NoticeResponseDataType1MissingRecord
+
+        d = src_dict.copy()
+        _missing_record = d.pop("missing_record", UNSET)
+        missing_record: Union[Unset, NoticeResponseDataType1MissingRecord]
+        if isinstance(_missing_record, Unset):
+            missing_record = UNSET
+        else:
+            missing_record = NoticeResponseDataType1MissingRecord.from_dict(_missing_record)
+
+        notice_response_data_type_1 = cls(
+            missing_record=missing_record,
+        )
+
+        notice_response_data_type_1.additional_properties = d
+        return notice_response_data_type_1
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_1_missing_record.py
+++ b/test/flex/models/notice_response_data_type_1_missing_record.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="NoticeResponseDataType1MissingRecord")
+
+
+@_attrs_define
+class NoticeResponseDataType1MissingRecord:
+    """Data of the record missing in the database."""
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        notice_response_data_type_1_missing_record = cls()
+
+        notice_response_data_type_1_missing_record.additional_properties = d
+        return notice_response_data_type_1_missing_record
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_2.py
+++ b/test/flex/models/notice_response_data_type_2.py
@@ -1,0 +1,72 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.notice_response_data_type_2_updated_fields import NoticeResponseDataType2UpdatedFields
+
+
+T = TypeVar("T", bound="NoticeResponseDataType2")
+
+
+@_attrs_define
+class NoticeResponseDataType2:
+    """
+    Attributes:
+        updated_fields (Union[Unset, NoticeResponseDataType2UpdatedFields]): Values of fields that have been updated in
+            a later version of the resource.
+    """
+
+    updated_fields: Union[Unset, "NoticeResponseDataType2UpdatedFields"] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        updated_fields: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.updated_fields, Unset):
+            updated_fields = self.updated_fields.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if updated_fields is not UNSET:
+            field_dict["updated_fields"] = updated_fields
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.notice_response_data_type_2_updated_fields import NoticeResponseDataType2UpdatedFields
+
+        d = src_dict.copy()
+        _updated_fields = d.pop("updated_fields", UNSET)
+        updated_fields: Union[Unset, NoticeResponseDataType2UpdatedFields]
+        if isinstance(_updated_fields, Unset):
+            updated_fields = UNSET
+        else:
+            updated_fields = NoticeResponseDataType2UpdatedFields.from_dict(_updated_fields)
+
+        notice_response_data_type_2 = cls(
+            updated_fields=updated_fields,
+        )
+
+        notice_response_data_type_2.additional_properties = d
+        return notice_response_data_type_2
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_2_updated_fields.py
+++ b/test/flex/models/notice_response_data_type_2_updated_fields.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="NoticeResponseDataType2UpdatedFields")
+
+
+@_attrs_define
+class NoticeResponseDataType2UpdatedFields:
+    """Values of fields that have been updated in a later version of the resource."""
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        notice_response_data_type_2_updated_fields = cls()
+
+        notice_response_data_type_2_updated_fields.additional_properties = d
+        return notice_response_data_type_2_updated_fields
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_3_type_0.py
+++ b/test/flex/models/notice_response_data_type_3_type_0.py
@@ -1,0 +1,59 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="NoticeResponseDataType3Type0")
+
+
+@_attrs_define
+class NoticeResponseDataType3Type0:
+    """
+    Attributes:
+        invalid_timeline (Union[Unset, str]): Section of the resource's valid time that is not covered by a required
+            contract.
+    """
+
+    invalid_timeline: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        invalid_timeline = self.invalid_timeline
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if invalid_timeline is not UNSET:
+            field_dict["invalid_timeline"] = invalid_timeline
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        invalid_timeline = d.pop("invalid_timeline", UNSET)
+
+        notice_response_data_type_3_type_0 = cls(
+            invalid_timeline=invalid_timeline,
+        )
+
+        notice_response_data_type_3_type_0.additional_properties = d
+        return notice_response_data_type_3_type_0
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_3_type_1.py
+++ b/test/flex/models/notice_response_data_type_3_type_1.py
@@ -1,0 +1,72 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.notice_response_data_type_3_type_1_missing_record import NoticeResponseDataType3Type1MissingRecord
+
+
+T = TypeVar("T", bound="NoticeResponseDataType3Type1")
+
+
+@_attrs_define
+class NoticeResponseDataType3Type1:
+    """
+    Attributes:
+        missing_record (Union[Unset, NoticeResponseDataType3Type1MissingRecord]): Data of the record missing in the
+            database.
+    """
+
+    missing_record: Union[Unset, "NoticeResponseDataType3Type1MissingRecord"] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        missing_record: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.missing_record, Unset):
+            missing_record = self.missing_record.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if missing_record is not UNSET:
+            field_dict["missing_record"] = missing_record
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.notice_response_data_type_3_type_1_missing_record import NoticeResponseDataType3Type1MissingRecord
+
+        d = src_dict.copy()
+        _missing_record = d.pop("missing_record", UNSET)
+        missing_record: Union[Unset, NoticeResponseDataType3Type1MissingRecord]
+        if isinstance(_missing_record, Unset):
+            missing_record = UNSET
+        else:
+            missing_record = NoticeResponseDataType3Type1MissingRecord.from_dict(_missing_record)
+
+        notice_response_data_type_3_type_1 = cls(
+            missing_record=missing_record,
+        )
+
+        notice_response_data_type_3_type_1.additional_properties = d
+        return notice_response_data_type_3_type_1
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_3_type_1_missing_record.py
+++ b/test/flex/models/notice_response_data_type_3_type_1_missing_record.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="NoticeResponseDataType3Type1MissingRecord")
+
+
+@_attrs_define
+class NoticeResponseDataType3Type1MissingRecord:
+    """Data of the record missing in the database."""
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        notice_response_data_type_3_type_1_missing_record = cls()
+
+        notice_response_data_type_3_type_1_missing_record.additional_properties = d
+        return notice_response_data_type_3_type_1_missing_record
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_3_type_2.py
+++ b/test/flex/models/notice_response_data_type_3_type_2.py
@@ -1,0 +1,72 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.notice_response_data_type_3_type_2_updated_fields import NoticeResponseDataType3Type2UpdatedFields
+
+
+T = TypeVar("T", bound="NoticeResponseDataType3Type2")
+
+
+@_attrs_define
+class NoticeResponseDataType3Type2:
+    """
+    Attributes:
+        updated_fields (Union[Unset, NoticeResponseDataType3Type2UpdatedFields]): Values of fields that have been
+            updated in a later version of the resource.
+    """
+
+    updated_fields: Union[Unset, "NoticeResponseDataType3Type2UpdatedFields"] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        updated_fields: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.updated_fields, Unset):
+            updated_fields = self.updated_fields.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if updated_fields is not UNSET:
+            field_dict["updated_fields"] = updated_fields
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.notice_response_data_type_3_type_2_updated_fields import NoticeResponseDataType3Type2UpdatedFields
+
+        d = src_dict.copy()
+        _updated_fields = d.pop("updated_fields", UNSET)
+        updated_fields: Union[Unset, NoticeResponseDataType3Type2UpdatedFields]
+        if isinstance(_updated_fields, Unset):
+            updated_fields = UNSET
+        else:
+            updated_fields = NoticeResponseDataType3Type2UpdatedFields.from_dict(_updated_fields)
+
+        notice_response_data_type_3_type_2 = cls(
+            updated_fields=updated_fields,
+        )
+
+        notice_response_data_type_3_type_2.additional_properties = d
+        return notice_response_data_type_3_type_2
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_3_type_2_updated_fields.py
+++ b/test/flex/models/notice_response_data_type_3_type_2_updated_fields.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="NoticeResponseDataType3Type2UpdatedFields")
+
+
+@_attrs_define
+class NoticeResponseDataType3Type2UpdatedFields:
+    """Values of fields that have been updated in a later version of the resource."""
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        notice_response_data_type_3_type_2_updated_fields = cls()
+
+        notice_response_data_type_3_type_2_updated_fields.additional_properties = d
+        return notice_response_data_type_3_type_2_updated_fields
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_4_type_0.py
+++ b/test/flex/models/notice_response_data_type_4_type_0.py
@@ -1,0 +1,59 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="NoticeResponseDataType4Type0")
+
+
+@_attrs_define
+class NoticeResponseDataType4Type0:
+    """
+    Attributes:
+        invalid_timeline (Union[Unset, str]): Section of the resource's valid time that is not covered by a required
+            contract.
+    """
+
+    invalid_timeline: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        invalid_timeline = self.invalid_timeline
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if invalid_timeline is not UNSET:
+            field_dict["invalid_timeline"] = invalid_timeline
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        invalid_timeline = d.pop("invalid_timeline", UNSET)
+
+        notice_response_data_type_4_type_0 = cls(
+            invalid_timeline=invalid_timeline,
+        )
+
+        notice_response_data_type_4_type_0.additional_properties = d
+        return notice_response_data_type_4_type_0
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_4_type_1.py
+++ b/test/flex/models/notice_response_data_type_4_type_1.py
@@ -1,0 +1,72 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.notice_response_data_type_4_type_1_missing_record import NoticeResponseDataType4Type1MissingRecord
+
+
+T = TypeVar("T", bound="NoticeResponseDataType4Type1")
+
+
+@_attrs_define
+class NoticeResponseDataType4Type1:
+    """
+    Attributes:
+        missing_record (Union[Unset, NoticeResponseDataType4Type1MissingRecord]): Data of the record missing in the
+            database.
+    """
+
+    missing_record: Union[Unset, "NoticeResponseDataType4Type1MissingRecord"] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        missing_record: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.missing_record, Unset):
+            missing_record = self.missing_record.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if missing_record is not UNSET:
+            field_dict["missing_record"] = missing_record
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.notice_response_data_type_4_type_1_missing_record import NoticeResponseDataType4Type1MissingRecord
+
+        d = src_dict.copy()
+        _missing_record = d.pop("missing_record", UNSET)
+        missing_record: Union[Unset, NoticeResponseDataType4Type1MissingRecord]
+        if isinstance(_missing_record, Unset):
+            missing_record = UNSET
+        else:
+            missing_record = NoticeResponseDataType4Type1MissingRecord.from_dict(_missing_record)
+
+        notice_response_data_type_4_type_1 = cls(
+            missing_record=missing_record,
+        )
+
+        notice_response_data_type_4_type_1.additional_properties = d
+        return notice_response_data_type_4_type_1
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_4_type_1_missing_record.py
+++ b/test/flex/models/notice_response_data_type_4_type_1_missing_record.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="NoticeResponseDataType4Type1MissingRecord")
+
+
+@_attrs_define
+class NoticeResponseDataType4Type1MissingRecord:
+    """Data of the record missing in the database."""
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        notice_response_data_type_4_type_1_missing_record = cls()
+
+        notice_response_data_type_4_type_1_missing_record.additional_properties = d
+        return notice_response_data_type_4_type_1_missing_record
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_4_type_2.py
+++ b/test/flex/models/notice_response_data_type_4_type_2.py
@@ -1,0 +1,72 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.notice_response_data_type_4_type_2_updated_fields import NoticeResponseDataType4Type2UpdatedFields
+
+
+T = TypeVar("T", bound="NoticeResponseDataType4Type2")
+
+
+@_attrs_define
+class NoticeResponseDataType4Type2:
+    """
+    Attributes:
+        updated_fields (Union[Unset, NoticeResponseDataType4Type2UpdatedFields]): Values of fields that have been
+            updated in a later version of the resource.
+    """
+
+    updated_fields: Union[Unset, "NoticeResponseDataType4Type2UpdatedFields"] = UNSET
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        updated_fields: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.updated_fields, Unset):
+            updated_fields = self.updated_fields.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if updated_fields is not UNSET:
+            field_dict["updated_fields"] = updated_fields
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.notice_response_data_type_4_type_2_updated_fields import NoticeResponseDataType4Type2UpdatedFields
+
+        d = src_dict.copy()
+        _updated_fields = d.pop("updated_fields", UNSET)
+        updated_fields: Union[Unset, NoticeResponseDataType4Type2UpdatedFields]
+        if isinstance(_updated_fields, Unset):
+            updated_fields = UNSET
+        else:
+            updated_fields = NoticeResponseDataType4Type2UpdatedFields.from_dict(_updated_fields)
+
+        notice_response_data_type_4_type_2 = cls(
+            updated_fields=updated_fields,
+        )
+
+        notice_response_data_type_4_type_2.additional_properties = d
+        return notice_response_data_type_4_type_2
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/test/flex/models/notice_response_data_type_4_type_2_updated_fields.py
+++ b/test/flex/models/notice_response_data_type_4_type_2_updated_fields.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="NoticeResponseDataType4Type2UpdatedFields")
+
+
+@_attrs_define
+class NoticeResponseDataType4Type2UpdatedFields:
+    """Values of fields that have been updated in a later version of the resource."""
+
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        notice_response_data_type_4_type_2_updated_fields = cls()
+
+        notice_response_data_type_4_type_2_updated_fields.additional_properties = d
+        return notice_response_data_type_4_type_2_updated_fields
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties


### PR DESCRIPTION
This PR turns the `data` field of the notice resource from a string into a specified object with several possible schemas based on the notice type.

For best OpenAPI support and least complexity, we keep the specification quite simple with a simple `oneOf` between the schemas without further dependencies on the `type` field. Some docs are added for the notice resource to compensate and help API users understand what they get.

![Screenshot 2025-06-19 133210](https://github.com/user-attachments/assets/550d0f85-b4ab-4964-ada5-88396c90ee71)

![Screenshot 2025-06-19 133218](https://github.com/user-attachments/assets/2afbcc20-efda-44b1-8eb7-83d7411e8545)

![Screenshot 2025-06-19 133225](https://github.com/user-attachments/assets/7ae54ca0-77fb-490f-95e3-811ebc5affaa)

Updated changelog as this is a "semi-breaking" change (the type change is breaking but in a way we are just making a field _more specified_ here).