### PR TITLE
feat: update history policies linked to deletable resources (FLEX-728)

### DIFF
--- a/docs/resources/party_membership.md
+++ b/docs/resources/party_membership.md
@@ -49,9 +49,8 @@ No policies.
 
 | Policy key  | Policy                                                    | Status |
 |-------------|-----------------------------------------------------------|--------|
-| PTYM-COM001 | Read history on all PTYM that they can read               | DONE   |
-| PTYM-COM002 | Read all the PTYM concerning the current party            | DONE   |
-| PTYM-COM003 | Read all the history of PTYM concerning the current party | DONE   |
+| PTYM-COM001 | Read all the PTYM concerning the current party            | TODO   |
+| PTYM-COM002 | Read all the history of PTYM concerning the current party | TODO   |
 
 #### Balance Responsible Party
 
@@ -81,6 +80,7 @@ No policies.
 | Policy key  | Policy                                                                                                 | Status |
 |-------------|--------------------------------------------------------------------------------------------------------|--------|
 | PTYM-ORG001 | Read, create, update and delete PTYM on all parties owned by the entity owning the organisation party. | DONE   |
+| PTYM-ORG002 | Read PTYM history on all parties owned by the entity owning the organisation party.                    | TODO   |
 
 #### System Operator
 

--- a/docs/resources/service_provider_product_suspension.md
+++ b/docs/resources/service_provider_product_suspension.md
@@ -46,9 +46,7 @@ No policies.
 
 #### Common
 
-| Policy key  | Policy                                   | Status |
-|-------------|------------------------------------------|--------|
-| SPPS-COM001 | Read history on SPPS that they can read. | DONE   |
+No policies.
 
 #### Balance Responsible Party
 
@@ -67,6 +65,7 @@ No policies.
 | Policy key   | Policy                                    | Status |
 |--------------|-------------------------------------------|--------|
 | SPPS-FISO001 | Create, read, update and delete all SPPS. | DONE   |
+| SPPS-FISO002 | Read all SPPS history.                    | TODO   |
 
 #### Market Operator
 
@@ -78,10 +77,12 @@ No policies.
 
 #### System Operator
 
-| Policy key | Policy                                                                                  | Status |
-|------------|-----------------------------------------------------------------------------------------|--------|
-| SPPS-SO001 | Create, read, update and delete their own SPPS.                                         | DONE   |
-| SPPS-SO002 | Read SPPS targeted at any SP they have qualified for at least one of the product types. | DONE   |
+| Policy key | Policy                                                                                            | Status |
+|------------|---------------------------------------------------------------------------------------------------|--------|
+| SPPS-SO001 | Create, read, update and delete their own SPPS.                                                   | DONE   |
+| SPPS-SO002 | Read history on their own SPPS.                                                                   | TODO   |
+| SPPS-SO003 | Read SPPS targeted at any SP they have qualified for at least one of the product types.           | TODO   |
+| SPPS-SO004 | Read history on SPPS targeted at any SP they had qualified for at least one of the product types. | TODO   |
 
 #### Service Provider
 

--- a/docs/resources/service_provider_product_suspension_comment.md
+++ b/docs/resources/service_provider_product_suspension_comment.md
@@ -46,8 +46,7 @@ No policies.
 
 | Policy key   | Policy                                        | Status |
 |--------------|-----------------------------------------------|--------|
-| SPPSC-COM001 | Read history on SPPSC that they can read.     | DONE   |
-| SPPSC-COM002 | Update SPPSC that they created.               | DONE   |
+| SPPSC-COM001 | Update SPPSC that they created.               | TODO   |
 
 #### Balance Responsible Party
 
@@ -66,6 +65,7 @@ No policies.
 | Policy key    | Policy                             | Status |
 |---------------|------------------------------------|--------|
 | SPPSC-FISO001 | Read, create and update all SPPSC. | DONE   |
+| SPPSC-FISO002 | Read history on all SPPSC.         | TODO   |
 
 #### Market Operator
 
@@ -77,17 +77,19 @@ No policies.
 
 #### System Operator
 
-| Policy key  | Policy                                                            | Status |
-|-------------|-------------------------------------------------------------------|--------|
-| SPPSC-SO001 | Create SPPSC on SPPS where they are PSO.                          | DONE   |
-| SPPSC-SO002 | Read SPPSC that the visibility allows on SPPS where they are PSO. | DONE   |
+| Policy key  | Policy                                                                         | Status |
+|-------------|--------------------------------------------------------------------------------|--------|
+| SPPSC-SO001 | Create SPPSC on SPPS where they are PSO.                                       | DONE   |
+| SPPSC-SO002 | Read SPPSC that the visibility allows on SPPS where they are PSO.              | DONE   |
+| SPPSC-SO003 | Read history on SPPSC that the visibility allowed on SPPS where they were PSO. | TODO   |
 
 #### Service Provider
 
