### PR TITLE
fix(test): make party membership tests stateless (FLEX-893)

### DIFF
--- a/test/api_client_tests/test_entity_client.py
+++ b/test/api_client_tests/test_entity_client.py
@@ -31,6 +31,7 @@ from test_party import (
 )
 from flex.api.party_membership import (
     create_party_membership,
+    delete_party_membership,
 )
 import pytest
 from typing import cast
@@ -201,6 +202,13 @@ def test_entity_client_fiso(sts):
     d = delete_entity_client.sync(
         client=client_ent,
         id=cast(int, clt.id),
+        body=EmptyObject(),
+    )
+    assert not isinstance(d, ErrorMessage)
+
+    d = delete_party_membership.sync(
+        client=client_fiso,
+        id=cast(int, pm.id),
         body=EmptyObject(),
     )
     assert not isinstance(d, ErrorMessage)

--- a/test/api_client_tests/test_party_membership.py
+++ b/test/api_client_tests/test_party_membership.py
@@ -283,6 +283,24 @@ def test_ptym_org(sts):
     )
     assert isinstance(e, ErrorMessage)
 
+    # cleanup
+
+    d = delete_party_membership.sync(
+        client=client_fiso,
+        id=cast(int, pm.id),
+        body=EmptyObject(),
+    )
+    assert not (isinstance(d, ErrorMessage))
+
+    u = update_party_membership.sync(
+        client=client_fiso,
+        id=cast(int, org_pm.id),
+        body=PartyMembershipUpdateRequest(
+            scopes=[AuthScope.MANAGEAUTH, AuthScope.MANAGEDATA],
+        ),
+    )
+    assert not isinstance(u, ErrorMessage)
+
 
 def test_ptym_common(sts):
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")


### PR DESCRIPTION
Some tests were creating party memberships without deleting them, or updating existing memberships without resetting to the state before the test began. This caused the tests to fail on second run. Now this should be fixed.