### PR TITLE
fix: correct and updated notification recipient queries for SPGGS/SPGPS

### DIFF
--- a/backend/event/models.sql
+++ b/backend/event/models.sql
@@ -312,9 +312,9 @@ WHERE spggsh.service_providing_group_grid_suspension_id = @resource_id
     AND tstzrange(spgpah.recorded_at, spgpah.replaced_at, '[]')
         @> @recorded_at::timestamptz
     AND (
-        spgpa.status IN ('verified', 'prequalified')
-        OR spgpa.verified_at IS NOT null
-        OR spgpa.prequalified_at IS NOT null
+        spgpah.status IN ('verified', 'prequalified', 'temporary_qualified')
+        OR spgpah.verified_at IS NOT null
+        OR spgpah.prequalified_at IS NOT null
     );
 
 -- name: GetServiceProvidingGroupGridSuspensionCommentNotificationRecipients :many
@@ -361,9 +361,9 @@ WHERE spgpsh.service_providing_group_product_suspension_id = @resource_id
     AND tstzrange(spgpah.recorded_at, spgpah.replaced_at, '[]')
         @> @recorded_at::timestamptz
     AND (
-        spgpa.status IN ('verified', 'prequalified', 'temporary_qualified')
-        OR spgpa.verified_at IS NOT null
-        OR spgpa.prequalified_at IS NOT null
+        spgpah.status IN ('verified', 'prequalified', 'temporary_qualified')
+        OR spgpah.verified_at IS NOT null
+        OR spgpah.prequalified_at IS NOT null
     );
 
 -- name: GetServiceProvidingGroupProductSuspensionCommentNotificationRecipients :many

--- a/backend/event/models/models.sql.go
+++ b/backend/event/models/models.sql.go
@@ -488,35 +488,33 @@ WHERE spggsh.service_providing_group_grid_suspension_id = $1
     AND tstzrange(spggsh.recorded_at, spggsh.replaced_at, '[]')
         @> $2::timestamptz
 UNION ALL
-SELECT spggp.impacted_system_operator_id
+SELECT spggph.impacted_system_operator_id
 FROM service_providing_group_grid_suspension_history AS spggsh
-    INNER JOIN service_providing_group_grid_prequalification AS spggp
-        ON spggsh.service_providing_group_id = spggp.service_providing_group_id
-    -- SPGGP cannot be deleted + ISO does not change
-    -- we want to notify the ISOs currently having approved prequalifications
-    -- we also want to notify possible new ISOs coming after the suspension
+    INNER JOIN service_providing_group_grid_prequalification_history AS spggph
+        ON spggsh.service_providing_group_id = spggph.service_providing_group_id
 WHERE spggsh.service_providing_group_grid_suspension_id = $1
     AND tstzrange(spggsh.recorded_at, spggsh.replaced_at, '[]')
         @> $2::timestamptz
+    AND tstzrange(spggph.recorded_at, spggph.replaced_at, '[]')
+        @> $2::timestamptz
     AND (
-        spggp.status IN ('approved', 'conditionally_approved')
-        OR spggp.prequalified_at IS NOT null
+        spggph.status IN ('approved', 'conditionally_approved')
+        OR spggph.prequalified_at IS NOT null
     )
 UNION ALL
-SELECT spgpa.procuring_system_operator_id
+SELECT spgpah.procuring_system_operator_id
 FROM service_providing_group_grid_suspension_history AS spggsh
-    INNER JOIN service_providing_group_product_application AS spgpa
-        ON spggsh.service_providing_group_id = spgpa.service_providing_group_id
-    -- SPGPA cannot be deleted + PSO does not change
-    -- we want to notify the PSOs currently having accepted product applications
-    -- we also want to notify possible new PSOs coming after the suspension
+    INNER JOIN service_providing_group_product_application_history AS spgpah
+        ON spggsh.service_providing_group_id = spgpah.service_providing_group_id
 WHERE spggsh.service_providing_group_grid_suspension_id = $1
     AND tstzrange(spggsh.recorded_at, spggsh.replaced_at, '[]')
         @> $2::timestamptz
+    AND tstzrange(spgpah.recorded_at, spgpah.replaced_at, '[]')
+        @> $2::timestamptz
     AND (
-        spgpa.status IN ('verified', 'prequalified')
-        OR spgpa.verified_at IS NOT null
-        OR spgpa.prequalified_at IS NOT null
+        spgpah.status IN ('verified', 'prequalified', 'temporary_qualified')
+        OR spgpah.verified_at IS NOT null
+        OR spgpah.prequalified_at IS NOT null
     )
 `
 
@@ -675,20 +673,19 @@ WHERE spgpsh.service_providing_group_product_suspension_id = $1
     AND tstzrange(spgpsh.recorded_at, spgpsh.replaced_at, '[]')
         @> $2::timestamptz
 UNION ALL
-SELECT spgpa.procuring_system_operator_id
+SELECT spgpah.procuring_system_operator_id
 FROM service_providing_group_product_suspension_history AS spgpsh
-    -- SPGPA cannot be deleted + PSO does not change
-    -- we want to notify the PSOs currently having accepted product applications
-    -- we also want to notify possible new PSOs coming after the suspension
-    INNER JOIN service_providing_group_product_application AS spgpa
-        ON spgpsh.service_providing_group_id = spgpa.service_providing_group_id
+    INNER JOIN service_providing_group_product_application_history AS spgpah
+        ON spgpsh.service_providing_group_id = spgpah.service_providing_group_id
 WHERE spgpsh.service_providing_group_product_suspension_id = $1
     AND tstzrange(spgpsh.recorded_at, spgpsh.replaced_at, '[]')
         @> $2::timestamptz
+    AND tstzrange(spgpah.recorded_at, spgpah.replaced_at, '[]')
+        @> $2::timestamptz
     AND (
-        spgpa.status IN ('verified', 'prequalified', 'temporary_qualified')
-        OR spgpa.verified_at IS NOT null
-        OR spgpa.prequalified_at IS NOT null
+        spgpah.status IN ('verified', 'prequalified', 'temporary_qualified')
+        OR spgpah.verified_at IS NOT null
+        OR spgpah.prequalified_at IS NOT null
     )
 `
 


### PR DESCRIPTION
This PR fixes invalid notification recipient queries in SPGGS and SPGPS following a recent change.

The bug was not spotted before when testing because SQLC was not run on the new queries. `main` was therefore not impacted since changes to update the actual code of the event worker have not been applied.

Fixed and carefully tested.