### PR TITLE
feat(backend): accept single parameters as alternative to full DB URI (FLEX-866)

### DIFF
--- a/backend/flex.go
+++ b/backend/flex.go
@@ -224,7 +224,7 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 
 		replURIDatabase, exists := lookupenv("FLEX_DB_REPLICATION_URI_DATABASE")
 		if !exists {
-			return fmt.Errorf("%w: FLEX_DB_URI_DATABASE", errMissingEnv)
+			return fmt.Errorf("%w: FLEX_DB_REPLICATION_URI_DATABASE", errMissingEnv)
 		}
 
 		replURIUser, exists := lookupenv("FLEX_DB_REPLICATION_URI_USER")


### PR DESCRIPTION
This PR allows settings the DB URI parameter by parameter instead of with the full URI. The reason is that it is easier for deployment.

The previous behaviour is preserved for compatibility.