### PR TITLE
fix(docs): update docs after set up

### DIFF
--- a/docs-dev/index.md
+++ b/docs-dev/index.md
@@ -57,7 +57,7 @@ addition we are also using the root certificate (at `~/.ca/root/ca.cert.pem`
 * `<domain>.key.pem` - The private key
 
 Then we need to make sure that these domains resolve. Add the following to your
-(Windows) hosts file:
+(Windows) hosts file and restart wsl:
 
 ```text
 127.0.0.1          dev.flex.internal
@@ -75,7 +75,7 @@ the scripts, with the following commands:
 ```bash
 just permissions
 just openapi
-just test-accounts
+just init
 ```
 
 Now, you just have to run:


### PR DESCRIPTION
The docs for setup were good, i almost had no problems getting up and running.

`just test-accounts` does not exists, and i had some liquibase errors when running `just reset` before running `just init`.

I think you need to restart wsl for the hosts to be applied. But it might have been a coincidence that that worked