### PR TITLE
fix(test): remove hardcoded IDs for end user in tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -58,7 +58,7 @@ load: liquibase
         psql -X -v ON_ERROR_STOP=1 -d flex -U postgres \
             -c "BEGIN" \
             -c "SELECT set_config('flex.current_identity', '0', true);" \
-            -c "UPDATE flex.entity_client SET client_id = '${UUID}', public_key = '${PUBKEY}', client_secret='87h87hijhulO', recorded_by = 0 WHERE id = (SELECT e.id FROM flex.entity AS e WHERE name ilike '${entity}%' AND NOT name ilike '%AS');" \
+            -c "UPDATE flex.entity_client SET client_id = '${UUID}', public_key = '${PUBKEY}', client_secret='87h87hijhulO', recorded_by = 0 WHERE entity_id = (SELECT e.id FROM flex.entity AS e WHERE name ilike '${entity}%' AND NOT name ilike '%AS');" \
             -c "COMMIT"
     done
 
@@ -67,7 +67,7 @@ load: liquibase
     psql -X -v ON_ERROR_STOP=1 -d flex -U postgres \
         -c "BEGIN" \
         -c "SELECT set_config('flex.current_identity', '0', true);" \
-        -c "UPDATE flex.entity_client SET client_id = '${UUID_TESTAS}', client_secret='87h87hijhulO', recorded_by = 0 WHERE id = (SELECT e.id FROM flex.entity AS e WHERE name = 'Test Suite AS');" \
+        -c "UPDATE flex.entity_client SET client_id = '${UUID_TESTAS}', client_secret='87h87hijhulO', recorded_by = 0 WHERE entity_id = (SELECT e.id FROM flex.entity AS e WHERE name = 'Test Suite AS');" \
         -c "COMMIT"
 
     docker compose kill -s SIGUSR1 postgrest

--- a/test/api_client_tests/test_cu.py
+++ b/test/api_client_tests/test_cu.py
@@ -269,12 +269,14 @@ def test_controllable_unit_so(sts):
     )
     assert isinstance(spg, ServiceProvidingGroupResponse)
 
+    client_eu = sts.get_client(TestEntity.TEST, "EU")
+    eu_id = sts.get_userinfo(client_eu)["party_id"]
     cu_sp = create_controllable_unit_service_provider.sync(
         client=client_fiso,
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cast(int, cu.id),
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2024-01-01T00:00:00+1",
         ),
@@ -503,6 +505,9 @@ def test_controllable_unit_sp(sts):
     client_sp2 = sts.get_client(TestEntity.COMMON, "SP")
     sp2_id = sts.get_userinfo(client_sp2)["party_id"]
 
+    client_eu = sts.get_client(TestEntity.TEST, "EU")
+    eu_id = sts.get_userinfo(client_eu)["party_id"]
+
     cu = create_controllable_unit.sync(
         client=client_fiso,
         body=ControllableUnitCreateRequest(
@@ -525,7 +530,7 @@ def test_controllable_unit_sp(sts):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cast(int, cu.id),
             service_provider_id=sp1_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2099-01-01T00:00:00+1",
             valid_to=None,
@@ -571,7 +576,7 @@ def test_controllable_unit_sp(sts):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cast(int, cu.id),
             service_provider_id=sp1_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2099-01-01T00:00:00+1",
             valid_to=None,
@@ -585,7 +590,7 @@ def test_controllable_unit_sp(sts):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cast(int, cu.id),
             service_provider_id=sp2_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2000-01-01T00:00:00+1",
             valid_to="2090-01-01T00:00:00+1",

--- a/test/api_client_tests/test_cu_lookup.py
+++ b/test/api_client_tests/test_cu_lookup.py
@@ -226,9 +226,11 @@ def test_cu_lookup_params(sts):
 def test_cu_lookup_flow(sts):
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")
 
+    eu_userinfo = sts.get_userinfo(sts.get_client(TestEntity.TEST, "EU"))
+
     eu_entity = read_entity.sync(
         client=client_fiso,
-        id=sts.get_userinfo(sts.get_client(TestEntity.TEST))["entity_id"],
+        id=eu_userinfo["entity_id"],
     )
     assert isinstance(eu_entity, EntityResponse)
 
@@ -280,7 +282,7 @@ def test_cu_lookup_flow(sts):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cul.controllable_units[0].id,
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_userinfo["party_id"],
             contract_reference="TEST-CONTRACT",
             valid_from=midnight_n_days_diff(20),
         ),

--- a/test/api_client_tests/test_cusp.py
+++ b/test/api_client_tests/test_cusp.py
@@ -49,7 +49,10 @@ def data():
     )
     assert isinstance(cu, ControllableUnitResponse)
 
