### PR TITLE
feat: generate tables for comment resources (FLEX-792)

### DIFF
--- a/db/flex/service_provider_product_application_comment.sql
+++ b/db/flex/service_provider_product_application_comment.sql
@@ -1,8 +1,7 @@
 --liquibase formatted sql
--- Manually managed file
+-- GENERATED CODE -- DO NOT EDIT (scripts/openapi_to_db.py)
 
--- changeset flex:service-provider-product-application-comment-create runOnChange:false endDelimiter:--
--- validCheckSum: 9:97f1f204aa46130c720cd3b63b49cb8d
+-- changeset flex:service-provider-product-application-comment-create runOnChange:true endDelimiter:--
 CREATE TABLE IF NOT EXISTS service_provider_product_application_comment (
     id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     service_provider_product_application_id bigint NOT NULL,
@@ -30,7 +29,10 @@ CREATE TABLE IF NOT EXISTS service_provider_product_application_comment (
 );
 
 -- changeset flex:service-provider-product-application-comment-capture-event runOnChange:true endDelimiter:--
-CREATE OR REPLACE TRIGGER service_provider_product_application_comment_event
-AFTER INSERT OR UPDATE ON service_provider_product_application_comment
+CREATE OR REPLACE TRIGGER
+service_provider_product_application_comment_event
+AFTER INSERT OR UPDATE
+ON service_provider_product_application_comment
 FOR EACH ROW
-EXECUTE FUNCTION capture_event('service_provider_product_application_comment');
+EXECUTE FUNCTION
+capture_event('service_provider_product_application_comment');

--- a/db/flex/service_provider_product_suspension_comment.sql
+++ b/db/flex/service_provider_product_suspension_comment.sql
@@ -1,8 +1,7 @@
 --liquibase formatted sql
--- Manually managed file
+-- GENERATED CODE -- DO NOT EDIT (scripts/openapi_to_db.py)
 
--- changeset flex:service-provider-product-suspension-comment-create runOnChange:false endDelimiter:--
--- validCheckSum: 9:5e2a329a77b6d2feb6c1a208c0551e16
+-- changeset flex:service-provider-product-suspension-comment-create runOnChange:true endDelimiter:--
 CREATE TABLE IF NOT EXISTS service_provider_product_suspension_comment (
     id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     service_provider_product_suspension_id bigint NOT NULL,
@@ -24,14 +23,17 @@ CREATE TABLE IF NOT EXISTS service_provider_product_suspension_comment (
             'any_involved_party'
         )
     ),
-    CONSTRAINT service_provider_product_suspension_comment_sppa_fkey
+    CONSTRAINT service_provider_product_suspension_comment_spps_fkey
     FOREIGN KEY (service_provider_product_suspension_id)
     REFERENCES service_provider_product_suspension (id)
     ON DELETE CASCADE
 );
 
 -- changeset flex:service-provider-product-suspension-comment-capture-event runOnChange:true endDelimiter:--
-CREATE OR REPLACE TRIGGER service_provider_product_suspension_comment_event
-AFTER INSERT OR UPDATE ON service_provider_product_suspension_comment
+CREATE OR REPLACE TRIGGER
+service_provider_product_suspension_comment_event
+AFTER INSERT OR UPDATE
+ON service_provider_product_suspension_comment
 FOR EACH ROW
-EXECUTE FUNCTION capture_event('service_provider_product_suspension_comment');
+EXECUTE FUNCTION
+capture_event('service_provider_product_suspension_comment');

--- a/db/flex/service_provider_product_suspension_comment_migrations.sql
+++ b/db/flex/service_provider_product_suspension_comment_migrations.sql
@@ -1,16 +1,6 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:service-provider-product-suspension-comment-on-delete-cascade runOnChange:false endDelimiter:;
-ALTER TABLE flex.service_provider_product_suspension_comment
-DROP CONSTRAINT IF EXISTS service_provider_product_suspension_comment_sppa_fkey;
-
-ALTER TABLE flex.service_provider_product_suspension_comment
-ADD CONSTRAINT service_provider_product_suspension_comment_sppa_fkey
-FOREIGN KEY (service_provider_product_suspension_id)
-REFERENCES service_provider_product_suspension (id)
-ON DELETE CASCADE;
-
 -- changeset flex:service-provider-product-suspension-comment-visibility-update runOnChange:false endDelimiter:;
 --preconditions onFail:MARK_RAN
 --precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM pg_catalog.pg_constraint WHERE conname = 'service_provider_product_suspension_comment_visibility_check' AND conbin::text LIKE '%115 97 109 101 95 112 97 114 116 121 95 116 121 112 101%'
