### PR TITLE
fix: make AP ID on CU non-nullable again (FLEX-673)

### DIFF
--- a/db/flex/controllable_unit_migrations.sql
+++ b/db/flex/controllable_unit_migrations.sql
@@ -46,3 +46,9 @@ DROP COLUMN accounting_point_id CASCADE;
 
 ALTER TABLE flex.controllable_unit_history
 RENAME COLUMN tmp_accounting_point_id TO accounting_point_id;
+
+-- changeset flex:controllable-unit-accounting-point-id-restore-nullable runOnChange:false endDelimiter:;
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = 'flex' AND table_name = 'controllable_unit' AND is_nullable = 'YES' AND column_name = 'accounting_point_id'
+ALTER TABLE flex.controllable_unit
+ALTER COLUMN accounting_point_id SET NOT NULL;


### PR DESCRIPTION
This PR fixes a bug where the accounting point ID field on controllable unit was made nullable. It comes from the previous migration above in that file, that had to replace the field but we forgot to make it non-nullable again.