### PR TITLE
feat: restrict SPGPA-SO001 policy to SPGs targeting the SO (FLEX-667)

### DIFF
--- a/docs/resources/service_providing_group_product_application.md
+++ b/docs/resources/service_providing_group_product_application.md
@@ -101,10 +101,10 @@ No policies.
 
 #### System Operator
 
-| Policy key  | Policy                       | Status |
-|-------------|------------------------------|--------|
-| SPGPA-SO001 | Read all SPGPA.              | DONE   |
-| SPGPA-SO002 | Update SPGPA targeting them. | DONE   |
+| Policy key  | Policy                                                            | Status |
+|-------------|-------------------------------------------------------------------|--------|
+| SPGPA-SO001 | Read SPGPA from SPGs that have at least one SPGPA targeting them. | TODO   |
+| SPGPA-SO002 | Update SPGPA targeting them.                                      | DONE   |
 
 #### Service Provider
 


### PR DESCRIPTION
The problem here is that sometimes a SO can see a SPG product application, but they actually cannot see the SPG's name. This causes an empty field to be shown in the UI for instance. This is because policies on SPG are based on other resources linking the SPG to the SO. If a SO has no ongoing process with an SPG, then they should not see it. However the SPGPA policies are not that restrictive.

Indeed, we used a very widely open rule that lets SO read all SPGPAs. But it does not _need_ to be so. The original reason for an SO to see SPG product applications is that by doing that, they can check whether another SO has prequalified the SPG for the same product type, and thereby they could decide faster on their own ongoing applications from the same SPG.

It means that it is interesting for a SO to see other product applications only when they have received an application from the same SPG. It is useless for them to see applications from SPGs they have nothing to do with.

(cf note after step 10 here: https://elhub.github.io/flex-information-system/processes/service-providing-group-product-application/). 

We can therefore fix the bug by making the SPGPA-SO001 rule more restrictive.