### PR TITLE
feat: notifications for SPPS comments (FLEX-733)

### DIFF
--- a/backend/event/models.sql
+++ b/backend/event/models.sql
@@ -153,7 +153,9 @@ SELECT DISTINCT
     unnest(
         ARRAY[sppsh.service_provider_id, sppsh.procuring_system_operator_id]
     )::bigint
+-- using history because comments can be deleted
 FROM service_provider_product_suspension_comment_history AS sppsch
+    -- using history because suspensions can be deleted
     INNER JOIN service_provider_product_suspension_history AS sppsh
         ON sppsch.service_provider_product_suspension_id
             = sppsh.service_provider_product_suspension_id
@@ -161,7 +163,9 @@ FROM service_provider_product_suspension_comment_history AS sppsch
                 @> @recorded_at::timestamptz
 WHERE sppsch.service_provider_product_suspension_comment_id = @resource_id
     AND tstzrange(sppsch.recorded_at, sppsch.replaced_at, '[]')
-        @> @recorded_at::timestamptz;
+        @> @recorded_at::timestamptz
+    AND sppsch.visibility = 'any_party';
+-- see query for SPPAC below for explanation about visibilities
 
 -- name: GetServiceProvidingGroupCreateNotificationRecipients :many
 SELECT service_provider_id
