### PR TITLE
fix: spgm cusp consistency bug (FLEX-900)

### DIFF
--- a/db/flex/service_providing_group_membership.sql
+++ b/db/flex/service_providing_group_membership.sql
@@ -48,7 +48,8 @@ BEGIN
     from flex.service_providing_group spg
     where spg.id = NEW.service_providing_group_id;
 
-    select range_agg(cusp.valid_time_range) @> NEW.valid_time_range
+    select
+        COALESCE(range_agg(cusp.valid_time_range) @> NEW.valid_time_range, false)
     into lv_covered
     from flex.controllable_unit_service_provider as cusp
     where cusp.controllable_unit_id = NEW.controllable_unit_id


### PR DESCRIPTION
I spotted this while implementing the same type of logic for bidding zone consistency.

The gist of the bug is that `range_agg(cusp.valid_time_range) @> NEW.valid_time_range` can end with a `null` result when there are no rows returned by the select. Null is not `false`. COALESCE fixes that.

Before fix, I was able to add CUs from other SPs.