-| Policy key  | Policy                                                           | Status |
-|-------------|------------------------------------------------------------------|--------|
-| SPPSC-SP001 | Create SPPSC on SPPS where they are SP.                          | DONE   |
-| SPPSC-SP002 | Read SPPSC that the visibility allows on SPPS where they are SP. | DONE   |
+| Policy key  | Policy                                                                        | Status |
+|-------------|-------------------------------------------------------------------------------|--------|
+| SPPSC-SP001 | Create SPPSC on SPPS where they are SP.                                       | DONE   |
+| SPPSC-SP002 | Read SPPSC that the visibility allows on SPPS where they are SP.              | DONE   |
+| SPPSC-SP003 | Read history on SPPSC that the visibility allowed on SPPS where they were SP. | TODO   |
 
 #### Third Party
 

--- a/docs/resources/service_providing_group_membership.md
+++ b/docs/resources/service_providing_group_membership.md
@@ -44,9 +44,7 @@ No policies.
 
 #### Common
 
-| Policy key  | Policy                                   | Status |
-|-------------|------------------------------------------|--------|
-| SPGM-COM001 | Read history on SPGM that they can read. | DONE   |
+No policies.
 
 #### Balance Responsible Party
 
@@ -65,6 +63,7 @@ No policies.
 | Policy key   | Policy                                                        | Status |
 |--------------|---------------------------------------------------------------|--------|
 | SPGM-FISO001 | Read, create, update and delete all SPG membership relations. | DONE   |
+| SPGM-FISO002 | Read history on all SPG memberships.                          | TODO   |
 
 #### Market Operator
 
@@ -76,9 +75,10 @@ No policies.
 
 #### System Operator
 
-| Policy key | Policy                                     | Status |
-|------------|--------------------------------------------|--------|
-| SPGM-SO001 | Read SPGM belonging to SPGs they can read. | DONE   |
+| Policy key | Policy                                                | Status |
+|------------|-------------------------------------------------------|--------|
+| SPGM-SO001 | Read SPGM belonging to SPGs they can read.            | DONE   |
+| SPGM-SO002 | Read history on SPGM belonging to SPGs they can read. | TODO   |
 
 #### Service Provider
 
@@ -86,6 +86,7 @@ No policies.
 |------------|------------------------------------------------------------------------------------------------|--------|
 | SPGM-SP001 | Create and update SPGM for SPGS that belongs to them, on periods where they are SP for the CU. | DONE   |
 | SPGM-SP002 | Read, delete SPGM for SPGS that belongs to them.                                               | DONE   |
+| SPGM-SP003 | Read history on SPGM for SPGs that belong to them.                                             | TODO   |
 
 #### Third Party
 

--- a/docs/resources/technical_resource.md
+++ b/docs/resources/technical_resource.md
@@ -93,10 +93,10 @@ No policies.
 
 #### System Operator
 
-| Policy key | Policy                                       | Status |
-|------------|----------------------------------------------|--------|
-| TR-SO001   | Read TR belonging to CU that the SO can see. | DONE   |
-| TR-SO002   | Read history on TR that they can read.       | DONE   |
+| Policy key | Policy                                                  | Status |
+|------------|---------------------------------------------------------|--------|
+| TR-SO001   | Read TR belonging to CU that the SO can see.            | DONE   |
+| TR-SO002   | Read history on TR belonging to CU that the SO can see. | TODO   |
 
 #### Service Provider
 


### PR DESCRIPTION
This PR proposes an update to the RLS policies, based on the observation that some of the current policies hide history records that should be visible because some of the resources in the RLS checks are deletable.

Here are the resources that can be deleted: ECL, PM, CUSP, SPGM, TR, SPPS, SPPSC.
ECL has no history resource in the API and CUSP has soft delete, so they are not touched there.

The main type of change is to remove policies related to deletable resources that are formulated like the following:
> _Read X history when they can read X._

Such policies are a very good first approximation, but they do not work for deletable resources. Indeed, if the base resource X is deleted, then the user loses access to history even though it may be useful/legit to access it in the future.

In such cases, I suggest duplicating the other policies allowing read access, so that there is an equivalent for the history resource. In the new policies, for every check on another resource, we consider switching to a check on the history of this resource instead, if it makes more sense.

Draft for communication before implementation. I will add comments on the various files to explain the reflection behind the proposed changes.