### PR TITLE
feat(ui): disable sortering on reference fields (FLEX-663)

### DIFF
--- a/frontend/src/AssumePartyPage.tsx
+++ b/frontend/src/AssumePartyPage.tsx
@@ -133,10 +133,20 @@ export const AssumePartyPage = () => {
           <Datagrid bulkActionButtons={false}>
             <TextField label="ID" source="party_id" />
             <AssumePartyButton field="party_id" />
-            <ReferenceField label="Name" source="party_id" reference="party">
+            <ReferenceField
+              label="Name"
+              source="party_id"
+              reference="party"
+              sortable={false}
+            >
               <TextField source="name" />
             </ReferenceField>
-            <ReferenceField label="Type" source="party_id" reference="party">
+            <ReferenceField
+              label="Type"
+              source="party_id"
+              reference="party"
+              sortable={false}
+            >
               <TextField source="type" />
             </ReferenceField>
           </Datagrid>

--- a/frontend/src/controllable_unit/balance_responsible_party/ControllableUnitBalanceResponsiblePartyList.tsx
+++ b/frontend/src/controllable_unit/balance_responsible_party/ControllableUnitBalanceResponsiblePartyList.tsx
@@ -30,6 +30,7 @@ export const ControllableUnitBalanceResponsiblePartyList = () => {
             <ReferenceField
               source="balance_responsible_party_id"
               reference="party"
+              sortable={false}
             >
               <TextField source="name" />
             </ReferenceField>

--- a/frontend/src/controllable_unit/energy_supplier/ControllableUnitEnergySupplierList.tsx
+++ b/frontend/src/controllable_unit/energy_supplier/ControllableUnitEnergySupplierList.tsx
@@ -27,7 +27,11 @@ export const ControllableUnitEnergySupplierList = () => {
           disableSyncWithLocation
         >
           <Datagrid bulkActionButtons={false}>
-            <ReferenceField source="energy_supplier_id" reference="party">
+            <ReferenceField
+              source="energy_supplier_id"
+              reference="party"
+              sortable={false}
+            >
               <TextField source="name" />
             </ReferenceField>
             <DateField source="valid_from" showTime />

--- a/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderHistoryList.tsx
+++ b/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderHistoryList.tsx
@@ -46,7 +46,11 @@ export const ControllableUnitServiceProviderHistoryList = () => {
       >
         <TextField source="id" label="ID" />
         <TextField source="controllable_unit_service_provider_id" />
-        <ReferenceField source="service_provider_id" reference="party">
+        <ReferenceField
+          source="service_provider_id"
+          reference="party"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
         <TextField source="contract_reference" />

--- a/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderList.tsx
+++ b/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderList.tsx
@@ -62,7 +62,11 @@ export const ControllableUnitServiceProviderList = () => {
             }
           >
             <TextField source="id" label="ID" />
-            <ReferenceField source="service_provider_id" reference="party">
+            <ReferenceField
+              source="service_provider_id"
+              reference="party"
+              sortable={false}
+            >
               <TextField source="name" />
             </ReferenceField>
             <TextField source="contract_reference" />

--- a/frontend/src/controllable_unit/technical_resource/TechnicalResourceHistoryList.tsx
+++ b/frontend/src/controllable_unit/technical_resource/TechnicalResourceHistoryList.tsx
@@ -53,6 +53,7 @@ export const TechnicalResourceHistoryList = () => {
         <ReferenceField
           source="controllable_unit_id"
           reference="controllable_unit"
+          sortable={false}
         >
           <TextField source="name" />
         </ReferenceField>

--- a/frontend/src/notice/NoticeList.tsx
+++ b/frontend/src/notice/NoticeList.tsx
@@ -15,7 +15,7 @@ export const NoticeList = () => (
   // cf https://github.com/marmelab/react-admin/blob/27dccfb8519de551ef7e236355860aacef36ef56/packages/ra-core/src/controller/list/useListController.ts#L451-L454
   <List perPage={25} sort={{ field: "type", order: "ASC" }} empty={false}>
     <Datagrid expand={NoticeShow} expandSingle={true}>
-      <ReferenceField source="party_id" reference="party">
+      <ReferenceField source="party_id" reference="party" sortable={false}>
         <TextField source="name" />
       </ReferenceField>
       <TextField source="type" />

--- a/frontend/src/notification/NotificationList.tsx
+++ b/frontend/src/notification/NotificationList.tsx
@@ -43,20 +43,31 @@ export const NotificationList = () => {
         <TextField source="id" label="ID" />
         <BooleanField source="acknowledged" />
         <TextField source="event_id" label="Event ID" />
-        <ReferenceField source="event_id" reference="event" label="Event type">
+        <ReferenceField
+          source="event_id"
+          reference="event"
+          label="Event type"
+          sortable={false}
+        >
           <TextField source="type" />
         </ReferenceField>
         <ReferenceField
           source="event_id"
           reference="event"
           label="Event source"
+          sortable={false}
         >
           <TextField source="source" />
         </ReferenceField>
-        <ReferenceField source="event_id" reference="event" label="Event time">
+        <ReferenceField
+          source="event_id"
+          reference="event"
+          label="Event time"
+          sortable={false}
+        >
           <DateField source="time" showTime />
         </ReferenceField>
-        <ReferenceField source="party_id" reference="party">
+        <ReferenceField source="party_id" reference="party" sortable={false}>
           <TextField source="name" />
         </ReferenceField>
         <DateField source="recorded_at" showTime />

--- a/frontend/src/party/PartyHistoryList.tsx
+++ b/frontend/src/party/PartyHistoryList.tsx
@@ -18,7 +18,7 @@ export const PartyHistoryList = () => {
         <TextField source="id" label="ID" />
         <TextField source="party_id" />
         <TextField source="business_id" label="Business ID" />
-        <ReferenceField source="entity_id" reference="entity">
+        <ReferenceField source="entity_id" reference="entity" sortable={false}>
           <TextField source="name" />
         </ReferenceField>
         <TextField source="name" />

--- a/frontend/src/party/PartyList.tsx
+++ b/frontend/src/party/PartyList.tsx
@@ -60,7 +60,7 @@ export const PartyList = () => {
       <Datagrid>
         <TextField source="id" label="ID" />
         <TextField source="business_id" label="Business ID" />
-        <ReferenceField source="entity_id" reference="entity">
+        <ReferenceField source="entity_id" reference="entity" sortable={false}>
           <TextField source="name" />
         </ReferenceField>
         <TextField source="name" />

--- a/frontend/src/party/membership/PartyMembershipHistoryList.tsx
+++ b/frontend/src/party/membership/PartyMembershipHistoryList.tsx
@@ -35,10 +35,20 @@ export const PartyMembershipHistoryList = () => {
       >
         <TextField source="id" label="ID" />
         <TextField source="party_membership_id" />
-        <ReferenceField source="entity_id" reference="entity" link="show">
+        <ReferenceField
+          source="entity_id"
+          reference="entity"
+          link="show"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
-        <ReferenceField source="party_id" reference="party" link="show">
+        <ReferenceField
+          source="party_id"
+          reference="party"
+          link="show"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
         <DateField source="recorded_at" showTime />

--- a/frontend/src/party/membership/PartyMembershipList.tsx
+++ b/frontend/src/party/membership/PartyMembershipList.tsx
@@ -54,7 +54,11 @@ export const PartyMembershipList = () => {
             }
           >
             <TextField source="id" label="ID" />
-            <ReferenceField source="entity_id" reference="entity">
+            <ReferenceField
+              source="entity_id"
+              reference="entity"
+              sortable={false}
+            >
               <TextField source="name" />
             </ReferenceField>
             <DateField source="recorded_at" showTime />

--- a/frontend/src/service_provider_product_application/ServiceProviderProductApplicationHistoryList.tsx
+++ b/frontend/src/service_provider_product_application/ServiceProviderProductApplicationHistoryList.tsx
@@ -20,10 +20,18 @@ export const ServiceProviderProductApplicationHistoryList = () => {
       <Datagrid rowClick={historyRowClick}>
         <TextField source="id" label="ID" />
         <TextField source="service_provider_product_application_id" />
-        <ReferenceField source="service_provider_id" reference="party">
+        <ReferenceField
+          source="service_provider_id"
+          reference="party"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
-        <ReferenceField source="system_operator_id" reference="party">
+        <ReferenceField
+          source="system_operator_id"
+          reference="party"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
         <TextField source="status" />

--- a/frontend/src/service_provider_product_application/ServiceProviderProductApplicationList.tsx
+++ b/frontend/src/service_provider_product_application/ServiceProviderProductApplicationList.tsx
@@ -39,10 +39,18 @@ export const ServiceProviderProductApplicationList = () => {
     >
       <Datagrid>
         <TextField source="id" label="ID" />
-        <ReferenceField source="service_provider_id" reference="party">
+        <ReferenceField
+          source="service_provider_id"
+          reference="party"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
-        <ReferenceField source="system_operator_id" reference="party">
+        <ReferenceField
+          source="system_operator_id"
+          reference="party"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
         <ProductTypeArrayField

--- a/frontend/src/service_providing_group/ServiceProvidingGroupHistoryList.tsx
+++ b/frontend/src/service_providing_group/ServiceProvidingGroupHistoryList.tsx
@@ -19,7 +19,11 @@ export const ServiceProvidingGroupHistoryList = () => {
         <TextField source="id" />
         <TextField source="service_providing_group_id" />
         <TextField source="name" />
-        <ReferenceField source="service_provider_id" reference="party">
+        <ReferenceField
+          source="service_provider_id"
+          reference="party"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
         <TextField source="status" />

--- a/frontend/src/service_providing_group/ServiceProvidingGroupList.tsx
+++ b/frontend/src/service_providing_group/ServiceProvidingGroupList.tsx
@@ -12,7 +12,11 @@ export const ServiceProvidingGroupList = () => (
     <Datagrid>
       <TextField source="id" />
       <TextField source="name" />
-      <ReferenceField source="service_provider_id" reference="party">
+      <ReferenceField
+        source="service_provider_id"
+        reference="party"
+        sortable={false}
+      >
         <TextField source="name" />
       </ReferenceField>
       <TextField source="status" />
@@ -20,11 +24,13 @@ export const ServiceProvidingGroupList = () => (
         reference="service_providing_group_grid_prequalification"
         target="service_providing_group_id"
         label="Grid prequalification"
+        sortable={false}
       >
         <Datagrid empty={<span>No grid prequalification</span>}>
           <ReferenceField
             source="impacted_system_operator_id"
             reference="party"
+            sortable={false}
           >
             <TextField source="name" />
           </ReferenceField>
@@ -35,9 +41,14 @@ export const ServiceProvidingGroupList = () => (
         reference="service_providing_group_product_application"
         target="service_providing_group_id"
         label="Product application"
+        sortable={false}
       >
         <Datagrid empty={<span>No product application</span>}>
-          <ReferenceField source="system_operator_id" reference="party">
+          <ReferenceField
+            source="procuring_system_operator_id"
+            reference="party"
+            sortable={false}
+          >
             <TextField source="name" />
           </ReferenceField>
           <TextField source="status" />

--- a/frontend/src/service_providing_group/grid_prequalification/ServiceProvidingGroupGridPrequalificationHistoryList.tsx
+++ b/frontend/src/service_providing_group/grid_prequalification/ServiceProvidingGroupGridPrequalificationHistoryList.tsx
@@ -49,10 +49,15 @@ export const ServiceProvidingGroupGridPrequalificationHistoryList = () => {
         <ReferenceField
           source="service_providing_group_id"
           reference="service_providing_group"
+          sortable={false}
         >
           <TextField source="name" />
         </ReferenceField>
-        <ReferenceField source="impacted_system_operator_id" reference="party">
+        <ReferenceField
+          source="impacted_system_operator_id"
+          reference="party"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
         <TextField source="status" />

--- a/frontend/src/service_providing_group/grid_prequalification/ServiceProvidingGroupGridPrequalificationList.tsx
+++ b/frontend/src/service_providing_group/grid_prequalification/ServiceProvidingGroupGridPrequalificationList.tsx
@@ -68,6 +68,7 @@ export const ServiceProvidingGroupGridPrequalificationList = () => {
               <ReferenceField
                 source="service_providing_group_id"
                 reference="service_providing_group"
+                sortable={false}
               >
                 <TextField source="name" />
               </ReferenceField>
@@ -75,6 +76,7 @@ export const ServiceProvidingGroupGridPrequalificationList = () => {
             <ReferenceField
               source="impacted_system_operator_id"
               reference="party"
+              sortable={false}
             >
               <TextField source="name" />
             </ReferenceField>

--- a/frontend/src/service_providing_group/membership/ServiceProvidingGroupMembershipHistoryList.tsx
+++ b/frontend/src/service_providing_group/membership/ServiceProvidingGroupMembershipHistoryList.tsx
@@ -49,12 +49,14 @@ export const ServiceProvidingGroupMembershipHistoryList = () => {
         <ReferenceField
           source="controllable_unit_id"
           reference="controllable_unit"
+          sortable={false}
         >
           <TextField source="name" />
         </ReferenceField>
         <ReferenceField
           source="service_providing_group_id"
           reference="service_providing_group"
+          sortable={false}
         >
           <TextField source="name" />
         </ReferenceField>

--- a/frontend/src/service_providing_group/membership/ServiceProvidingGroupMembershipList.tsx
+++ b/frontend/src/service_providing_group/membership/ServiceProvidingGroupMembershipList.tsx
@@ -71,6 +71,7 @@ export const ServiceProvidingGroupMembershipList = () => {
               <ReferenceField
                 source="service_providing_group_id"
                 reference="service_providing_group"
+                sortable={false}
               >
                 <TextField source="name" />
               </ReferenceField>
@@ -78,6 +79,7 @@ export const ServiceProvidingGroupMembershipList = () => {
             <ReferenceField
               source="controllable_unit_id"
               reference="controllable_unit"
+              sortable={false}
             >
               <TextField source="name" />
             </ReferenceField>

--- a/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationHistoryList.tsx
+++ b/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationHistoryList.tsx
@@ -46,10 +46,18 @@ export const ServiceProvidingGroupProductApplicationHistoryList = () => {
       >
         <TextField source="id" label="ID" />
         <TextField source="service_provider_product_application_id" />
-        <ReferenceField source="procuring_system_operator_id" reference="party">
+        <ReferenceField
+          source="procuring_system_operator_id"
+          reference="party"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
-        <ReferenceField reference="product_type" source="product_type_id" />
+        <ReferenceField
+          reference="product_type"
+          source="product_type_id"
+          sortable={false}
+        />
         <TextField source="status" />
         <DateField source="last_prequalified" showTime />
         <DateField source="last_verified" showTime />

--- a/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationList.tsx
+++ b/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationList.tsx
@@ -71,6 +71,7 @@ export const ServiceProvidingGroupProductApplicationList = () => {
               <ReferenceField
                 source="service_providing_group_id"
                 reference="service_providing_group"
+                sortable={false}
               >
                 <TextField source="name" />
               </ReferenceField>
@@ -78,10 +79,15 @@ export const ServiceProvidingGroupProductApplicationList = () => {
             <ReferenceField
               source="procuring_system_operator_id"
               reference="party"
+              sortable={false}
             >
               <TextField source="name" />
             </ReferenceField>
-            <ReferenceField reference="product_type" source="product_type_id" />
+            <ReferenceField
+              reference="product_type"
+              source="product_type_id"
+              sortable={false}
+            />
             <TextField source="status" />
             {permissions.includes(
               "service_providing_group_product_application.delete",

--- a/frontend/src/system_operator_product_type/SystemOperatorProductTypeHistoryList.tsx
+++ b/frontend/src/system_operator_product_type/SystemOperatorProductTypeHistoryList.tsx
@@ -17,12 +17,20 @@ export const SystemOperatorProductTypeHistoryList = () => {
       empty={false}
     >
       <Datagrid rowClick={historyRowClick}>
-        <TextField source="id" />
+        <TextField source="id" label="ID" />
         <TextField source="system_operator_product_type_id" />
-        <ReferenceField source="system_operator_id" reference="party">
+        <ReferenceField
+          source="system_operator_id"
+          reference="party"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
-        <ReferenceField reference="product_type" source="product_type_id" />
+        <ReferenceField
+          reference="product_type"
+          source="product_type_id"
+          sortable={false}
+        />
         <TextField source="status" />
         <DateField source="recorded_at" showTime />
         <DateField source="replaced_at" showTime />

--- a/frontend/src/system_operator_product_type/SystemOperatorProductTypeList.tsx
+++ b/frontend/src/system_operator_product_type/SystemOperatorProductTypeList.tsx
@@ -33,11 +33,19 @@ export const SystemOperatorProductTypeList = () => {
       filters={SystemOperatorProductTypeListFilters}
     >
       <Datagrid>
-        <TextField source="id" />
-        <ReferenceField source="system_operator_id" reference="party">
+        <TextField source="id" label="ID" />
+        <ReferenceField
+          source="system_operator_id"
+          reference="party"
+          sortable={false}
+        >
           <TextField source="name" />
         </ReferenceField>
-        <ReferenceField reference="product_type" source="product_type_id" />
+        <ReferenceField
+          reference="product_type"
+          source="product_type_id"
+          sortable={false}
+        />
         <TextField source="status" />
         <DateField source="recorded_at" showTime />
       </Datagrid>


### PR DESCRIPTION
This PR makes it impossible to sort columns that are reference fields in the header of a `Datagrid` component. The reason is that these fields are actually IDs, not names for example.