### PR TITLE
docs: fix alert in get ready for market to GH style

### DIFF
--- a/docs-dev/documentation.md
+++ b/docs-dev/documentation.md
@@ -1,6 +1,9 @@
 # Documentation
 
 Documentation is published with
-[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/).
+[Material for MkDocs](https://squidfunk.github.io/mkdocs-material/). We are
+using the
+[Github callout](https://github.com/oprypin/markdown-callouts?tab=readme-ov-file#support-github-alerts-style-of-admonitions)
+format for admonitions.
 
 We are following documentation as code.

--- a/docs-dev/tooling.md
+++ b/docs-dev/tooling.md
@@ -47,6 +47,7 @@ We are relying on the markdown linting tools made by David Anson.
 To make life easier in VSCode, consider installing the following extensions:
 
 * [marvhen.reflow-markdown](https://marketplace.visualstudio.com/items?itemName=marvhen.reflow-markdown)
+* [saeris.markdown-github-alerts](https://marketplace.visualstudio.com/items?itemName=saeris.markdown-github-alerts)
 * [yzhang.markdown-all-in-one](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one)
 
 ### SQL

--- a/docs/guides/get-ready-for-market.md
+++ b/docs/guides/get-ready-for-market.md
@@ -9,6 +9,12 @@ The diagram below highlights the key steps and their dependencies. It is not a
 map of all the processes, but shows the processes required for service providers
 and system operators to participate in the market.
 
+> [!TIP]
+>
+> For a detailed definition of when a service providing group (SPG) is
+> considered *ready for market*, check the
+> [Ready for market](../concepts/ready-for-market.md) concept page.
+
 ## Prerequisites
 
 * System operator is registered in FIS.
@@ -19,17 +25,17 @@ and system operators to participate in the market.
 The registration and qualification steps can be grouped into two purposes,
 which explains why these processes are necessary for market participation:
 
-1. **Ensuring safe operation**  
+1. **Ensuring safe operation**
 Covers the technical registration of controllable units and the formation of
 service providing groups. This ensures that units do not compromise system
 security when participating in the market.
-Approved by connecting/impacted system operators.  
+Approved by connecting/impacted system operators.
 
-2. **Ensuring delivery capability**  
+2. **Ensuring delivery capability**
 Covers product applications and (pre)qualification steps for both service
 providers and service providing groups. This ensures that the provider can
 actually deliver the requested product type according to the requirements.
-Approved by procuring system operators.  
+Approved by procuring system operators.
 
 ## Registration and Qualification Overview
 
@@ -57,8 +63,3 @@ We are using the following notation:
     * `red` - flexibility information system operator
     * `white` - unspecified
 * `arrows` - dependencies between processes
-
-!!! note "For a detailed definition of when a Service Providing Group (SPG) is
-considered *ready for market*"
-
-    See the [Ready for market](../concepts/ready_for_market.md) concept page.


### PR DESCRIPTION
I moved it up a bit. Looks like this now:

<img width="1040" height="704" alt="bilde" src="https://github.com/user-attachments/assets/b414c4a0-a961-416f-81ae-95d090a82853" />
