### PR TITLE
feat(db): make definition of human user stricter for ECL-ORG002 (FLEX-691)

### DIFF
--- a/db/flex/entity_client_migrations.sql
+++ b/db/flex/entity_client_migrations.sql
@@ -69,8 +69,9 @@ END;
 $$;
 
 -- changeset flex:entity-client-check-assumable-party-trigger runOnChange:true endDelimiter:--
+-- ECL-VAL001
 CREATE OR REPLACE TRIGGER entity_client_check_assumable_party
-BEFORE UPDATE ON entity_client
+BEFORE INSERT OR UPDATE ON entity_client
 FOR EACH ROW
 WHEN (new.party_id IS NOT null)
 EXECUTE FUNCTION entity_client_check_assumable_party();

--- a/db/flex/entity_client_rls.sql
+++ b/db/flex/entity_client_rls.sql
@@ -24,11 +24,14 @@ CREATE OR REPLACE FUNCTION user_is_human()
 RETURNS boolean
 SECURITY INVOKER
 LANGUAGE sql
+STABLE
 AS $$
-    -- TODO: also check the user did login without an entity client
     SELECT EXISTS (
-        SELECT 1 FROM flex.entity AS e
-        WHERE e.id = (SELECT flex.current_entity()) AND e.type = 'person'
+        SELECT 1 FROM flex.identity AS i
+            INNER JOIN flex.entity AS e ON i.entity_id = e.id
+        WHERE i.id = (SELECT flex.current_identity())
+            AND e.type = 'person'
+            AND i.client_id IS null
     )
 $$;
 

--- a/docs/resources/entity_client.md
+++ b/docs/resources/entity_client.md
@@ -25,7 +25,9 @@ methods. An entity can have several clients registered.
 
 ## Validation Rules
 
-No validation rules.
+| Validation rule key | Validation rule                                               | Status |
+|---------------------|---------------------------------------------------------------|--------|
+| ECL-VAL001          | Entity clients can only target a party the entity can assume. | DONE   |
 
 ## Notifications
 


### PR DESCRIPTION
This PR restricts our definition of _human user_ (for access to entity clients as organisation party) to both the following checks:
- the current entity is a _person_ entity;
- user _not_ logged in through an entity client.

The first condition was already being checked, the second is now checked by reading the current identity (possible since #274).

As also explained in a comment, by restricting to human users, we lose the ability to test the positive case of this policy, but testing manually shows this works.

> [!NOTE]
> On the side, I noticed that our trigger restricting `party_id` on entity clients was not running on insert. This is now fixed. It is not a critical fix, because anyway we do that kind of check server-side (`auth.assume_party`), but it reduces confusion.
> If `party_id` is not null, then it should point to a party the entity actually can assume. Now documented as a validation rule.