### PR TITLE
test: revive schemathesis (FLEX-839)

### DIFF
--- a/schemathesis.toml
+++ b/schemathesis.toml
@@ -1,0 +1,3 @@
+[checks]
+not_a_server_error.enabled = false
+unsupported_method.enabled = false

--- a/test/other_tests/test_schemathesis.py
+++ b/test/other_tests/test_schemathesis.py
@@ -1,11 +1,12 @@
 import schemathesis
-from schemathesis.checks import not_a_server_error
 import os
 from dotenv import load_dotenv
+from typing import Protocol
 
 from security_token_service import (
     SecurityTokenService,
     TestEntity,
+    AuthenticatedClient,
 )
 
 """
@@ -16,22 +17,34 @@ are consistent with the documented error cases in the OpenAPI specification.
 load_dotenv()
 
 # login to get access to the OpenAPI file
-token = SecurityTokenService().get_client(TestEntity.TEST, "FISO").token
+client = SecurityTokenService().get_client(TestEntity.TEST, "FISO")
+assert isinstance(client, AuthenticatedClient)
+token = client.token
 
 # We are reading the file from local instead of the URL to be able to
 # iterate faster on the OpenAPI file while developing
 openapi_document = open("backend/data/static/openapi.json", "r").read()
 
-api_url = os.environ["FLEX_URL_BASE"] + "/api/v0"
 
-schema = schemathesis.openapi.from_file(
-    openapi_document
-)
+# Filter function to allow us to precisely pick out relevant checks.
+class HasAPIOperation(Protocol):
+    operation: schemathesis.APIOperation
+
+
+# Include func to filter only relevant operations
+def include_func(call: HasAPIOperation) -> bool:
+    return call.operation.path.startswith(
+        "/openapi.json"
+    ) or call.operation.path.startswith("/controllable_unit")
+
+
+schema = schemathesis.openapi.from_file(openapi_document).include(func=include_func)
 
 
 @schema.parametrize()
-def test_schemathesis(case):
-    response = case.call(headers={"Authorization": f"Bearer {token}"})
+def test_schemathesis(case: schemathesis.Case) -> None:
+    api_url = os.environ["FLEX_URL_BASE"] + "/api/v0"
+    response = case.call(base_url=api_url, headers={"Authorization": f"Bearer {token}"})
 
     # When the OpenAPI spec includes a cookie securityScheme, then we get some 500s
-    case.validate_response(response, excluded_checks=(not_a_server_error,))
+    case.validate_response(response)


### PR DESCRIPTION
This brings schemathesis back to a _runnable_ state. It is still throwing a lot of errors.

The errors are probably real. Examples:

```
  | - Undocumented Content-Type
  |
  |     Received: text/plain; charset=utf-8
  |     Documented: application/json
  |
  | - Missing header not rejected
  |
  |     Missing header not rejected (got 403, expected 401)
  |
  | [403] Forbidden:
  |
  |     `{"code":"HTTP403","message":"Forbidden","details":"insufficient scope"}`
  |
  | Reproduce with:
  |
  |     curl -X POST -H 'Content-Type: application/json' -d '{"controllable_unit_id": 2, "end_user_id": 0, "service_provider_id": 78}' http://localhost/api/v0/controllable_unit_service_provider
  |
  |  (2 sub-exceptions)
  +-+---------------- 1 ----------------
    | schemathesis.openapi.checks.UndefinedContentType: Undocumented Content-Type
    |
    | Received: text/plain; charset=utf-8
    | Documented: application/json
    +---------------- 2 ----------------
    | schemathesis.openapi.checks.MissingHeaderNotRejected: Missing header not rejected
    |
    | Missing header not rejected (got 403, expected 401)
```

I think it it worth looking into some of these at some point, but I think our appetite for fixing these errors right now is not there. So for now, we just leave it like this and prioritize other work. I'll register a debt task in our backlog.