### PR TITLE
ci: define liquibase entrypoint (FLEX-867)

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -44,6 +44,7 @@ elhubProject(Group.FLEX, "flex-information-system") {
                         repository = imageRepoBackend
                     }
                     changelogDirectory = "./db"
+                    liquibaseEntrypoint = "changelog.yml"
                     source = Source.CommitSha
                 }
 


### PR DESCRIPTION
This PR defines the entry point for Liquibase as done [here](https://github.com/elhub/user-interface-mypage-backend-for-frontend/blob/fbff10f186d42217314071cdf6b16a04208b1107/.teamcity/settings.kts#L45) for instance.

Hopefully fixes the startup error we get on the Liquibase init container:
```
Unexpected error running Liquibase: changelog.yaml does not exist
```