### PR TITLE
feat: 4x default query limit (FLEX-664)

### DIFF
--- a/backend/internal/middleware/defaultquerylimit.go
+++ b/backend/internal/middleware/defaultquerylimit.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 )
 
-const defaultLimit = 50
+const defaultLimit = 200
 
 // DefaultQueryLimit adds a default limit query parameter to the request if not
 // provided by the client, so that we never query a whole resource at once.


### PR DESCRIPTION
Our portal is doing requests like

> GET | https://flex-test.elhub.no/api/v0/party?id=in.(405,404,6,16,534,15,535,527,526,519,518,511,510,503,502,495,494,487,486,479,478,471,470,463,462,455,454,447,446,439,438,431,430,423,422,414,413,397,396,389,388,381,380,373,372,365,364,357,356,349,348,341,340,333,332,324,323,316,315,307,306,299,298,291,290,283,282,275,274,266,265,258,257,250,249,242,241,234,233,226,225,218,217,210,209,202,201,194,193,186,185)

~90 parties. The default limit is at 50, so stuff "disappear" in the frontend.