### PR TITLE
fix(ui): resource button checks if resource exists before redirecting (FLEX-911)

### DIFF
--- a/frontend/src/components/ResourceButton.tsx
+++ b/frontend/src/components/ResourceButton.tsx
@@ -25,7 +25,7 @@ export const ResourceButton = (props: ButtonProps & { source: string }) => {
           navigate(`/${resource}/${id}/show`);
         } else {
           notify(
-            `The concerned resource (${resource}/${id}) no longer exists.`,
+            `The concerned resource (${resource}/${id}) can no longer be accessed.`,
             { type: "error" },
           );
         }


### PR DESCRIPTION
This PR prevents broken redirects from happening on notifications about deleted resources, by checking whether the resource exists before doing the redirect.