### PR TITLE
fix: support events with no subject ID in pgoutput (FLEX-924)

### DIFF
--- a/backend/event/event.go
+++ b/backend/event/event.go
@@ -67,10 +67,8 @@ func fromTupleData(td *pgoutput.TupleData) (event, error) {
 	// We don't need it since we can infer it from `type`
 
 	// try to parse subject ID (it can be null if the event concerns a toplevel resource)
-	var subjectIDStr string
-	if len(td.Columns) < 9 { //nolint:mnd
-		subjectIDStr = ""
-	} else {
+	subjectIDStr := ""
+	if len(td.Columns) == 9 { //nolint:mnd
 		subjectIDStr = string(td.Columns[8])
 	}
 	if subjectIDStr != "" {


### PR DESCRIPTION
Aims to fix
```
panic: runtime error: index out of range [8] with length 7 [recovered, repanicked]
```