-    yield (sts, cu.id)
+    client_eu = cast(AuthenticatedClient, sts.get_client(TestEntity.TEST, "EU"))
+    eu_id = sts.get_userinfo(client_eu)["party_id"]
+
+    yield (sts, cu.id, eu_id)
 
 
 # ---- ---- ---- ---- ----
@@ -57,7 +60,7 @@ def data():
 
 # RLS: CUSP-FISO001
 def test_cusp_fiso(data):
-    (sts, cu_id) = data
+    (sts, cu_id, eu_id) = data
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")
 
     # create a CU-SP relation, check the visible list is one relation longer
@@ -77,7 +80,7 @@ def test_cusp_fiso(data):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cu_id,
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2020-01-01T00:00:00+1",
             valid_to=None,
@@ -181,7 +184,7 @@ def test_cusp_fiso(data):
 
 # RLS: CUSP-SP001
 def test_cusp_sp(data):
-    (sts, cu_id) = data
+    (sts, cu_id, eu_id) = data
 
     sp1_client = sts.get_client(TestEntity.TEST, "SP")
     sp1_id = sts.get_userinfo(sp1_client)["party_id"]
@@ -215,7 +218,7 @@ def test_cusp_sp(data):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cu_id,
             service_provider_id=sp1_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from=midnight_n_days_diff(-5),
         ),
@@ -229,7 +232,7 @@ def test_cusp_sp(data):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cu_id,
             service_provider_id=sp1_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from=midnight_n_days_diff(1),
         ),
@@ -243,7 +246,7 @@ def test_cusp_sp(data):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cu_id,
             service_provider_id=sp2_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from=midnight_n_days_diff(0),
         ),
@@ -257,7 +260,7 @@ def test_cusp_sp(data):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cu_id,
             service_provider_id=sp1_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT-2",
             valid_from=midnight_n_days_diff(16),
         ),
@@ -282,7 +285,7 @@ def test_cusp_sp(data):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cu_id,
             service_provider_id=sp1_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from=midnight_n_days_diff(16),
         ),
@@ -334,7 +337,7 @@ def test_cusp_sp(data):
 
 # RLS: CUSP-SO001
 def test_cusp_so(data):
-    (sts, _) = data
+    (sts, _, _) = data
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")
     client_so = sts.get_client(TestEntity.TEST, "SO")
 
@@ -367,7 +370,7 @@ def test_cusp_so(data):
 # RLS: CUSP-SO002
 # RLS: CUSP-SP002
 def test_cusp_history(data):
-    (sts, _) = data
+    (sts, _, _) = data
 
     for role in ["FISO", "SO", "SP"]:
         client = sts.get_client(TestEntity.TEST, role)
@@ -389,7 +392,7 @@ def test_cusp_history(data):
 # RLS: CUSP-EU001
 # RLS: CUSP-EU002
 def test_cusp_eu(data):
-    (sts, _) = data
+    (sts, _, _) = data
 
     # former AP end user can see the old version of the CU-SPs in the test data,
     # but not the current contracts
@@ -444,7 +447,7 @@ def test_cusp_eu(data):
 
 
 def test_rla_absence(data):
-    (sts, _) = data
+    (sts, _, _) = data
 
     roles_without_rla = ["BRP", "ES", "MO", "TP"]
 

--- a/test/api_client_tests/test_entity_lookup.py
+++ b/test/api_client_tests/test_entity_lookup.py
@@ -6,11 +6,9 @@ from flex.models import (
     EntityLookupRequest,
     EntityLookupRequestType,
     EntityLookupResponse,
-    EntityResponse,
     ErrorMessage,
 )
 from flex.api.entity import (
-    read_entity,
     list_entity,
     call_entity_lookup,
 )
