### PR TITLE
fix(ui): filter events on source or subject depending on resource (FLEX-836)

### DIFF
--- a/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderShow.tsx
+++ b/frontend/src/controllable_unit/service_provider/ControllableUnitServiceProviderShow.tsx
@@ -96,7 +96,7 @@ export const ControllableUnitServiceProviderShow = () => {
             <IdentityField source="recorded_by" />
           </FieldStack>
         </Stack>
-        {!isHistory && <EventButton />}
+        {!isHistory && <EventButton filterOnSubject />}
         <NestedResourceHistoryButton
           child="service_provider"
           label="service provider contracts"

--- a/frontend/src/controllable_unit/suspension/ControllableUnitSuspensionShow.tsx
+++ b/frontend/src/controllable_unit/suspension/ControllableUnitSuspensionShow.tsx
@@ -86,7 +86,7 @@ export const ControllableUnitSuspensionShow = () => {
           </FieldStack>
         </Stack>
         <NestedResourceHistoryButton child="suspension" label="Suspensions" />
-        {!isHistory && <EventButton />}
+        {!isHistory && <EventButton filterOnSubject />}
         {!isHistory && (
           <>
             <Typography variant="h6" gutterBottom>

--- a/frontend/src/controllable_unit/technical_resource/TechnicalResourceShow.tsx
+++ b/frontend/src/controllable_unit/technical_resource/TechnicalResourceShow.tsx
@@ -78,7 +78,7 @@ export const TechnicalResourceShow = () => {
             <IdentityField source="recorded_by" />
           </FieldStack>
         </Stack>
-        {!isHistory && <EventButton />}
+        {!isHistory && <EventButton filterOnSubject />}
         <NestedResourceHistoryButton
           child="technical_resource"
           childAPIResource="technical_resource"

--- a/frontend/src/event/EventButton.tsx
+++ b/frontend/src/event/EventButton.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ButtonProps,
   usePermissions,
   useRecordContext,
   useResourceContext,
@@ -8,7 +9,10 @@ import { Permissions } from "../auth/permissions";
 import { Link } from "react-router-dom";
 import NewReleasesIcon from "@mui/icons-material/NewReleases";
 
-export const EventButton = (props: any) => {
+export const EventButton = (
+  props: ButtonProps & { filterOnSubject?: boolean },
+) => {
+  const { filterOnSubject, ...rest } = props;
   const resource = useResourceContext();
   const record = useRecordContext()!;
 
@@ -17,9 +21,14 @@ export const EventButton = (props: any) => {
   // Permission checks
   const canRead = permissions?.allow("event", "read");
 
+  // if the button is on a subresource's page, we should filter events on subject,
+  // because the source field will contain the parent resource instead
+  const filterField = filterOnSubject ? "subject" : "source";
   const filter =
     "?filter=" +
-    encodeURIComponent(`{ "source@like": "/${resource}/${record.id}" }`);
+    encodeURIComponent(
+      `{ "${filterField}@like": "/${resource}/${record.id}" }`,
+    );
 
   return canRead ? (
     <Button
@@ -27,7 +36,7 @@ export const EventButton = (props: any) => {
       to={`/event${filter}`}
       startIcon={<NewReleasesIcon />}
       label="Events"
-      {...props}
+      {...rest}
     />
   ) : null;
 };

--- a/frontend/src/party/membership/PartyMembershipShow.tsx
+++ b/frontend/src/party/membership/PartyMembershipShow.tsx
@@ -76,7 +76,7 @@ export const PartyMembershipShow = () => {
             <IdentityField source="recorded_by" />
           </FieldStack>
         </Stack>
-        <EventButton />
+        <EventButton filterOnSubject />
         <NestedResourceHistoryButton
           child="membership"
           label="party memberships"

--- a/frontend/src/service_providing_group/grid_prequalification/ServiceProvidingGroupGridPrequalificationShow.tsx
+++ b/frontend/src/service_providing_group/grid_prequalification/ServiceProvidingGroupGridPrequalificationShow.tsx
@@ -86,7 +86,7 @@ export const ServiceProvidingGroupGridPrequalificationShow = () => {
             <IdentityField source="recorded_by" />
           </FieldStack>
         </Stack>
-        {!isHistory && <EventButton />}
+        {!isHistory && <EventButton filterOnSubject />}
         {!isHistory && (
           <>
             <Typography variant="h6" gutterBottom>

--- a/frontend/src/service_providing_group/grid_suspension/ServiceProvidingGroupGridSuspensionShow.tsx
+++ b/frontend/src/service_providing_group/grid_suspension/ServiceProvidingGroupGridSuspensionShow.tsx
@@ -85,7 +85,7 @@ export const ServiceProvidingGroupGridSuspensionShow = () => {
             <IdentityField source="recorded_by" />
           </FieldStack>
         </Stack>
-        {!isHistory && <EventButton />}
+        {!isHistory && <EventButton filterOnSubject />}
         <NestedResourceHistoryButton
           child="grid_suspension"
           label="grid suspension"

--- a/frontend/src/service_providing_group/membership/ServiceProvidingGroupMembershipShow.tsx
+++ b/frontend/src/service_providing_group/membership/ServiceProvidingGroupMembershipShow.tsx
@@ -91,7 +91,7 @@ export const ServiceProvidingGroupMembershipShow = () => {
             <IdentityField source="recorded_by" />
           </FieldStack>
         </Stack>
-        {!isHistory && <EventButton />}
+        {!isHistory && <EventButton filterOnSubject />}
         <NestedResourceHistoryButton
           child="membership"
           label="memberships in this group"

--- a/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationShow.tsx
+++ b/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationShow.tsx
@@ -100,7 +100,7 @@ export const ServiceProvidingGroupProductApplicationShow = () => {
             <IdentityField source="replaced_by" />
           </FieldStack>
         </Stack>
-        {!isHistory && <EventButton />}
+        {!isHistory && <EventButton filterOnSubject />}
         <NestedResourceHistoryButton
           child="product_application"
           label="product applications"

--- a/frontend/src/service_providing_group/product_suspension/ServiceProvidingGroupProductSuspensionShow.tsx
+++ b/frontend/src/service_providing_group/product_suspension/ServiceProvidingGroupProductSuspensionShow.tsx
@@ -87,7 +87,7 @@ export const ServiceProvidingGroupProductSuspensionShow = () => {
             <IdentityField source="recorded_by" />
           </FieldStack>
         </Stack>
-        {!isHistory && <EventButton />}
+        {!isHistory && <EventButton filterOnSubject />}
         <NestedResourceHistoryButton
           child="product_suspension"
           label="product suspension"


### PR DESCRIPTION
This PR fixes a bug introduced when switching events from only source to source + subject.

On resources that will have their name in the `subject` field, the button on show pages leading to the events concerning these resources should filter events by subject, not by source.