@@ -243,15 +247,17 @@ WHERE cu.id = (
 AND cu.status != 'new';
 
 -- name: GetServiceProviderProductApplicationCommentNotificationRecipients :many
-SELECT unnest(array[sppa.service_provider_id, sppa.system_operator_id])::bigint
--- not using SPPA history because SP and SO are stable
-FROM service_provider_product_application sppa
--- using SPPA comment history because the visibility can change over time
-JOIN service_provider_product_application_comment_history sppach
-ON sppa.id = sppach.service_provider_product_application_id
+SELECT DISTINCT
+    unnest(ARRAY[sppa.service_provider_id, sppa.system_operator_id])::bigint
+-- using SPPA comment history because visibility can change over time
+FROM service_provider_product_application_comment_history AS sppach
+    -- not using SPPA history because the resource cannot be deleted
+    INNER JOIN service_provider_product_application AS sppa
+        ON sppach.service_provider_product_application_id = sppa.id
 WHERE sppach.service_provider_product_application_comment_id = @resource_id
-AND tstzrange(sppach.recorded_at, sppach.replaced_at, '[)') @> @recorded_at::timestamptz
-AND sppach.visibility = 'any_party';
+    AND tstzrange(sppach.recorded_at, sppach.replaced_at, '[]')
+        @> @recorded_at::timestamptz
+    AND sppach.visibility = 'any_party';
 -- other visibilities mean no notification (empty notified parties list) :
 --   - 'same_party' leaves only the current party, removed from the list anyway
 --   - 'same_party_type' leaves only different party types :

--- a/backend/event/models/models.custom.go
+++ b/backend/event/models/models.custom.go
@@ -38,7 +38,7 @@ func (q *Queries) GetNotificationRecipients( //nolint:cyclop,funlen
 	case "no.elhub.flex.service_provider_product_application_comment.create",
 		"no.elhub.flex.service_provider_product_application_comment.update":
 		return q.GetServiceProviderProductApplicationCommentNotificationRecipients(
-			ctx, resourceID, recordedAt,
+			ctx, recordedAt, resourceID,
 		)
 	case "no.elhub.flex.service_provider_product_suspension.create",
 		"no.elhub.flex.service_provider_product_suspension.update",

--- a/backend/event/models/models.custom.go
+++ b/backend/event/models/models.custom.go
@@ -7,7 +7,7 @@ import (
 )
 
 // GetNotificationRecipients returns a list of party IDs that should receive a notification for an event.
-func (q *Queries) GetNotificationRecipients( //nolint:cyclop
+func (q *Queries) GetNotificationRecipients( //nolint:cyclop,funlen
 	ctx context.Context,
 	eventType string,
 	resourceID int,
@@ -44,6 +44,11 @@ func (q *Queries) GetNotificationRecipients( //nolint:cyclop
 		"no.elhub.flex.service_provider_product_suspension.update",
 		"no.elhub.flex.service_provider_product_suspension.delete":
 		return q.GetServiceProviderProductSuspensionNotificationRecipients(ctx, resourceID, recordedAt)
+	case "no.elhub.flex.service_provider_product_suspension_comment.create",
+		"no.elhub.flex.service_provider_product_suspension_comment.update":
+		return q.GetServiceProviderProductSuspensionCommentNotificationRecipients(
+			ctx, recordedAt, resourceID,
+		)
 	case "no.elhub.flex.service_providing_group.create":
 		return q.GetServiceProvidingGroupCreateNotificationRecipients(ctx, resourceID)
 	case "no.elhub.flex.service_providing_group.update":

--- a/backend/internal/validate/validate.go
+++ b/backend/internal/validate/validate.go
@@ -33,7 +33,7 @@ func New() *Validate {
 
 // Check adds an error message to the list of error messages if the condition c is false.
 // Format and a are passed directly to fmt.Sprintf.
-func (v *Validate) Check(c bool, format string, a ...any) {
+func (v *Validate) Check(c bool, format string, a ...any) { //nolint:goprintffuncname
 	if !c {
 		v.errormsgs = append(v.errormsgs, fmt.Sprintf(format, a...))
 	}

--- a/db/flex/event_rls.sql
+++ b/db/flex/event_rls.sql
@@ -80,6 +80,7 @@ USING (
         'service_provider_product_application',
         'service_provider_product_application_comment',
         'service_provider_product_suspension',
+        'service_provider_product_suspension_comment',
         'service_providing_group',
         'service_providing_group_membership',
         'service_providing_group_grid_prequalification',
@@ -251,5 +252,21 @@ USING (
             WHERE sppsh.id = event.source_id -- noqa
                 AND sppsh.service_provider_id = (SELECT flex.current_party())
         )
+    )
+);
+
+-- RLS: EVENT-SP012
+CREATE POLICY "EVENT_SP012" ON event
+FOR SELECT
+TO flex_service_provider
+USING (
+    source_resource = 'service_provider_product_suspension_comment'
+    AND EXISTS (
+        SELECT 1
+        FROM flex.service_provider_product_suspension_comment AS sppsc
+            INNER JOIN flex.service_provider_product_suspension AS spps
+                ON sppsc.service_provider_product_suspension_id = spps.id
+        WHERE sppsc.id = event.source_id -- noqa
+            AND spps.service_provider_id = (SELECT flex.current_party())
     )
 );

--- a/db/flex/service_provider_product_application.sql
+++ b/db/flex/service_provider_product_application.sql
@@ -96,7 +96,7 @@ EXECUTE FUNCTION
 service_provider_product_application_product_type_ids_insert();
 
 -- changeset flex:service-provider-product-type-ids-update-function runOnChange:true endDelimiter:--
--- RLS: SPPA-SP003
+-- RLS: SPPA-SP002
 -- reject updates by SP if the status is not `requested`
 CREATE OR REPLACE FUNCTION
 service_provider_product_application_product_type_ids_update()

--- a/docs/resources/event.md
+++ b/docs/resources/event.md
@@ -77,9 +77,9 @@ No policies.
 
 #### System Operator
 
-| Policy key  | Policy                                                                                     | Status |
-|-------------|--------------------------------------------------------------------------------------------|--------|
-| EVENT-SO001 | Read all events related to CU, CUSP, TR, SOPT, SPPA, SPPS, SPPAC, SPG, SPGM, SPGGP, SPGPA. | DONE   |
+| Policy key  | Policy                                                                                            | Status |
+|-------------|---------------------------------------------------------------------------------------------------|--------|
+| EVENT-SO001 | Read all events related to CU, CUSP, TR, SOPT, SPPA, SPPS, SPPAC, SPPSC, SPG, SPGM, SPGGP, SPGPA. | DONE   |
 
 #### Service Provider
 
@@ -96,6 +96,7 @@ No policies.
 | EVENT-SP009 | Read events related to SPG product applications when they own the SPG.                         | DONE   |
 | EVENT-SP010 | Read events related to SOPT.                                                                   | DONE   |
 | EVENT-SP011 | Read events related to SPPS when they are the SP.                                              | DONE   |
+| EVENT-SP012 | Read events related to comments on SPPS concerning themselves, when they can see the comments. | DONE   |
 
 #### Third Party
 

--- a/docs/resources/service_provider_product_application_comment.md
+++ b/docs/resources/service_provider_product_application_comment.md
@@ -27,9 +27,9 @@ No validation rules.
 
 ## Notifications
 
-| Action         | Recipient         | Comment |
-|----------------|-------------------|---------|
-| create, update | SO and SP of SPPA |         |
+| Action         | Recipient                                       | Comment |
+|----------------|-------------------------------------------------|---------|
+| create, update | SO and SP of SPPA when they can see the comment |         |
 
 ## Authorization
 

--- a/docs/resources/service_provider_product_suspension_comment.md
+++ b/docs/resources/service_provider_product_suspension_comment.md
@@ -27,9 +27,9 @@ No validation rules.
 
 ## Notifications
 
-| Action         | Recipient         | Comment |
-|----------------|-------------------|---------|
-| create, update | SO and SP of SPPS |         |
+| Action         | Recipient                                       | Comment |
+|----------------|-------------------------------------------------|---------|
+| create, update | SO and SP of SPPS when they can see the comment |         |
 
 ## Authorization
 

--- a/test/api_client_tests/test_cu.py
+++ b/test/api_client_tests/test_cu.py
@@ -559,6 +559,11 @@ def test_controllable_unit_sp(sts):
     )
     assert isinstance(cu, ControllableUnitResponse)
 
+    # RLS: CU-SP005
+    # SP1 can read the CU they just created
+    r = read_controllable_unit.sync(client=client_sp1, id=cast(int, cu.id))
+    assert isinstance(r, ControllableUnitResponse)
+
     # RLS: CU-SP003
     # create CU-SP in the distant future
     cu_sp = create_controllable_unit_service_provider.sync(

--- a/test/api_client_tests/test_entity.py
+++ b/test/api_client_tests/test_entity.py
@@ -292,6 +292,7 @@ def test_entity_org(sts):
 
     # organisation should by default see the entity with email business id type
     # TODO this is a temporary solution for pilot testing w/ email based entities
+    # RLS: ENT-ORG002
     ent = list_entity.sync(client=client_org, business_id_type="eq.email")
     assert isinstance(ent, list)
     assert len(ent) >= 1

--- a/test/api_client_tests/test_service_provider_product_suspension.py
+++ b/test/api_client_tests/test_service_provider_product_suspension.py
@@ -106,7 +106,7 @@ def data():
 # ---- ---- ---- ---- ----
 
 
-# RLS: SPPA-COM001
+# RLS: SPPS-COM001
 # function to check history (will be called in several tests)
 # harder to write a general function because of fresh clients
 def check_history(client, spps_id):
@@ -204,6 +204,15 @@ def test_spps_sp(data):
     )
     assert isinstance(spps, ServiceProviderProductSuspensionResponse)
 
+    check_history(client_sp, spps.id)
+
+    d = delete_service_provider_product_suspension.sync(
+        client=client_fiso, id=cast(int, spps.id), body=EmptyObject()
+    )
+    assert not isinstance(d, ErrorMessage)
+
+    # RLS: SPPS-SP002
+    # they can still read history after deletion
     check_history(client_sp, spps.id)
 
 


### PR DESCRIPTION
This PR adds notifications for _SP product suspension comments_ and restores full RLS test coverage (some stuff had been forgotten).