### PR TITLE
feat(ui): add CU lookup button on CUSP list on CU show page (FLEX-672)

### DIFF
--- a/frontend/src/controllable_unit/lookup/ControllableUnitLookupInput.tsx
+++ b/frontend/src/controllable_unit/lookup/ControllableUnitLookupInput.tsx
@@ -6,12 +6,13 @@ import {
   useNotify,
 } from "react-admin";
 import { Typography, Stack, Button, Box } from "@mui/material";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import TravelExploreIcon from "@mui/icons-material/TravelExplore";
 import UndoIcon from "@mui/icons-material/Undo";
 import { apiURL } from "../../httpConfig";
 import { useFormContext } from "react-hook-form";
 import { InputStack } from "../../auth";
+import { useEffect } from "react";
 
 const Toolbar = () => {
   const navigate = useNavigate();
@@ -75,8 +76,18 @@ const Toolbar = () => {
 
 // page to enter data required for controllable unit lookup
 export const ControllableUnitLookupInput = () => {
+  const {
+    state: { controllable_unit },
+  } = useLocation();
+
   const ControllableUnitLookupForm = () => {
-    const { getValues } = useFormContext();
+    const { getValues, setValue } = useFormContext();
+
+    useEffect(() => {
+      if (controllable_unit) {
+        setValue("controllable_unit", controllable_unit);
+      }
+    });
 
     const values = getValues();
     const accountingPointDefined =

--- a/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderList.tsx
+++ b/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderList.tsx
@@ -13,10 +13,11 @@ import { Datagrid } from "../../auth";
 import AddIcon from "@mui/icons-material/Add";
 import { Link } from "react-router-dom";
 import { DateField } from "../../components/datetime";
+import TravelExploreIcon from "@mui/icons-material/TravelExplore";
 
 export const ControllableUnitServiceProviderList = () => {
   // id of the controllable unit whose relations we want to get
-  const { id } = useRecordContext()!;
+  const { id, business_id } = useRecordContext()!;
   const { permissions } = usePermissions();
 
   // automatically fill the controllable_unit_id field with the ID of the
@@ -31,8 +32,19 @@ export const ControllableUnitServiceProviderList = () => {
     />
   );
 
+  const CULookupButton = () => (
+    <Button
+      component={Link}
+      to="/controllable_unit/lookup"
+      startIcon={<TravelExploreIcon />}
+      state={{ controllable_unit: business_id }}
+      label="Lookup this controllable unit"
+    />
+  );
+
   const ListActions = () => (
     <TopToolbar>
+      {permissions.includes("controllable_unit.lookup") && <CULookupButton />}
       {permissions.includes("controllable_unit_service_provider.create") && (
         <CreateButton />
       )}


### PR DESCRIPTION
This PR adds a CU lookup button on the CUSP list on the CU show page, so that SPs can get the end user technical ID a bit faster.

The button works the same as the one we already have in the CU list, except there the CU business ID gets autofilled on arrival, because we know we lookup by CU and not by AP.

<img width="1411" height="278" alt="Screenshot 2025-07-18 161154" src="https://github.com/user-attachments/assets/ec193c45-9440-48ab-a10f-4d47cce0e18a" />

<img width="446" height="250" alt="Screenshot 2025-07-18 161247" src="https://github.com/user-attachments/assets/21720483-44bd-4659-8fba-311e6c64b459" />
