### PR TITLE
fix: disable secretlint on some local files with database connection strings (FLEX-735)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 ---
+# secretlint-disable
 name: flex
 services:
   db:

--- a/local/backend/dev.env
+++ b/local/backend/dev.env
@@ -1,4 +1,5 @@
 # Env file for dev
+# secretlint-disable
 FLEX_BASE_URL=https://dev.flex.internal:5443/
 FLEX_DB_REPLICATION_SLOT_NAME=event_slot
 FLEX_DB_REPLICATION_URI=postgres://flex_replication:replication_password@localhost:5432/flex

--- a/local/backend/test.env
+++ b/local/backend/test.env
@@ -1,4 +1,5 @@
 # Env file for test
+# secretlint-disable
 FLEX_BASE_URL=https://test.flex.internal:6443/
 FLEX_DB_REPLICATION_SLOT_NAME=event_slot
 FLEX_DB_REPLICATION_URI=postgres://flex_replication:replication_password@db:5432/flex


### PR DESCRIPTION
Fixes false positives with @secretlint/secretlint-rule-database-connection-string in the three files.
Since they are all local files, then we can safely ignore them fully.
Considered adding a .secretlintignore file but I think the current strategy of using .gitignore is pretty solid in general - so I'd rather mark individual files like this.