### PR TITLE
fix(ui): column sort on list components with overridden data (FLEX-663)

### DIFF
--- a/frontend/src/controllable_unit/balance_responsible_party/ControllableUnitBalanceResponsiblePartyList.tsx
+++ b/frontend/src/controllable_unit/balance_responsible_party/ControllableUnitBalanceResponsiblePartyList.tsx
@@ -9,13 +9,17 @@ import {
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import { DateField } from "../../components/datetime";
+import { useState } from "react";
 
 export const ControllableUnitBalanceResponsiblePartyList = () => {
   // accounting point id of the controllable unit whose BRPs we want to get
   const { accounting_point_id } = useRecordContext()!;
   const { permissions } = usePermissions();
 
-  const sort: SortPayload = { field: "valid_from", order: "ASC" };
+  const [sort, setSort] = useState<SortPayload>({
+    field: "valid_from",
+    order: "ASC",
+  });
   const filter = { accounting_point_id: accounting_point_id };
 
   return (
@@ -29,7 +33,7 @@ export const ControllableUnitBalanceResponsiblePartyList = () => {
           filter={filter}
           sort={sort}
         >
-          <Datagrid bulkActionButtons={false}>
+          <Datagrid bulkActionButtons={false} sort={sort} setSort={setSort}>
             <ReferenceField
               source="balance_responsible_party_id"
               reference="party"

--- a/frontend/src/controllable_unit/energy_supplier/ControllableUnitEnergySupplierList.tsx
+++ b/frontend/src/controllable_unit/energy_supplier/ControllableUnitEnergySupplierList.tsx
@@ -9,13 +9,17 @@ import {
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import { DateField } from "../../components/datetime";
+import { useState } from "react";
 
 export const ControllableUnitEnergySupplierList = () => {
   // accounting point id of the controllable unit whose ESs we want to get
   const { accounting_point_id } = useRecordContext()!;
   const { permissions } = usePermissions();
 
-  const sort: SortPayload = { field: "valid_from", order: "ASC" };
+  const [sort, setSort] = useState<SortPayload>({
+    field: "valid_from",
+    order: "ASC",
+  });
   const filter = { accounting_point_id: accounting_point_id };
 
   return (
@@ -29,7 +33,7 @@ export const ControllableUnitEnergySupplierList = () => {
           filter={filter}
           sort={sort}
         >
-          <Datagrid bulkActionButtons={false}>
+          <Datagrid bulkActionButtons={false} sort={sort} setSort={setSort}>
             <ReferenceField source="energy_supplier_id" reference="party">
               <TextField source="name" />
             </ReferenceField>

--- a/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderList.tsx
+++ b/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderList.tsx
@@ -15,13 +15,17 @@ import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
+import { useState } from "react";
 
 export const ControllableUnitServiceProviderList = () => {
   // id of the controllable unit whose relations we want to get
   const { id } = useRecordContext()!;
   const { permissions } = usePermissions();
 
-  const sort: SortPayload = { field: "valid_from", order: "DESC" };
+  const [sort, setSort] = useState<SortPayload>({
+    field: "valid_from",
+    order: "DESC",
+  });
   const { data, isLoading } = useGetList("controllable_unit_service_provider", {
     filter: { controllable_unit_id: id, "valid_from@not.is": null },
     sort,
@@ -59,12 +63,14 @@ export const ControllableUnitServiceProviderList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
+          sort={sort}
         >
           <Datagrid
             bulkActionButtons={false}
             data={data}
             isLoading={isLoading}
             sort={sort}
+            setSort={setSort}
             rowClick={(_id, _res, record) =>
               `/controllable_unit/${record.controllable_unit_id}/service_provider/${record.id}/show`
             }

--- a/frontend/src/controllable_unit/technical_resource/TechnicalResourceList.tsx
+++ b/frontend/src/controllable_unit/technical_resource/TechnicalResourceList.tsx
@@ -8,18 +8,22 @@ import {
   useGetList,
   usePermissions,
   useRecordContext,
+  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
+import { useState } from "react";
 
 export const TechnicalResourceList = () => {
   // id of the controllable unit whose technical resources we want to get
   const { id } = useRecordContext()!;
   const { permissions } = usePermissions();
 
+  const [sort, setSort] = useState<SortPayload>({ field: "id", order: "DESC" });
   const { data, isLoading } = useGetList("technical_resource", {
     filter: { controllable_unit_id: id },
+    sort,
   });
 
   // automatically fill the controllable_unit_id field with the ID of the
@@ -49,10 +53,13 @@ export const TechnicalResourceList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
+          sort={sort}
         >
           <Datagrid
             bulkActionButtons={false}
             data={data}
+            sort={sort}
+            setSort={setSort}
             isLoading={isLoading}
             rowClick={(_id, _res, record) =>
               `/controllable_unit/${record.controllable_unit_id}/technical_resource/${record.id}/show`

--- a/frontend/src/entity/client/EntityClientList.tsx
+++ b/frontend/src/entity/client/EntityClientList.tsx
@@ -8,20 +8,24 @@ import {
   useGetList,
   usePermissions,
   useRecordContext,
+  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
 import { IdentityField } from "../../components/IdentityField";
+import { useState } from "react";
 
 export const EntityClientList = () => {
   // id of the entity
   const { id } = useRecordContext()!;
   const { permissions } = usePermissions();
 
+  const [sort, setSort] = useState<SortPayload>({ field: "id", order: "DESC" });
   const { data, isLoading } = useGetList("entity_client", {
     filter: { entity_id: id },
+    sort,
   });
 
   const CreateButton = () => (
@@ -53,6 +57,8 @@ export const EntityClientList = () => {
           <Datagrid
             bulkActionButtons={false}
             data={data}
+            sort={sort}
+            setSort={setSort}
             isLoading={isLoading}
             rowClick={(_id, _res, record) =>
               `/entity/${record.entity_id}/client/${record.id}/show`

--- a/frontend/src/party/membership/PartyMembershipList.tsx
+++ b/frontend/src/party/membership/PartyMembershipList.tsx
@@ -9,20 +9,24 @@ import {
   useGetList,
   usePermissions,
   useRecordContext,
+  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
 import { IdentityField } from "../../components/IdentityField";
+import { useState } from "react";
 
 export const PartyMembershipList = () => {
   // id of the SPG
   const { id } = useRecordContext()!;
   const { permissions } = usePermissions();
 
+  const [sort, setSort] = useState<SortPayload>({ field: "id", order: "DESC" });
   const { data, isLoading } = useGetList("party_membership", {
     filter: { party_id: id },
+    sort,
   });
 
   const CreateButton = () => (
@@ -53,12 +57,14 @@ export const PartyMembershipList = () => {
           <Datagrid
             bulkActionButtons={false}
             data={data}
+            sort={sort}
+            setSort={setSort}
             isLoading={isLoading}
             rowClick={(_id, _res, record) =>
               `/party/${record.party_id}/membership/${record.id}/show`
             }
           >
-            <TextField source="id" />
+            <TextField source="id" label="ID" />
             <ReferenceField source="entity_id" reference="entity">
               <TextField source="name" />
             </ReferenceField>

--- a/frontend/src/service_provider_product_application/comment/ServiceProviderProductApplicationCommentList.tsx
+++ b/frontend/src/service_provider_product_application/comment/ServiceProviderProductApplicationCommentList.tsx
@@ -8,6 +8,7 @@ import {
   useRecordContext,
   RichTextField,
   useGetList,
+  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
@@ -15,6 +16,7 @@ import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
 import { IdentityField } from "../../components/IdentityField";
 import { CircularProgress } from "@mui/material";
+import { useState } from "react";
 
 export const ServiceProviderProductApplicationCommentList = () => {
   // id of the SPPA
@@ -22,9 +24,13 @@ export const ServiceProviderProductApplicationCommentList = () => {
   const id = record?.id;
   const { permissions } = usePermissions();
 
+  const [sort, setSort] = useState<SortPayload>({
+    field: "created_at",
+    order: "ASC",
+  });
   const { data, isLoading } = useGetList(
     "service_provider_product_application_comment",
-    { filter: { service_provider_product_application_id: id } },
+    { filter: { service_provider_product_application_id: id }, sort },
   );
 
   if (isLoading) return <CircularProgress size={25} thickness={2} />;
@@ -62,7 +68,8 @@ export const ServiceProviderProductApplicationCommentList = () => {
           <Datagrid
             bulkActionButtons={false}
             data={data}
-            sort={{ field: "created_at", order: "ASC" }}
+            sort={sort}
+            setSort={setSort}
             rowClick={(_id, _res, record) =>
               `/service_provider_product_application/${record.service_provider_product_application_id}/comment/${record.id}/show`
             }

--- a/frontend/src/service_providing_group/grid_prequalification/ServiceProvidingGroupGridPrequalificationList.tsx
+++ b/frontend/src/service_providing_group/grid_prequalification/ServiceProvidingGroupGridPrequalificationList.tsx
@@ -9,11 +9,13 @@ import {
   useGetList,
   usePermissions,
   useRecordContext,
+  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
+import { useState } from "react";
 
 export const ServiceProvidingGroupGridPrequalificationList = () => {
   // id of the SPG (present only when this page is a subresource of SPG)
@@ -21,9 +23,10 @@ export const ServiceProvidingGroupGridPrequalificationList = () => {
   const id = record?.id;
   const { permissions } = usePermissions();
 
+  const [sort, setSort] = useState<SortPayload>({ field: "id", order: "DESC" });
   const { data, isLoading } = useGetList(
     "service_providing_group_grid_prequalification",
-    { filter: id ? { service_providing_group_id: id } : undefined },
+    { filter: id ? { service_providing_group_id: id } : undefined, sort },
   );
 
   const CreateButton = () => (
@@ -59,16 +62,19 @@ export const ServiceProvidingGroupGridPrequalificationList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
+          sort={sort}
         >
           <Datagrid
             bulkActionButtons={false}
             data={data}
+            sort={sort}
+            setSort={setSort}
             isLoading={isLoading}
             rowClick={(_id, _res, record) =>
               `/service_providing_group/${record.service_providing_group_id}/grid_prequalification/${record.id}/show`
             }
           >
-            <TextField source="id" />
+            <TextField source="id" label="ID" />
             {!record?.id && (
               <ReferenceField
                 source="service_providing_group_id"

--- a/frontend/src/service_providing_group/membership/ServiceProvidingGroupMembershipList.tsx
+++ b/frontend/src/service_providing_group/membership/ServiceProvidingGroupMembershipList.tsx
@@ -15,6 +15,7 @@ import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
+import { useState } from "react";
 
 export const ServiceProvidingGroupMembershipList = () => {
   // id of the SPG
@@ -22,7 +23,10 @@ export const ServiceProvidingGroupMembershipList = () => {
   const id = record?.id;
   const { permissions } = usePermissions();
 
-  const sort: SortPayload = { field: "valid_from", order: "DESC" };
+  const [sort, setSort] = useState<SortPayload>({
+    field: "valid_from",
+    order: "DESC",
+  });
   const { data, isLoading } = useGetList("service_providing_group_membership", {
     filter: id
       ? { service_providing_group_id: id, "valid_from@not.is": null }
@@ -62,17 +66,19 @@ export const ServiceProvidingGroupMembershipList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
+          sort={sort}
         >
           <Datagrid
             bulkActionButtons={false}
             data={data}
             isLoading={isLoading}
             sort={sort}
+            setSort={setSort}
             rowClick={(_id, _res, record) =>
               `/service_providing_group/${record.service_providing_group_id}/membership/${record.id}/show`
             }
           >
-            <TextField source="id" />
+            <TextField source="id" label="ID" />
             {!record?.id && (
               <ReferenceField
                 source="service_providing_group_id"

--- a/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationList.tsx
+++ b/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationList.tsx
@@ -9,10 +9,12 @@ import {
   useGetList,
   usePermissions,
   useRecordContext,
+  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
+import { useState } from "react";
 
 export const ServiceProvidingGroupProductApplicationList = () => {
   // id of the SPG (present only when this page is a subresource of SPG)
@@ -20,9 +22,13 @@ export const ServiceProvidingGroupProductApplicationList = () => {
   const id = record?.id;
   const { permissions } = usePermissions();
 
+  const [sort, setSort] = useState<SortPayload>({ field: "id", order: "DESC" });
   const { data, isLoading } = useGetList(
     "service_providing_group_product_application",
-    { filter: id ? { service_providing_group_id: id } : undefined },
+    {
+      filter: id ? { service_providing_group_id: id } : undefined,
+      sort,
+    },
   );
 
   const CreateButton = () => (
@@ -58,6 +64,7 @@ export const ServiceProvidingGroupProductApplicationList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
+          sort={sort}
         >
           <Datagrid
             bulkActionButtons={false}
@@ -66,6 +73,8 @@ export const ServiceProvidingGroupProductApplicationList = () => {
             rowClick={(_id, _res, record) =>
               `/service_providing_group/${record.service_providing_group_id}/product_application/${record.id}/show`
             }
+            sort={sort}
+            setSort={setSort}
           >
             <TextField source="id" label="ID" />
             {!record?.id && (


### PR DESCRIPTION
Our manual override did not leave the possibility of changing the sort parameter.

The bug was also bigger than expected. Enabling a sort column on a page with several list components was breaking the other lists. Probably because of the sort parameter being collected from some common context if not explicitly specified (which we now do in such pages).