### PR TITLE
fix(ui): fix pagination in lists of subresources (FLEX-663)

### DIFF
--- a/frontend/src/controllable_unit/balance_responsible_party/ControllableUnitBalanceResponsiblePartyList.tsx
+++ b/frontend/src/controllable_unit/balance_responsible_party/ControllableUnitBalanceResponsiblePartyList.tsx
@@ -2,25 +2,17 @@ import {
   List,
   ReferenceField,
   ResourceContextProvider,
-  SortPayload,
   TextField,
   usePermissions,
   useRecordContext,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import { DateField } from "../../components/datetime";
-import { useState } from "react";
 
 export const ControllableUnitBalanceResponsiblePartyList = () => {
   // accounting point id of the controllable unit whose BRPs we want to get
   const { accounting_point_id } = useRecordContext()!;
   const { permissions } = usePermissions();
-
-  const [sort, setSort] = useState<SortPayload>({
-    field: "valid_from",
-    order: "ASC",
-  });
-  const filter = { accounting_point_id: accounting_point_id };
 
   return (
     permissions.includes("accounting_point_balance_responsible_party.read") && (
@@ -30,10 +22,11 @@ export const ControllableUnitBalanceResponsiblePartyList = () => {
           perPage={10}
           exporter={false}
           empty={false}
-          filter={filter}
-          sort={sort}
+          filter={{ accounting_point_id: accounting_point_id }}
+          sort={{ field: "valid_from", order: "ASC" }}
+          disableSyncWithLocation
         >
-          <Datagrid bulkActionButtons={false} sort={sort} setSort={setSort}>
+          <Datagrid bulkActionButtons={false}>
             <ReferenceField
               source="balance_responsible_party_id"
               reference="party"

--- a/frontend/src/controllable_unit/energy_supplier/ControllableUnitEnergySupplierList.tsx
+++ b/frontend/src/controllable_unit/energy_supplier/ControllableUnitEnergySupplierList.tsx
@@ -2,25 +2,17 @@ import {
   List,
   ReferenceField,
   ResourceContextProvider,
-  SortPayload,
   TextField,
   usePermissions,
   useRecordContext,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import { DateField } from "../../components/datetime";
-import { useState } from "react";
 
 export const ControllableUnitEnergySupplierList = () => {
   // accounting point id of the controllable unit whose ESs we want to get
   const { accounting_point_id } = useRecordContext()!;
   const { permissions } = usePermissions();
-
-  const [sort, setSort] = useState<SortPayload>({
-    field: "valid_from",
-    order: "ASC",
-  });
-  const filter = { accounting_point_id: accounting_point_id };
 
   return (
     permissions.includes("accounting_point_energy_supplier.read") && (
@@ -30,10 +22,11 @@ export const ControllableUnitEnergySupplierList = () => {
           perPage={10}
           exporter={false}
           empty={false}
-          filter={filter}
-          sort={sort}
+          filter={{ accounting_point_id: accounting_point_id }}
+          sort={{ field: "valid_from", order: "ASC" }}
+          disableSyncWithLocation
         >
-          <Datagrid bulkActionButtons={false} sort={sort} setSort={setSort}>
+          <Datagrid bulkActionButtons={false}>
             <ReferenceField source="energy_supplier_id" reference="party">
               <TextField source="name" />
             </ReferenceField>

--- a/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderList.tsx
+++ b/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderList.tsx
@@ -4,10 +4,8 @@ import {
   DeleteButton,
   ReferenceField,
   ResourceContextProvider,
-  SortPayload,
   TextField,
   TopToolbar,
-  useGetList,
   usePermissions,
   useRecordContext,
 } from "react-admin";
@@ -15,21 +13,11 @@ import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
-import { useState } from "react";
 
 export const ControllableUnitServiceProviderList = () => {
   // id of the controllable unit whose relations we want to get
   const { id } = useRecordContext()!;
   const { permissions } = usePermissions();
-
-  const [sort, setSort] = useState<SortPayload>({
-    field: "valid_from",
-    order: "DESC",
-  });
-  const { data, isLoading } = useGetList("controllable_unit_service_provider", {
-    filter: { controllable_unit_id: id, "valid_from@not.is": null },
-    sort,
-  });
 
   // automatically fill the controllable_unit_id field with the ID of the
   // show page the create button is displayed on
@@ -63,14 +51,12 @@ export const ControllableUnitServiceProviderList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
-          sort={sort}
+          filter={{ controllable_unit_id: id, "valid_from@not.is": null }}
+          sort={{ field: "valid_from", order: "DESC" }}
+          disableSyncWithLocation
         >
           <Datagrid
             bulkActionButtons={false}
-            data={data}
-            isLoading={isLoading}
-            sort={sort}
-            setSort={setSort}
             rowClick={(_id, _res, record) =>
               `/controllable_unit/${record.controllable_unit_id}/service_provider/${record.id}/show`
             }

--- a/frontend/src/controllable_unit/technical_resource/TechnicalResourceList.tsx
+++ b/frontend/src/controllable_unit/technical_resource/TechnicalResourceList.tsx
@@ -5,26 +5,17 @@ import {
   ResourceContextProvider,
   TextField,
   TopToolbar,
-  useGetList,
   usePermissions,
   useRecordContext,
-  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
-import { useState } from "react";
 
 export const TechnicalResourceList = () => {
   // id of the controllable unit whose technical resources we want to get
   const { id } = useRecordContext()!;
   const { permissions } = usePermissions();
-
-  const [sort, setSort] = useState<SortPayload>({ field: "id", order: "DESC" });
-  const { data, isLoading } = useGetList("technical_resource", {
-    filter: { controllable_unit_id: id },
-    sort,
-  });
 
   // automatically fill the controllable_unit_id field with the ID of the
   // show page the create button is displayed on
@@ -53,14 +44,12 @@ export const TechnicalResourceList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
-          sort={sort}
+          filter={{ controllable_unit_id: id }}
+          sort={{ field: "id", order: "DESC" }}
+          disableSyncWithLocation
         >
           <Datagrid
             bulkActionButtons={false}
-            data={data}
-            sort={sort}
-            setSort={setSort}
-            isLoading={isLoading}
             rowClick={(_id, _res, record) =>
               `/controllable_unit/${record.controllable_unit_id}/technical_resource/${record.id}/show`
             }

--- a/frontend/src/entity/client/EntityClientList.tsx
+++ b/frontend/src/entity/client/EntityClientList.tsx
@@ -5,28 +5,19 @@ import {
   ResourceContextProvider,
   TextField,
   TopToolbar,
-  useGetList,
   usePermissions,
   useRecordContext,
-  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
 import { IdentityField } from "../../components/IdentityField";
-import { useState } from "react";
 
 export const EntityClientList = () => {
   // id of the entity
   const { id } = useRecordContext()!;
   const { permissions } = usePermissions();
-
-  const [sort, setSort] = useState<SortPayload>({ field: "id", order: "DESC" });
-  const { data, isLoading } = useGetList("entity_client", {
-    filter: { entity_id: id },
-    sort,
-  });
 
   const CreateButton = () => (
     <Button
@@ -53,13 +44,11 @@ export const EntityClientList = () => {
           exporter={false}
           empty={false}
           title={false}
+          filter={{ entity_id: id }}
+          sort={{ field: "id", order: "DESC" }}
         >
           <Datagrid
             bulkActionButtons={false}
-            data={data}
-            sort={sort}
-            setSort={setSort}
-            isLoading={isLoading}
             rowClick={(_id, _res, record) =>
               `/entity/${record.entity_id}/client/${record.id}/show`
             }

--- a/frontend/src/party/membership/PartyMembershipList.tsx
+++ b/frontend/src/party/membership/PartyMembershipList.tsx
@@ -6,28 +6,19 @@ import {
   ResourceContextProvider,
   TextField,
   TopToolbar,
-  useGetList,
   usePermissions,
   useRecordContext,
-  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
 import { IdentityField } from "../../components/IdentityField";
-import { useState } from "react";
 
 export const PartyMembershipList = () => {
   // id of the SPG
   const { id } = useRecordContext()!;
   const { permissions } = usePermissions();
-
-  const [sort, setSort] = useState<SortPayload>({ field: "id", order: "DESC" });
-  const { data, isLoading } = useGetList("party_membership", {
-    filter: { party_id: id },
-    sort,
-  });
 
   const CreateButton = () => (
     <Button
@@ -53,13 +44,11 @@ export const PartyMembershipList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
+          filter={{ party_id: id }}
+          sort={{ field: "id", order: "DESC" }}
         >
           <Datagrid
             bulkActionButtons={false}
-            data={data}
-            sort={sort}
-            setSort={setSort}
-            isLoading={isLoading}
             rowClick={(_id, _res, record) =>
               `/party/${record.party_id}/membership/${record.id}/show`
             }

--- a/frontend/src/service_provider_product_application/comment/ServiceProviderProductApplicationCommentList.tsx
+++ b/frontend/src/service_provider_product_application/comment/ServiceProviderProductApplicationCommentList.tsx
@@ -7,33 +7,18 @@ import {
   usePermissions,
   useRecordContext,
   RichTextField,
-  useGetList,
-  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
 import { IdentityField } from "../../components/IdentityField";
-import { CircularProgress } from "@mui/material";
-import { useState } from "react";
 
 export const ServiceProviderProductApplicationCommentList = () => {
   // id of the SPPA
   const record = useRecordContext();
   const id = record?.id;
   const { permissions } = usePermissions();
-
-  const [sort, setSort] = useState<SortPayload>({
-    field: "created_at",
-    order: "ASC",
-  });
-  const { data, isLoading } = useGetList(
-    "service_provider_product_application_comment",
-    { filter: { service_provider_product_application_id: id }, sort },
-  );
-
-  if (isLoading) return <CircularProgress size={25} thickness={2} />;
 
   const CreateButton = () => (
     <Button
@@ -64,12 +49,11 @@ export const ServiceProviderProductApplicationCommentList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
+          filter={{ service_provider_product_application_id: id }}
+          sort={{ field: "created_at", order: "ASC" }}
         >
           <Datagrid
             bulkActionButtons={false}
-            data={data}
-            sort={sort}
-            setSort={setSort}
             rowClick={(_id, _res, record) =>
               `/service_provider_product_application/${record.service_provider_product_application_id}/comment/${record.id}/show`
             }

--- a/frontend/src/service_providing_group/grid_prequalification/ServiceProvidingGroupGridPrequalificationList.tsx
+++ b/frontend/src/service_providing_group/grid_prequalification/ServiceProvidingGroupGridPrequalificationList.tsx
@@ -6,28 +6,19 @@ import {
   ResourceContextProvider,
   TextField,
   TopToolbar,
-  useGetList,
   usePermissions,
   useRecordContext,
-  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
-import { useState } from "react";
 
 export const ServiceProvidingGroupGridPrequalificationList = () => {
   // id of the SPG (present only when this page is a subresource of SPG)
   const record = useRecordContext()!;
   const id = record?.id;
   const { permissions } = usePermissions();
-
-  const [sort, setSort] = useState<SortPayload>({ field: "id", order: "DESC" });
-  const { data, isLoading } = useGetList(
-    "service_providing_group_grid_prequalification",
-    { filter: id ? { service_providing_group_id: id } : undefined, sort },
-  );
 
   const CreateButton = () => (
     <Button
@@ -62,14 +53,12 @@ export const ServiceProvidingGroupGridPrequalificationList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
-          sort={sort}
+          filter={id ? { service_providing_group_id: id } : undefined}
+          sort={{ field: "id", order: "DESC" }}
+          disableSyncWithLocation
         >
           <Datagrid
             bulkActionButtons={false}
-            data={data}
-            sort={sort}
-            setSort={setSort}
-            isLoading={isLoading}
             rowClick={(_id, _res, record) =>
               `/service_providing_group/${record.service_providing_group_id}/grid_prequalification/${record.id}/show`
             }

--- a/frontend/src/service_providing_group/membership/ServiceProvidingGroupMembershipList.tsx
+++ b/frontend/src/service_providing_group/membership/ServiceProvidingGroupMembershipList.tsx
@@ -4,10 +4,8 @@ import {
   DeleteButton,
   ReferenceField,
   ResourceContextProvider,
-  SortPayload,
   TextField,
   TopToolbar,
-  useGetList,
   usePermissions,
   useRecordContext,
 } from "react-admin";
@@ -15,24 +13,12 @@ import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
-import { useState } from "react";
 
 export const ServiceProvidingGroupMembershipList = () => {
   // id of the SPG
   const record = useRecordContext();
   const id = record?.id;
   const { permissions } = usePermissions();
-
-  const [sort, setSort] = useState<SortPayload>({
-    field: "valid_from",
-    order: "DESC",
-  });
-  const { data, isLoading } = useGetList("service_providing_group_membership", {
-    filter: id
-      ? { service_providing_group_id: id, "valid_from@not.is": null }
-      : { "valid_from@not.is": null },
-    sort,
-  });
 
   const CreateButton = () => {
     let createUrl = "/service_providing_group_membership/create";
@@ -66,14 +52,16 @@ export const ServiceProvidingGroupMembershipList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
-          sort={sort}
+          filter={
+            id
+              ? { service_providing_group_id: id, "valid_from@not.is": null }
+              : { "valid_from@not.is": null }
+          }
+          sort={{ field: "valid_from", order: "DESC" }}
+          disableSyncWithLocation
         >
           <Datagrid
             bulkActionButtons={false}
-            data={data}
-            isLoading={isLoading}
-            sort={sort}
-            setSort={setSort}
             rowClick={(_id, _res, record) =>
               `/service_providing_group/${record.service_providing_group_id}/membership/${record.id}/show`
             }

--- a/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationList.tsx
+++ b/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationList.tsx
@@ -6,30 +6,18 @@ import {
   ResourceContextProvider,
   TextField,
   TopToolbar,
-  useGetList,
   usePermissions,
   useRecordContext,
-  SortPayload,
 } from "react-admin";
 import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
-import { useState } from "react";
 
 export const ServiceProvidingGroupProductApplicationList = () => {
   // id of the SPG (present only when this page is a subresource of SPG)
   const record = useRecordContext();
   const id = record?.id;
   const { permissions } = usePermissions();
-
-  const [sort, setSort] = useState<SortPayload>({ field: "id", order: "DESC" });
-  const { data, isLoading } = useGetList(
-    "service_providing_group_product_application",
-    {
-      filter: id ? { service_providing_group_id: id } : undefined,
-      sort,
-    },
-  );
 
   const CreateButton = () => (
     <Button
@@ -64,17 +52,19 @@ export const ServiceProvidingGroupProductApplicationList = () => {
           actions={<ListActions />}
           exporter={false}
           empty={false}
-          sort={sort}
+          filter={id ? { service_providing_group_id: id } : undefined}
+          sort={{ field: "id", order: "DESC" }}
+          // disable read/writes to/from the URL by this component
+          // (necessary on pages with several List components,
+          // i.e., in our case, subresources)
+          // see https://github.com/marmelab/react-admin/pull/5741
+          disableSyncWithLocation
         >
           <Datagrid
             bulkActionButtons={false}
-            data={data}
-            isLoading={isLoading}
             rowClick={(_id, _res, record) =>
               `/service_providing_group/${record.service_providing_group_id}/product_application/${record.id}/show`
             }
-            sort={sort}
-            setSort={setSort}
           >
             <TextField source="id" label="ID" />
             {!record?.id && (


### PR DESCRIPTION
This PR fixes pagination on all list pages used as subresources, and removes our manual calls to `useGetList` when we can go through the built-in call in the `List` component.

Basically, fixing pagination keeping the manual calls to `useGetList` would have forced us to override pagination in all pages with such a manual call. In the end, you just reimplement the whole list controller on top of the existing one. This felt wrong.

Such manual calls were initially a way to introduce filtering (unnecessary though, we could just have gone with the `filter` prop in `List`), and they became crucial to fix the sorting in the [previous PR](https://github.com/elhub/flex-information-system/pull/243), because they allowed avoiding a weird behaviour of React-Admin on pages with several lists:  _[quoted from the PR]_

> Enabling a sort column on a page with several list components was breaking the other lists. Probably because of the sort parameter being collected from some common context if not explicitly specified (which we now do in such pages).

This buggy behaviour actually comes from the fact that `List` components, by default, get some of their data from the page URL, and also sync with this URL, meaning if you change some parameters, they end up in the URL of the current page. If you have several lists on a single page, it means the filter/sort/whatever parameters synced with the URL just mess up with the other lists.

The bug is described [there](https://github.com/marmelab/react-admin/issues/2903#issuecomment-465526008) and was fixed [there](https://github.com/marmelab/react-admin/pull/5741) by introducing a special prop to disable this synchronisation. It is a kind of workaround, and it means in such cases you can't pre-set filters and sorting by tweaking the URL, but I think one prefers their pages to work correctly even if it means losing this little feature.

The current PR introduces this `disableSyncWithLocation` prop in the lists used as subresources. Then, because the custom calls to `useGetList` are no longer needed, we just remove them.