@@ -103,12 +101,10 @@ def test_entity_lookup_params(sts):
 def test_entity_lookup_fiso(sts):
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")
 
-    e = read_entity.sync(
-        client=client_fiso,
-        id=1,
-    )
-    assert isinstance(e, EntityResponse)
-    assert e.business_id == "13370000000"
+    es = list_entity.sync(client=client_fiso, business_id="eq.13370000000")
+    assert isinstance(es, list)
+    assert len(es) == 1
+    ent_id = es[0].id
 
     # lookup existing entity
     el = call_entity_lookup.sync(
@@ -121,7 +117,7 @@ def test_entity_lookup_fiso(sts):
     )
     assert isinstance(el, EntityLookupResponse)
 
-    assert el.entity_id == e.id
+    assert el.entity_id == ent_id
 
     def random_number(length):
         return "".join([random.choice(string.digits) for _ in range(length)])

--- a/test/api_client_tests/test_event.py
+++ b/test/api_client_tests/test_event.py
@@ -184,6 +184,9 @@ def test_event_sp(sts):
     client_so = sts.fresh_client(TestEntity.TEST, "SO")
     so_id = sts.get_userinfo(client_so)["party_id"]
 
+    client_eu = sts.fresh_client(TestEntity.TEST, "EU")
+    eu_id = sts.get_userinfo(client_eu)["party_id"]
+
     cu = create_controllable_unit.sync(
         client=client_fiso,
         body=ControllableUnitCreateRequest(
@@ -228,7 +231,7 @@ def test_event_sp(sts):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cast(int, cu.id),
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="EVENT-TEST-CONTRACT",
             valid_from="2020-01-01T00:00:00+1",
             valid_to=None,

--- a/test/api_client_tests/test_spg.py
+++ b/test/api_client_tests/test_spg.py
@@ -50,6 +50,9 @@ def sts():
 def test_spg_fiso_sp(sts):
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")
 
+    client_eu = sts.get_client(TestEntity.TEST, "EU")
+    eu_id = sts.get_userinfo(client_eu)["party_id"]
+
     # RLS: SPG-FISO001
     # RLS: SPG-SP001
 
@@ -109,7 +112,7 @@ def test_spg_fiso_sp(sts):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cast(int, cu.id),
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2024-01-01T00:00:00+1",
         ),

--- a/test/api_client_tests/test_spg_grid_prequalification.py
+++ b/test/api_client_tests/test_spg_grid_prequalification.py
@@ -113,12 +113,15 @@ def data():
 
     # relate the CUs to the SP in charge of the test SPG
 
+    client_eu = cast(AuthenticatedClient, sts.get_client(TestEntity.TEST, "EU"))
+    eu_id = sts.get_userinfo(client_eu)["party_id"]
+
     cu_sp1 = create_controllable_unit_service_provider.sync(
         client=client_fiso,
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cast(int, cu1.id),
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2024-01-01T00:00:00+1",
         ),
@@ -130,7 +133,7 @@ def data():
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cast(int, cu2.id),
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2024-01-01T00:00:00+1",
         ),
@@ -142,7 +145,7 @@ def data():
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cast(int, cu3.id),
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2024-01-01T00:00:00+1",
         ),

--- a/test/api_client_tests/test_spg_membership.py
+++ b/test/api_client_tests/test_spg_membership.py
@@ -54,6 +54,9 @@ def data():
     client_sp = cast(AuthenticatedClient, sts.get_client(TestEntity.TEST, "SP"))
     sp_id = sts.get_userinfo(client_sp)["party_id"]
 
+    client_eu = cast(AuthenticatedClient, sts.get_client(TestEntity.TEST, "EU"))
+    eu_id = sts.get_userinfo(client_eu)["party_id"]
+
     # Create new controllable unit and spg to play with
     cu = create_controllable_unit.sync(
         client=client_fiso,
@@ -77,14 +80,14 @@ def data():
     )
     assert isinstance(spg, ServiceProvidingGroupResponse)
 
