### PR TITLE
feat: run kbackend in local Docker Compose setup (FLEX-1109)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,15 @@ services:
         condition: service_healthy
     extra_hosts:
       - "idp.flex.internal:host-gateway"
+  kbackend:
+    image: flex-kbackend
+    pull_policy: never # the image is always built locally
+    ports:
+      - "7002:8080"
+    env_file: "./local/kbackend/test.env"
+    depends_on:
+      db:
+        condition: service_started
   frontend:
     build: ./frontend
     volumes:

--- a/justfile
+++ b/justfile
@@ -24,6 +24,7 @@ tbls-lint:
 
 gradle-docker-image:
     #!/usr/bin/env bash
+    set -euo pipefail
     cd kbackend
     ./gradlew jibDockerBuild --image=flex-kbackend
     cd ..

--- a/justfile
+++ b/justfile
@@ -22,15 +22,14 @@ megalinter:
 tbls-lint:
     tbls lint
 
-gradle-docker-image:
+build-kbackend:
     #!/usr/bin/env bash
     set -euo pipefail
     cd kbackend
     ./gradlew jibDockerBuild --image=flex-kbackend
-    cd ..
 
 # start the docker environment
-start: gradle-docker-image
+start: build-kbackend
     #!/usr/bin/env bash
     set -euo pipefail
     docker compose up -d
@@ -49,11 +48,11 @@ unload:
     ./db/unload.sh
 
 # docker compose pull
-pull: gradle-docker-image
+pull:
     docker compose pull
 
 # docker compose build
-build: gradle-docker-image
+build: build-kbackend
     docker compose build --pull
 
 # load the database

--- a/justfile
+++ b/justfile
@@ -22,8 +22,14 @@ megalinter:
 tbls-lint:
     tbls lint
 
+gradle-docker-image:
+    #!/usr/bin/env bash
+    cd kbackend
+    ./gradlew jibDockerBuild --image=flex-kbackend
+    cd ..
+
 # start the docker environment
-start:
+start: gradle-docker-image
     #!/usr/bin/env bash
     set -euo pipefail
     docker compose up -d
@@ -42,11 +48,11 @@ unload:
     ./db/unload.sh
 
 # docker compose pull
-pull:
+pull: gradle-docker-image
     docker compose pull
 
 # docker compose build
-build:
+build: gradle-docker-image
     docker compose build --pull
 
 # load the database

--- a/local/kbackend/test.env
+++ b/local/kbackend/test.env
@@ -1,8 +1,8 @@
 # Env file for test
 # secretlint-disable
-FLEX_DATABASE_URL=postgres://flex_authenticator:authenticator_password@db:5432/flex?search_path=api,notification,auth,public
+FLEX_DATABASE_URL=jdbc:postgresql://db:5432/flex
 FLEX_DATABASE_USERNAME=flex_authenticator
 FLEX_DATABASE_PASSWORD=authenticator_password
 FLEX_JWT_SECRET=rqQHuW5MppUkriINN1gr1JWjftoJYWhn1234567890ohausd987ahf8a7hsf0a7shf0ash7f
 ACCOUNTING_POINT_ADAPTER_BASE_URL=http://ap-adapter:8080
-ACCOUNTING_POINT_ADAPTER_API_KEY=test_api_key
+ACCOUNTING_POINT_ADAPTER_API_KEY=key

--- a/local/kbackend/test.env
+++ b/local/kbackend/test.env
@@ -1,0 +1,8 @@
+# Env file for test
+# secretlint-disable
+FLEX_DATABASE_URL=postgres://flex_authenticator:authenticator_password@db:5432/flex?search_path=api,notification,auth,public
+FLEX_DATABASE_USERNAME=flex_authenticator
+FLEX_DATABASE_PASSWORD=authenticator_password
+FLEX_JWT_SECRET=rqQHuW5MppUkriINN1gr1JWjftoJYWhn1234567890ohausd987ahf8a7hsf0a7shf0ash7f
+ACCOUNTING_POINT_ADAPTER_BASE_URL=http://ap-adapter:8080
+ACCOUNTING_POINT_ADAPTER_API_KEY=test_api_key


### PR DESCRIPTION
This PR runs the Kotlin backend as part of the Docker Compose setup.

We avoid writing a custom Dockerfile by reusing the Jib plugin already present in the Kotlin projects at Elhub, We just have to check in the justfile that the image is built locally before starting the Docker Compose.