### PR TITLE
fix: rename parameter in latest visibility function for SPGGSC (FLEX-808)

### DIFF
--- a/db/flex/service_providing_group_grid_suspension_comment_rls.sql
+++ b/db/flex/service_providing_group_grid_suspension_comment_rls.sql
@@ -82,7 +82,8 @@ USING (
     )
 );
 
-CREATE OR REPLACE FUNCTION spggs_comment_latest_visibility(id bigint)
+DROP FUNCTION IF EXISTS spggs_comment_latest_visibility(bigint);
+CREATE OR REPLACE FUNCTION spggs_comment_latest_visibility(in_spggsc_id bigint)
 RETURNS text
 SECURITY DEFINER
 LANGUAGE sql
@@ -94,14 +95,14 @@ AS $$
                 spggsc.visibility,
                 spggsc.record_time_range
             FROM flex.service_providing_group_grid_suspension_comment AS spggsc
-            WHERE spggsc.id = id
+            WHERE spggsc.id = in_spggsc_id
             UNION ALL
             SELECT
                 spggsch.visibility,
                 spggsch.record_time_range
             FROM flex.service_providing_group_grid_suspension_comment_history
                 AS spggsch -- noqa
-            WHERE spggsch.id = id
+            WHERE spggsch.id = in_spggsc_id
         )
 
     SELECT spggs_history.visibility


### PR DESCRIPTION
This PR renames a parameter in the function giving latest visibility for a SPGGS comment.

This change is not strictly necessary before actually using the generation mechanism, but since the former parameter name `id` is also the name of a field in the tables, we got a bug in https://github.com/elhub/flex-information-system/pull/365 because of this. Fixed by renaming + adding a prefix.

> [!NOTE]
> The changes in this PR are temporary anyway, the point is to deploy this hotfix so the automation PR is accepted by Liquibase.