### PR TITLE
fix(test): filter SPGGP by ISO so that SO tests their own resource (FLEX-893)

### DIFF
--- a/test/api_client_tests/test_spg_grid_prequalification.py
+++ b/test/api_client_tests/test_spg_grid_prequalification.py
@@ -428,6 +428,7 @@ def test_spggp_so(data):
         impacted_system_operator_id=f"eq.{so_id}",
     )
     assert isinstance(spggps_so, list)
+    assert len(spggps_so) > 0, "No SPGGP records returned for impacted_system_operator_id"
     so_spggp = spggps_so[0]
 
     u = update_service_providing_group_grid_prequalification.sync(


### PR DESCRIPTION
We were not filtering by ISO, so SO was trying to edit someone else's grid prequalification.

Tests remained green the 2 first runs because it's one of their resources that comes up first, but at some point it changed and the test became red. Fixed.