### PR TITLE
feat(backend): common timeout for all OIDC-related requests (FLEX-888)

### DIFF
--- a/backend/pgpool/userdetails.go
+++ b/backend/pgpool/userdetails.go
@@ -19,11 +19,9 @@ type UserDetails interface {
 
 // UserDetailsFromContext returns the UserDetails value stored in ctx.
 // Errors if no UserDetails is found.
-//
-//nolint:ireturn
-func UserDetailsFromContext(ctx context.Context, key string) (UserDetails, error) {
+func UserDetailsFromContext(ctx context.Context, key string) (UserDetails, error) { //nolint:ireturn
 	value := ctx.Value(key)
-	if value == nil {
+	if value == nil { //nolint:ireturn
 		return nil, fmt.Errorf("%w: context value for %s is empty", errMissingUserDetails, key)
 	}
 


### PR DESCRIPTION
Just made the previously hardcoded timeout the same for all requests, including the config one that did not have a timeout.