### PR TITLE
docs: update docs with advice on RLS creation (FLEX-728)

### DIFF
--- a/db/flex/technical_resource_rls.sql
+++ b/db/flex/technical_resource_rls.sql
@@ -155,11 +155,13 @@ CREATE POLICY "TR_SO002"
 ON technical_resource_history
 FOR SELECT
 TO flex_system_operator
-USING (EXISTS (
-    SELECT 1
-    FROM controllable_unit
-    WHERE controllable_unit.id = technical_resource_history.controllable_unit_id -- noqa
-));
+USING (
+    EXISTS (
+        SELECT 1
+        FROM controllable_unit
+        WHERE controllable_unit.id = technical_resource_history.controllable_unit_id -- noqa
+    )
+);
 
 -- RLS: TR-SP001
 GRANT INSERT, UPDATE, DELETE ON technical_resource TO flex_service_provider;

--- a/docs-dev/editing-resources.md
+++ b/docs-dev/editing-resources.md
@@ -84,15 +84,14 @@ Postgres. It consists in SQL grants for various roles, that are generated from a
 matrix (`field X role`) in the `permissions.csv` file. This allows for easier
 modification without having to dive into the code.
 
-!!! warning
-
-    FLA grants do not mention history, because if one can read a resource, we
-    consider they should also be able to read the history. However, this means
-    that the script must know for which resources to generate history grants,
-    and for which resources it is not required (_i.e._, they do not have a
-    history table and the grant would not compile). For this reason, history
-    grants should be enabled by hand directly in the `permissions_to_*.py`
-    scripts, by adding the name of the resource to the `history_enabled` list.
+> [!WARNING]
+> FLA grants do not mention history, because if one can read a resource, we
+> consider they should also be able to read the history. However, this means
+> that the script must know for which resources to generate history grants,
+> and for which resources it is not required (_i.e._, they do not have a
+> history table and the grant would not compile). For this reason, history
+> grants should be enabled by hand directly in the `permissions_to_*.py`
+> scripts, by adding the name of the resource to the `history_enabled` list.
 
 ### Row-Level Authorisation (RLA)
 
@@ -105,12 +104,61 @@ the Markdown file associated to the resource. Part of this file is generated,
 but the RLA section must be written by hand and the implementation status of
 each rule should also be maintained.
 
-!!! warning
+> [!WARNING]
+> Test coverage of all the RLS policies is checked by looking for specific
+> comments at the place of definition of the policies and use in the tests.
+> Do not forget to add a comment with the name of the RLS policy on top of its
+> definition, as it was done for existing resources in the project.
 
-    Test coverage of all the RLS policies is checked by looking for specific
-    comments at the place of definition of the policies and use in the tests.
-    Do not forget to add a comment with the name of the RLS policy on top of its
-    definition, as it was done for existing resources in the project.
+Here are some things to keep in mind when designing RLS policies:
+
+#### Policies are _security invoker_
+
+RLS policies are executed as the user the policies apply to.
+This means you should check that every resource mentioned in a policy is
+actually readable by the current user, otherwise the policy will always return
+false.
+
+Partial access on another resource makes policies more concise though.
+For instance, if the rule is _You can read `X` if you can read `Y`_, then the
+policy implementing this rule will just be a select on `Y`, because it will use
+the existing policies for the same user on resource `Y`.
+
+Another thing to think about is _reference cycles_.
+Indeed, if RLS policies giving access to resource `X` to a user refer `Y`, and
+access to `Y` depends on `X`, then the policies on `X` will indirectly run the
+policies on `Y`, which will internally run the policies on `X`, and so on.
+Reference cycles are broken by the use of a _security definer_ function, so that
+access to one of the resources in the cycle has no more dependencies on the
+other resources.
+
+#### Limit indirect references to other resources
+
+A reference chain can be hard to reason about.
+Indeed, if access to resource `X` is based on `Y`, but access to `Y` is based on
+`Z`, then everytime you reason about access to a row, you potentially need to
+think about 3 resources.
+It can be easier to take all resources at the end of the reference chain and
+build a single query or function that uses them all.
+In this way, all elements are there and you can reason about the policy without
+having to check several places.
+
+#### Policies for history
+
+Policies for history tables are a bit harder because you need to consider
+whether it makes sense to give access to history on `X` based on the current
+`X`, based on another resource `Y`, or based on history on `Y`, _etc_.
+A good first approximation is to say that you can read history on `X` when you
+can read the current `X`, but if the resource is _deletable_, then users lose
+access to history on a row whenever this row gets deleted.
+
+In that case, a second good approximation is to duplicate the policy for `X`, so
+that access is based on the data of the history row instead.
+Generally, for every resource referenced in a policy for history, you need to
+think about whether the history of this resource should be used or not.
+If the other resource is not deletable and the fields checked are immutable
+(for instance a foreign key), then you do not need to use history.
+Otherwise, you should use history and make sure to filter the right record time.
 
 ## Updating the tests
 

--- a/docs/resources/technical_resource.md
+++ b/docs/resources/technical_resource.md
@@ -93,10 +93,10 @@ No policies.
 
 #### System Operator
 
-| Policy key | Policy                                       | Status |
-|------------|----------------------------------------------|--------|
-| TR-SO001   | Read TR belonging to CU that the SO can see. | DONE   |
-| TR-SO002   | Read history on TR that they can read.       | DONE   |
+| Policy key | Policy                                                  | Status |
+|------------|---------------------------------------------------------|--------|
+| TR-SO001   | Read TR belonging to CU that the SO can see.            | DONE   |
+| TR-SO002   | Read history on TR belonging to CU that the SO can see. | DONE   |
 
 #### Service Provider
 


### PR DESCRIPTION
This PR adds docs based on the work done updating the RLS for deletable resources.

I checked the last resource we had to update before events (technical resource), and there was nothing more to do actually. The resource docs were wrong, but the implementation was already the one we want for now. So I just updated the docs. As mentioned in the other PR (https://github.com/elhub/flex-information-system/pull/302#discussion_r2378352720), it is possible to design a more precise policy, but it is not needed for now.