-    yield (sts, cu.id, spg.id)
+    yield (sts, cu.id, spg.id, eu_id)
 
 
 # ---- ---- ---- ---- ----
 
 
 def test_cusp_spgm_consistency_not_ok(data):
-    (sts, cu_id, spg_id) = data
+    (sts, cu_id, spg_id, eu_id) = data
 
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")
 
@@ -98,7 +101,7 @@ def test_cusp_spgm_consistency_not_ok(data):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cu_id,
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2024-01-08T00:00:00+1",
             valid_to="2024-01-12T00:00:00+1",
@@ -135,7 +138,7 @@ def test_cusp_spgm_consistency_not_ok(data):
 
 # RLS: SPGM-SP002
 def test_spgm_sp002(data):
-    (sts, cu_id, spg_id) = data
+    (sts, cu_id, spg_id, eu_id) = data
 
     client_sp = sts.get_client(TestEntity.TEST, "SP")
 
@@ -163,7 +166,7 @@ def test_spgm_sp002(data):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cu_id,
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2024-01-08T00:00:00+1",
             valid_to="2024-01-12T00:00:00+1",
@@ -209,7 +212,7 @@ def test_spgm_sp002(data):
 
 
 def test_spgm(data):
-    (sts, cu_id, spg_id) = data
+    (sts, cu_id, spg_id, eu_id) = data
 
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")
 
@@ -224,7 +227,7 @@ def test_spgm(data):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cu_id,
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2024-01-08T00:00:00+1",
             valid_to="2024-01-12T00:00:00+1",
@@ -343,7 +346,7 @@ def test_spgm(data):
 
 
 def test_spgm_so(data):
-    (sts, cu_id, spg_id) = data
+    (sts, cu_id, spg_id, eu_id) = data
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")
 
     # add a contract between CU and SP, add CU to the SPG
@@ -354,7 +357,7 @@ def test_spgm_so(data):
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cu_id,
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2024-01-09T00:00:00+1",
         ),
@@ -442,7 +445,7 @@ def test_spgm_so(data):
 
 
 def test_rla_absence(data):
-    (sts, _, _) = data
+    (sts, _, _, _) = data
 
     roles_without_rla = ["BRP", "EU", "ES", "MO", "TP"]
 

--- a/test/api_client_tests/test_spg_product_application.py
+++ b/test/api_client_tests/test_spg_product_application.py
@@ -90,6 +90,12 @@ def data():
     )
     other_so_id = sts.get_userinfo(client_other_so)["party_id"]
 
+    client_eu = cast(
+        AuthenticatedClient,
+        sts.fresh_client(TestEntity.TEST, "EU"),
+    )
+    eu_id = sts.get_userinfo(client_eu)["party_id"]
+
     # create 2 SPGs and activate them
     cu = create_controllable_unit.sync(
         client=client_fiso,
@@ -107,7 +113,7 @@ def data():
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cast(int, cu.id),
             service_provider_id=sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="TEST-CONTRACT",
             valid_from="2024-01-01T00:00:00+1",
         ),

--- a/test/api_client_tests/test_technical_resource.py
+++ b/test/api_client_tests/test_technical_resource.py
@@ -405,12 +405,14 @@ def test_tr_sp(sts):
     # add common CUSP from today midnight on new CU
 
     common_sp_id = sts.get_userinfo(client_common_sp)["party_id"]
+    client_eu = sts.get_client(TestEntity.TEST, "EU")
+    eu_id = sts.get_userinfo(client_eu)["party_id"]
     cusp_common = create_controllable_unit_service_provider.sync(
         client=client_fiso,
         body=ControllableUnitServiceProviderCreateRequest(
             controllable_unit_id=cu_id,
             service_provider_id=common_sp_id,
-            end_user_id=11,
+            end_user_id=eu_id,
             contract_reference="1111r4128",
             valid_from=f"{date.today().isoformat()} Europe/Oslo",
         ),


### PR DESCRIPTION
This PR makes the tests independent from ranking of entities/parties to point at the test end user, which makes them green again.

It also fixes a latent bug we had when setting hardcoded entity client IDs for some of the test users. Indeed, everything used to go fine because there was probably one entity client per entity in the test set, so IDs were aligned and we did not notice the wrong field there.