### PR TITLE
fix(ui): remove Show button from Edit pages (FLEX-797)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -475,9 +475,9 @@ export const App = () => (
             }
             edit={
               permissions.includes("entity.update") ? (
-                <Edit mutationMode="pessimistic">
+                <EditRedirectPreviousPage>
                   <EntityInput />
-                </Edit>
+                </EditRedirectPreviousPage>
               ) : (
                 (null as any)
               )
@@ -514,14 +514,9 @@ export const App = () => (
               path=":entity_id/client/:id"
               element={
                 <ResourceContextProvider value="entity_client">
-                  <Edit
-                    mutationMode="pessimistic"
-                    redirect={(_: any, _id: any, record: any) =>
-                      `entity/${record.entity_id}/show`
-                    }
-                  >
+                  <EditRedirectPreviousPage>
                     <EntityClientInput />
-                  </Edit>
+                  </EditRedirectPreviousPage>
                 </ResourceContextProvider>
               }
             />
@@ -534,9 +529,9 @@ export const App = () => (
             show={PartyShow}
             edit={
               permissions.includes("party.update") ? (
-                <Edit mutationMode="pessimistic">
+                <EditRedirectPreviousPage>
                   <PartyInput />
-                </Edit>
+                </EditRedirectPreviousPage>
               ) : (
                 (null as any)
               )
@@ -590,14 +585,9 @@ export const App = () => (
               path=":party_id/membership/:id"
               element={
                 <ResourceContextProvider value="party_membership">
-                  <Edit
-                    mutationMode="pessimistic"
-                    redirect={(_: any, _id: any, record: any) =>
-                      `party/${record.party_id}/show`
-                    }
-                  >
+                  <EditRedirectPreviousPage>
                     <PartyMembershipInput />
-                  </Edit>
+                  </EditRedirectPreviousPage>
                 </ResourceContextProvider>
               }
             />
@@ -624,9 +614,9 @@ export const App = () => (
             icon={BookmarkIcon}
             edit={
               permissions.includes("controllable_unit.update") ? (
-                <Edit mutationMode="pessimistic">
+                <EditRedirectPreviousPage>
                   <ControllableUnitInput />
-                </Edit>
+                </EditRedirectPreviousPage>
               ) : (
                 (null as any)
               )
@@ -694,14 +684,9 @@ export const App = () => (
               path=":controllable_unit_id/service_provider/:id"
               element={
                 <ResourceContextProvider value="controllable_unit_service_provider">
-                  <Edit
-                    mutationMode="pessimistic"
-                    redirect={(_: any, _id: any, record: any) =>
-                      `controllable_unit/${record.controllable_unit_id}/show`
-                    }
-                  >
+                  <EditRedirectPreviousPage>
                     <ControllableUnitServiceProviderInput />
-                  </Edit>
+                  </EditRedirectPreviousPage>
                 </ResourceContextProvider>
               }
             />
@@ -751,14 +736,9 @@ export const App = () => (
               path=":controllable_unit_id/technical_resource/:id"
               element={
                 <ResourceContextProvider value="technical_resource">
-                  <Edit
-                    mutationMode="pessimistic"
-                    redirect={(_: any, _id: any, record: any) =>
-                      `controllable_unit/${record.controllable_unit_id}/show`
-                    }
-                  >
+                  <EditRedirectPreviousPage>
                     <TechnicalResourceInput />
-                  </Edit>
+                  </EditRedirectPreviousPage>
                 </ResourceContextProvider>
               }
             />
@@ -801,9 +781,9 @@ export const App = () => (
             show={ServiceProvidingGroupShow}
             edit={
               permissions.includes("service_providing_group.update") ? (
-                <Edit mutationMode="pessimistic">
+                <EditRedirectPreviousPage>
                   <ServiceProvidingGroupInput />
-                </Edit>
+                </EditRedirectPreviousPage>
               ) : (
                 (null as any)
               )
@@ -1529,6 +1509,7 @@ const EditRedirectPreviousPage = (props: any) => {
 
   return (
     <Edit
+      actions={false} // disable potential Show button
       mutationMode="pessimistic"
       mutationOptions={{ onSuccess: () => navigate(-1) }}
     >


### PR DESCRIPTION
This PR removes the `Show` button in `Edit` pages. It did not work correctly with nested resources.

---

### Why these resources and not others?

I am still unsure about why this button was there in some pages and not in others. Maybe this has to do with being declared as a toplevel resource or not. Anyway, with the proposed solution, we don't have to care.

---

### Notes

As we had introduced previously a custom wrapper for `Edit` to control redirects, I thought it was better to just explicitly disable the Show button in this common component and use it for all edit pages of the app, instead of sprinkling `actions={false}` a bit everywhere. We make the behaviour uniform, and the jump-to-previous-page logic was already present anyway, in a hardcoded version.

Also, since we are going to remove the `/show` URL at some point, it makes a few less changes to think about when we work on this future task. We could have normalised the use of the `Create` wrapper as well. But then it is a bit out of scope and the redirects may be a bit more useful. I thought we could see that somewhat unrelated part later.