### PR TITLE
fix: Depend on healthy database before starting kbackend (FLEX-1064)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       -c cron.database_name=flex
       -c cron.timezone=Europe/Oslo
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d flex"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,11 @@ services:
       -c shared_preload_libraries=pg_cron
       -c cron.database_name=flex
       -c cron.timezone=Europe/Oslo
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d flex"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
   postgrest:
     image: postgrest/postgrest:latest
     expose:
@@ -48,7 +53,8 @@ services:
       PGRST_OPENAPI_SERVER_PROXY_URI: http://localhost:3000/
       PGRST_OPENAPI_SECURITY_ACTIVE: "True"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
   backend:
     build: ./backend
     ports:
@@ -60,7 +66,7 @@ services:
         target: /etc/ssl/certs/local-root.pem
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       postgrest:
         condition: service_started
       kbackend:
@@ -77,7 +83,7 @@ services:
     env_file: "./local/kbackend/test.env"
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
   frontend:
     build: ./frontend
     volumes:


### PR DESCRIPTION
kbackend connection pool failed because database was not ready yet