### PR TITLE
fix: changesets checksum make liquibase fail

### DIFF
--- a/db/flex/service_provider_product_application.sql
+++ b/db/flex/service_provider_product_application.sql
@@ -1,8 +1,7 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:service-provider-product-application-create runOnChange:false endDelimiter:--
--- validCheckSum: 9:a542c9d6b49641997506235f5cf99282
+-- changeset flex:service-provider-product-application-create runOnChange:true endDelimiter:--
 -- relation between SP and SO with its product types
 CREATE TABLE IF NOT EXISTS service_provider_product_application (
     id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,

--- a/db/flex/service_providing_group_grid_prequalification.sql
+++ b/db/flex/service_providing_group_grid_prequalification.sql
@@ -1,8 +1,7 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:service-providing-group-grid-prequalification-create runOnChange:false endDelimiter:--
--- validCheckSum: 9:76cd8e2f4596c1bd2e019d353f952dba
+-- changeset flex:service-providing-group-grid-prequalification-create runOnChange:true endDelimiter:--
 CREATE TABLE IF NOT EXISTS service_providing_group_grid_prequalification (
     id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     service_providing_group_id bigint NOT NULL,


### PR DESCRIPTION
We have recently removed `notes`. This makes the changeset checksum fail - which makes liquibase sad.

Switching to `runOnChange: true` allows us to not keep track for checksums, and since the table is created `IF NOT EXISTS`, its a safe pattern. I think we do this in other places as well.