### PR TITLE
fix(db): update RLS for SPPS when the check is based on history (FLEX-728)

### DIFF
--- a/db/flex/service_provider_product_suspension_rls.sql
+++ b/db/flex/service_provider_product_suspension_rls.sql
@@ -68,7 +68,16 @@ TO flex_system_operator
 USING (procuring_system_operator_id = (SELECT flex.current_party()));
 
 -- RLS: SPPS-SO002
+GRANT SELECT ON service_provider_product_suspension_history
+TO flex_system_operator;
 CREATE POLICY "SPPS_SO002"
+ON service_provider_product_suspension_history
+FOR SELECT
+TO flex_system_operator
+USING (procuring_system_operator_id = (SELECT flex.current_party()));
+
+-- RLS: SPPS-SO003
+CREATE POLICY "SPPS_SO003"
 ON service_provider_product_suspension
 FOR SELECT
 TO flex_system_operator
@@ -85,12 +94,10 @@ USING (
     )
 );
 
--- RLS: SPPS-SO003
+-- RLS: SPPS-SO004
 -- same check as above but with history tables, so that qualification can be
 -- removed later and/or suspension deleted, but history should still be readable
-GRANT SELECT ON service_provider_product_suspension_history
-TO flex_system_operator;
-CREATE POLICY "SPPS_SO003"
+CREATE POLICY "SPPS_SO004"
 ON service_provider_product_suspension_history
 FOR SELECT
 TO flex_system_operator

--- a/docs/resources/service_provider_product_suspension.md
+++ b/docs/resources/service_provider_product_suspension.md
@@ -80,8 +80,9 @@ No policies.
 | Policy key | Policy                                                                                            | Status |
 |------------|---------------------------------------------------------------------------------------------------|--------|
 | SPPS-SO001 | Create, read, update and delete their own SPPS.                                                   | DONE   |
-| SPPS-SO002 | Read SPPS targeted at any SP they have qualified for at least one of the product types.           | DONE   |
-| SPPS-SO003 | Read history on SPPS targeted at any SP they had qualified for at least one of the product types. | DONE   |
+| SPPS-SO002 | Read history on their own SPPS.                                                                   | DONE   |
+| SPPS-SO003 | Read SPPS targeted at any SP they have qualified for at least one of the product types.           | DONE   |
+| SPPS-SO004 | Read history on SPPS targeted at any SP they had qualified for at least one of the product types. | DONE   |
 
 #### Service Provider
 

--- a/test/api_client_tests/test_service_provider_product_suspension.py
+++ b/test/api_client_tests/test_service_provider_product_suspension.py
@@ -264,7 +264,7 @@ def test_spps_so(data):
     )
     assert not isinstance(d, ErrorMessage)
 
-    # RLS: SPPS-SO002
+    # RLS: SPPS-SO003
 
     # the other SO will create a SPPS targeting the same SP with one common
     # product type, and the first SO must be able to read it
@@ -287,7 +287,7 @@ def test_spps_so(data):
     )
     assert isinstance(spps2, ServiceProviderProductSuspensionResponse)
 
-    # RLS: SPPS-SO003
+    # RLS: SPPS-SO004
     # history still readable after SPPS deletion / SPPA unqualification
 
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")
@@ -302,3 +302,4 @@ def test_spps_so(data):
     assert not isinstance(u, ErrorMessage)
 
     check_history(client_so, spps.id)
+    check_history(client_so2, spps.id)


### PR DESCRIPTION
This PR fixes the bug on history-based RLS described in https://github.com/elhub/flex-information-system/pull/305#issuecomment-3338580016 for SPPS and removes overlapping policies.

The existing test was in fact already the right one, but it was not testing the right policy.

Indeed, as an SO, if a suspension is yours, then you are suspending someone you have qualified before, as ensured by the validation rule (SPPS-VAL001). This means the rule giving history access on your own suspensions (the former SPPS-SO002) is _always_ covered by the rule giving history access on suspensions targeted to SPs you have qualified once (the former SPPS-SO004). So in the case where it is your own suspension, the first rule was short-cutting the second, which means the second was not really being tested.

By removing the shortcut, we simplify the RLS and the tests do not even have to change.