### PR TITLE
docs: changelog for notice data (FLEX-488)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,14 @@
 # Changelog
 
+This changelog tracks all changes that are visible in our API.
+
 <!-- markdownlint-disable MD013 -->
+
+## 26.06.2025
+
+* **Specified the `data` field in the _Notice_ resource.**  
+  The field turns into an `object`, whose content depends on the `type` of the
+  notice.
 
 ## 03.06.2025
 


### PR DESCRIPTION
Forgot this in the last PR.

Also made it explicit that the changelog is not listing _all_ changes in the system, but focuses on _breaking changes in the API_ for the users.