### PR TITLE
feat: add support for EIC-Y business ID type and use it for MGAs (FLEX-749)

### DIFF
--- a/db/flex/business_id_type.sql
+++ b/db/flex/business_id_type.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS flex.business_id_type (
     )
 );
 
--- changeset flex:validate-business-id endDelimiter:-- runOnChange: true
+-- changeset flex:validate-business-id endDelimiter:-- runOnChange:true
 CREATE OR REPLACE FUNCTION flex.validate_business_id(
     business_id text, business_id_type text
 )
@@ -23,6 +23,14 @@ BEGIN
 
     IF business_id_type = 'eic_x' THEN
         IF business_id !~ '^[0-9]{2}X[0-9A-Z-]{12}[0-9A-Z]$' THEN
+            RETURN false;
+        END IF;
+
+        RETURN (
+            eic.validate_check_char(business_id)
+        );
+    ELSIF business_id_type = 'eic_y' THEN
+        IF business_id !~ '^[0-9]{2}Y[0-9A-Z-]{12}[0-9A-Z]$' THEN
             RETURN false;
         END IF;
 

--- a/db/flex/changelog.yml
+++ b/db/flex/changelog.yml
@@ -202,6 +202,9 @@ databaseChangeLog:
       maxDepth: 1
 
   - include:
+      file: ./metering_grid_area_migrations.sql
+      relativeToChangelogFile: true
+  - include:
       file: ./party_membership_migrations.sql
       relativeToChangelogFile: true
   - include:
@@ -241,6 +244,7 @@ databaseChangeLog:
   - changeSet:
       id: business-id-type-reference-data
       author: flex
+      validCheckSum: 9:1b2b49b6c93cea9eb2d24459a538974b
       changes:
         - loadUpdateData:
             file: ./reference_data/business_id_type.csv

--- a/db/flex/metering_grid_area.sql
+++ b/db/flex/metering_grid_area.sql
@@ -2,11 +2,10 @@
 -- Manually managed file
 
 -- changeset flex:metering-grid-area runOnChange:false endDelimiter:--
