### PR TITLE
fix(ui): represent recorded_by field with IdentityField (FLEX-837)

### DIFF
--- a/frontend/src/service_providing_group/grid_suspension/ServiceProvidingGroupGridSuspensionShow.tsx
+++ b/frontend/src/service_providing_group/grid_suspension/ServiceProvidingGroupGridSuspensionShow.tsx
@@ -17,6 +17,7 @@ import { EventButton } from "../../event/EventButton";
 import { DateField } from "../../components/datetime";
 import { FieldStack } from "../../auth";
 import { CommentList } from "../../components/comments";
+import { IdentityField } from "../../components/IdentityField";
 
 export const ServiceProvidingGroupGridSuspensionShow = () => {
   const resource = useResourceContext()!;
@@ -76,7 +77,7 @@ export const ServiceProvidingGroupGridSuspensionShow = () => {
           <FieldStack direction="row" flexWrap="wrap" spacing={2}>
             <TextField source="reason" />
             <DateField source="recorded_at" showTime />
-            <DateField source="recorded_by" showTime />
+            <IdentityField source="recorded_by" />
           </FieldStack>
         </Stack>
         {!isHistory && <EventButton />}

--- a/frontend/src/service_providing_group/product_suspension/ServiceProvidingGroupProductSuspensionShow.tsx
+++ b/frontend/src/service_providing_group/product_suspension/ServiceProvidingGroupProductSuspensionShow.tsx
@@ -18,6 +18,7 @@ import { DateField } from "../../components/datetime";
 import { FieldStack } from "../../auth";
 import { CommentList } from "../../components/comments";
 import { ProductTypeArrayField } from "../../product_type/components";
+import { IdentityField } from "../../components/IdentityField";
 
 export const ServiceProvidingGroupProductSuspensionShow = () => {
   const resource = useResourceContext()!;
@@ -78,7 +79,7 @@ export const ServiceProvidingGroupProductSuspensionShow = () => {
           <FieldStack direction="row" flexWrap="wrap" spacing={2}>
             <TextField source="reason" />
             <DateField source="recorded_at" showTime />
-            <DateField source="recorded_by" showTime />
+            <IdentityField source="recorded_by" />
           </FieldStack>
         </Stack>
         {!isHistory && <EventButton />}


### PR DESCRIPTION
This PR fixes the format of identities in a few pages where we were using `DateField`. Probably a copy-paste mistake from before.