@@ -53,3 +43,12 @@ WHERE visibility = 'any_party';
 UPDATE flex.service_provider_product_suspension_comment_history
 SET visibility = 'same_party'
 WHERE visibility = 'same_party_type';
+
+-- changeset flex:service-provider-product-suspension-comment-constraint-typo runOnChange:false endDelimiter:;
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:1 SELECT COUNT(*) FROM pg_catalog.pg_constraint WHERE conname = 'service_provider_product_suspension_comment_sppa_fkey'
+ALTER TABLE flex.service_provider_product_suspension_comment
+RENAME CONSTRAINT
+service_provider_product_suspension_comment_sppa_fkey
+TO
+service_provider_product_suspension_comment_spps_fkey;

--- a/local/scripts/openapi_to_db.py
+++ b/local/scripts/openapi_to_db.py
@@ -2,7 +2,6 @@
 import yaml
 import sys
 import j2
-from copy import deepcopy
 
 """
 This script generates SQL statements to create views in the `api` schema,
@@ -129,9 +128,14 @@ if __name__ == "__main__":
 
             # generate files for the comment resource
             if resource.get("comments", False):
-                base_resource = deepcopy(resource)
+                j2.template(
+                    resource,
+                    "comment_resource.j2.sql",
+                    f"{DB_DIR}/flex/{resource['id']}_comment.sql",
+                )
+
                 resource = yaml.safe_load(
-                    j2.template_str(base_resource, "comment_resource.j2.yml"),
+                    j2.template_str(resource, "comment_resource.j2.yml"),
                 )["data"]
 
                 print(

--- a/local/scripts/templates/comment_resource.j2.sql
+++ b/local/scripts/templates/comment_resource.j2.sql
@@ -1,0 +1,45 @@
+--liquibase formatted sql
+-- GENERATED CODE -- DO NOT EDIT (scripts/openapi_to_db.py)
+
+{%- set liquibase_resource = resource | replace("_", "-") %}
+{%- set base_resource_ops = data.operations | list %}
+{%- set base_resource_initials = resource.split('_') | map('first') | join  %}
+
+-- changeset flex:{{ liquibase_resource }}-comment-create runOnChange:true endDelimiter:--
+CREATE TABLE IF NOT EXISTS {{ resource }}_comment (
+    id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    {{ resource }}_id bigint NOT NULL,
+    visibility text NOT NULL DEFAULT 'same_party',
+    content text NULL CHECK (
+        char_length(content) <= 2048
+    ),
+    created_by bigint NOT NULL DEFAULT current_identity(),
+    created_at timestamp with time zone NOT NULL DEFAULT current_timestamp,
+    record_time_range tstzrange NOT NULL DEFAULT tstzrange(
+        localtimestamp, null, '[)'
+    ),
+    recorded_by bigint NOT NULL DEFAULT current_identity(),
+
+    CONSTRAINT {{ resource }}_comment_visibility_check
+    CHECK (
+        visibility IN (
+            'same_party',
+            'any_involved_party'
+        )
+    ),
+    CONSTRAINT {{ resource }}_comment_{{ base_resource_initials }}_fkey
+    FOREIGN KEY ({{ resource }}_id)
+    REFERENCES {{ resource }} (id)
+    {%- if "delete" in base_resource_ops %}
+    ON DELETE CASCADE
+    {%- endif %}
+);
+
+-- changeset flex:{{ liquibase_resource }}-comment-capture-event runOnChange:true endDelimiter:--
+CREATE OR REPLACE TRIGGER
+{{ resource }}_comment_event
+AFTER INSERT OR UPDATE
+ON {{ resource }}_comment
+FOR EACH ROW
+EXECUTE FUNCTION
+capture_event('{{ resource }}_comment');


### PR DESCRIPTION
This PR turns generation of comment tables on again.

We needed one little migration to fix a typo, and an old migration impacting the constraint name was removed (since it has been a while, we know it has already been run).

We get rid of checksums by using `runOnChange:true`. Since we use `IF NOT EXISTS`, the table is not impacted even if changes are made in this definition, so we are safe to go. The real changes will happen in the migrations file.