+-- validCheckSum: 9:69f04f17e0a84326f6a6eddd29777f01
 CREATE TABLE IF NOT EXISTS metering_grid_area (
     id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    business_id text UNIQUE NOT NULL CHECK (
-        validate_business_id(business_id, 'eic_x')
-    ),
+    business_id text UNIQUE NOT NULL,
     name text NOT NULL CHECK ((char_length(name) <= 128)),
     price_area text NOT NULL CHECK (
         price_area IN ('NO1', 'NO2', 'NO3', 'NO4', 'NO5')
@@ -27,6 +26,10 @@ CREATE TABLE IF NOT EXISTS metering_grid_area (
     ),
     recorded_by bigint NOT NULL DEFAULT current_identity(),
 
+    CONSTRAINT metering_grid_area_business_id_check
+    CHECK (
+        validate_business_id(business_id, 'eic_x')
+    ),
     CONSTRAINT metering_grid_area_system_operator_fkey
     FOREIGN KEY (
         system_operator_id, system_operator_party_type

--- a/db/flex/metering_grid_area_migrations.sql
+++ b/db/flex/metering_grid_area_migrations.sql
@@ -1,0 +1,67 @@
+--liquibase formatted sql
+-- Manually managed file
+
+-- changeset flex:metering-grid-area-business-id-update-to-eic-y runOnChange:false endDelimiter:--
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM pg_catalog.pg_constraint WHERE conname = 'metering_grid_area_business_id_check' AND conbin::text LIKE '%101 105 99 95 120%'
+-- (NB: searching for the ASCII codes for "eic_x")
+ALTER TABLE flex.metering_grid_area
+DISABLE TRIGGER USER;
+
+ALTER TABLE flex.metering_grid_area
+DROP CONSTRAINT IF EXISTS
+metering_grid_area_business_id_check;
+
+-- change all X to Y in EIC codes for MGAs
+UPDATE flex.metering_grid_area
+SET
+    business_id
+    = substring(business_id, 1, 2) || 'Y'
+    || substring(business_id, 4, 12) || '-';
+-- initially set check digit to '-' (invalid) so it is recomputed
+
+
+-- The check digit computation can give '-' for some codes, which is invalid.
+-- To solve this, we need to change characters in the prefix until a valid code
+-- is found. We do it with a terminating loop that replaces a range of
+-- characters in the code with 'X' one by one until a valid code is found.
+DO
+$$
+DECLARE
+    i bigint;
+BEGIN
+    FOR i IN REVERSE 15..4 LOOP
+        -- recompute check digit on invalid codes
+        UPDATE flex.metering_grid_area
+        SET business_id = eic.add_check_char(left(business_id, 15))
+        WHERE right(business_id, 1) = '-';
+
+        -- change one character on codes that got '-' as check digit again
+        UPDATE flex.metering_grid_area
+        SET
+            business_id
+            = left(business_id, i - 1) || 'X' || right(business_id, 16 - i)
+        WHERE right(business_id, 1) = '-';
+
+        -- early exit if no invalid codes are left
+        EXIT WHEN NOT FOUND;
+    END LOOP;
+END
+$$;
+
+ALTER TABLE flex.metering_grid_area
+ADD CONSTRAINT metering_grid_area_business_id_check
+CHECK (
+    validate_business_id(business_id, 'eic_y')
+);
+
+-- update from main table to history will work because MGAs cannot be deleted
+UPDATE flex.metering_grid_area_history
+SET business_id = (
+    SELECT mga.business_id
+    FROM flex.metering_grid_area AS mga
+    WHERE mga.id = metering_grid_area_history.id
+);
+
+ALTER TABLE flex.metering_grid_area
+ENABLE TRIGGER USER;

--- a/db/flex/reference_data/business_id_type.csv
+++ b/db/flex/reference_data/business_id_type.csv
@@ -6,3 +6,4 @@ gsrn,Global Service Relation Number
 gln,Global Location Number
 uuid,Universally Unique IDentifier
 eic_x,Energy Identification Code (Market Parties)
+eic_y,Energy Identification Code (Grid Areas)

--- a/db/test_data/test_data.sql
+++ b/db/test_data/test_data.sql
@@ -571,10 +571,10 @@ AS $$
 DECLARE
     l_eic text;
 BEGIN
-    -- EIC of the form PPX-NNNN-NNNN--
+    -- EIC of the form PPY-NNNN-NNNN--
     -- where P is a character in the prefix and N is a character in the name
     l_eic := eic.add_check_char(
-        lpad(left(in_prefix::text, 2), 2, '0') || 'X-' ||
+        lpad(left(in_prefix::text, 2), 2, '0') || 'Y-' ||
         upper(replace(rpad(left(in_entity_name, 10), 10), ' ', '-')) || '-'
     );
 


### PR DESCRIPTION
This PR adds EIC-Y codes for grid areas. We were using EIC-X also for MGAs before, which is wrong.

The migration replaces the `X` with `Y` in the existing MGAs, but it has to take care of recomputing check digits and possibly changing the prefix so that it is correct.

For instance, changing `X` into `Y` in `42X-U----------D` (example of MGA business ID in the formerly used EIC-X format) turns the check digit into `-`, which is invalid. Checkable [here](https://www.entsoe.eu/data/energy-identification-codes-eic/code-generator/eic_key_generator). In such cases we need a procedure to update the prefix in a way that:
- is simple enough for us not to lose too much time on the task;
- potentially catches several rounds of `-` check digit;
- terminates, because we don't want an infinite loop in a migration.

I came up with the following solution: replace some characters with `X` (chosen randomly in the acceptable alphabet) until the check digit is valid.

TBH I haven't thought about the theoretical probability of the check digit being wrong several times, but I felt doing only one replace was not enough if you are very unlucky. And once I had the loop in place, why not loop on like ~10 characters. We early exit if everything is correct anyway. And now it's probably impossible to have any invalid code after that.

Draft because tests are broken in `main` (they still depend on hard-coded entity/party IDs in some places and we have been touching this data with our liquibase structure data updates) so I cannot ensure it is ready, even though I tested the migration manually and it looks right.