### PR TITLE
fix(test): make tests great again w/ kbackend reverse-proxying

### DIFF
--- a/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/AccountingPointService.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/AccountingPointService.kt
@@ -91,7 +91,7 @@ class AccountingPointServiceImpl(
                 }
             },
             ifRight = { adapterAccountingPoint ->
-                logger.debug { "Raw data from adapter: $adapterAccountingPoint" }
+                logger.debug { "Raw data from adapter: ${adapterAccountingPoint.hidingEndUserIDs()}" }
                 with(FlexPrincipal.internalData()) {
                     flexTransaction { _ ->
                         either {
@@ -123,6 +123,9 @@ class AccountingPointServiceImpl(
         logger.error { "$context failed: $this" }
         return InternalServerError(traceIdOrUnknown())
     }
+
+    private fun AdapterAccountingPoint.hidingEndUserIDs(): AdapterAccountingPoint =
+        copy(endUser = endUser.map { it.copy(businessId = "<HIDDEN>") })
 
     private fun AdapterAccountingPoint.toAccountingPointEndUsers(accountingPointId: Long): List<AccountingPointEndUser> =
         endUser.map { eu ->

--- a/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/AccountingPointService.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/AccountingPointService.kt
@@ -83,15 +83,14 @@ class AccountingPointServiceImpl(
         .fold(
             ifLeft = { e ->
                 if (e.code == HttpStatusCode.NotFound) {
-                    logger.warn { "Accounting point not found in adapter: $accountingPointBusinessId" }
                     e.left()
                 } else {
-                    logger.warn { "Failed to fetch accounting point data for $accountingPointBusinessId — skipping sync" }
+                    logger.warn { "Skipping sync" }
                     Unit.right()
                 }
             },
             ifRight = { adapterAccountingPoint ->
-                logger.debug { "Raw data from adapter: ${adapterAccountingPoint.hidingEndUserIDs()}" }
+                logger.debug { "Raw data from adapter: ${adapterAccountingPoint.anonymizedForLogging()}" }
                 with(FlexPrincipal.internalData()) {
                     flexTransaction { _ ->
                         either {
@@ -124,8 +123,7 @@ class AccountingPointServiceImpl(
         return InternalServerError(traceIdOrUnknown())
     }
 
-    // useful for logging the structure without showing sensitive data
-    private fun AdapterAccountingPoint.hidingEndUserIDs(): AdapterAccountingPoint =
+    private fun AdapterAccountingPoint.anonymizedForLogging(): AdapterAccountingPoint =
         copy(endUser = endUser.map { it.copy(businessId = "<HIDDEN>") })
 
     private fun AdapterAccountingPoint.toAccountingPointEndUsers(accountingPointId: Long): List<AccountingPointEndUser> =

--- a/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/AccountingPointService.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/AccountingPointService.kt
@@ -152,7 +152,6 @@ class AccountingPointServiceImpl(
         accountingPointBusinessId: String
     ): Either<AppError, Long> = accountingPointRepository.checkEndUserMatchesAccountingPoint(endUserBusinessId, accountingPointBusinessId).mapLeft { error ->
         when (error) {
-            is NotFoundError -> ResourceNotFoundError("Accounting point not found")
             is NoMatchError -> EndUserError("End user does not match")
             else -> InternalServerError(traceIdOrUnknown())
         }

--- a/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/AccountingPointService.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/AccountingPointService.kt
@@ -124,6 +124,7 @@ class AccountingPointServiceImpl(
         return InternalServerError(traceIdOrUnknown())
     }
 
+    // useful for logging the structure without showing sensitive data
     private fun AdapterAccountingPoint.hidingEndUserIDs(): AdapterAccountingPoint =
         copy(endUser = endUser.map { it.copy(businessId = "<HIDDEN>") })
 

--- a/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/AccountingPointService.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/AccountingPointService.kt
@@ -14,6 +14,7 @@ import no.elhub.flex.model.domain.AccountingPoint
 import no.elhub.flex.model.domain.AccountingPointEndUser
 import no.elhub.flex.model.domain.AccountingPointEnergySupplier
 import no.elhub.flex.model.domain.db.LockTimeoutError
+import no.elhub.flex.model.domain.db.NoMatchError
 import no.elhub.flex.model.domain.db.NotFoundError
 import no.elhub.flex.model.domain.db.RepositoryError
 import no.elhub.flex.model.error.AppError
@@ -80,11 +81,17 @@ class AccountingPointServiceImpl(
         validFrom: Instant
     ): Either<AppError, Unit> = fetchAccountingPointData(accountingPointBusinessId, validFrom)
         .fold(
-            ifLeft = {
-                logger.warn { "Failed to fetch accounting point data for $accountingPointBusinessId — skipping sync" }
-                Unit.right()
+            ifLeft = { e ->
+                if (e.code == HttpStatusCode.NotFound) {
+                    logger.warn { "Accounting point not found in adapter: $accountingPointBusinessId" }
+                    e.left()
+                } else {
+                    logger.warn { "Failed to fetch accounting point data for $accountingPointBusinessId — skipping sync" }
+                    Unit.right()
+                }
             },
             ifRight = { adapterAccountingPoint ->
+                logger.debug { "Raw data from adapter: $adapterAccountingPoint" }
                 with(FlexPrincipal.internalData()) {
                     flexTransaction { _ ->
                         either {
@@ -143,7 +150,8 @@ class AccountingPointServiceImpl(
         accountingPointBusinessId: String
     ): Either<AppError, Long> = accountingPointRepository.checkEndUserMatchesAccountingPoint(endUserBusinessId, accountingPointBusinessId).mapLeft { error ->
         when (error) {
-            is NotFoundError -> EndUserError("Accounting point not found")
+            is NotFoundError -> ResourceNotFoundError("Accounting point not found")
+            is NoMatchError -> EndUserError("End user does not match")
             else -> InternalServerError(traceIdOrUnknown())
         }
     }

--- a/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepository.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepository.kt
@@ -52,7 +52,7 @@ interface AccountingPointRepository {
     /**
      * Calls `api.controllable_unit_lookup_check_end_user_matches_accounting_point`.
      *
-     * Returns the end-user ID, or [NotFoundError] when the check fails.
+     * Returns the end-user ID, or [NoMatchError] when the check fails.
      */
     context(principal: FlexPrincipal)
     suspend fun checkEndUserMatchesAccountingPoint(

--- a/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepository.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepository.kt
@@ -12,7 +12,6 @@ import no.elhub.flex.db.prepareNamed
 import no.elhub.flex.db.query
 import no.elhub.flex.db.queryRequiredSingle
 import no.elhub.flex.db.querySingle
-import no.elhub.flex.integration.accountingpointadapter.generated.models.EndUser
 import no.elhub.flex.model.domain.AccountingPoint
 import no.elhub.flex.model.domain.AccountingPointEndUser
 import no.elhub.flex.model.domain.AccountingPointEnergySupplier
@@ -21,7 +20,6 @@ import no.elhub.flex.model.domain.db.LockTimeoutError
 import no.elhub.flex.model.domain.db.NoMatchError
 import no.elhub.flex.model.domain.db.NotFoundError
 import no.elhub.flex.model.domain.db.RepositoryError
-import no.elhub.flex.model.error.EndUserError
 import no.elhub.flex.util.toSqlTimestamp
 import no.elhub.flex.util.toSqlTimestampOrNull
 import org.koin.core.annotation.Single

--- a/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepository.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepository.kt
@@ -12,13 +12,16 @@ import no.elhub.flex.db.prepareNamed
 import no.elhub.flex.db.query
 import no.elhub.flex.db.queryRequiredSingle
 import no.elhub.flex.db.querySingle
+import no.elhub.flex.integration.accountingpointadapter.generated.models.EndUser
 import no.elhub.flex.model.domain.AccountingPoint
 import no.elhub.flex.model.domain.AccountingPointEndUser
 import no.elhub.flex.model.domain.AccountingPointEnergySupplier
 import no.elhub.flex.model.domain.db.DatabaseError
 import no.elhub.flex.model.domain.db.LockTimeoutError
+import no.elhub.flex.model.domain.db.NoMatchError
 import no.elhub.flex.model.domain.db.NotFoundError
 import no.elhub.flex.model.domain.db.RepositoryError
+import no.elhub.flex.model.error.EndUserError
 import no.elhub.flex.util.toSqlTimestamp
 import no.elhub.flex.util.toSqlTimestampOrNull
 import org.koin.core.annotation.Single
@@ -207,8 +210,8 @@ class AccountingPointRepositoryImpl : AccountingPointRepository {
                 DatabaseError("Failed to check end user")
             }.flatMap { id ->
                 id?.right() ?: run {
-                    logger.info { "No match for end user $endUserBusinessId and accounting point $accountingPointBusinessId" }
-                    NotFoundError("End user does not match accounting point / controllable unit").left()
+                    logger.info { "No match between end user and accounting point $accountingPointBusinessId" }
+                    NoMatchError("End user does not match accounting point / controllable unit").left()
                 }
             }
         }
@@ -443,7 +446,7 @@ private fun resolveOrCreateEntity(conn: Connection, endUserBusinessId: String): 
     val (entityType, businessIdType) = when {
         endUserBusinessId.matches(Regex("^[1-9][0-9]{10}$")) -> "person" to "pid"
         endUserBusinessId.matches(Regex("^[1-9][0-9]{8}$")) -> "organisation" to "org"
-        else -> error("Cannot determine entity type for end user business ID: $endUserBusinessId")
+        else -> error("Cannot determine entity type for end user business ID")
     }
 
     conn.prepareNamed(

--- a/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
@@ -53,10 +53,6 @@ class ControllableUnitLookup(
                 logger.debug { "Controllable unit used in lookup: ${request.controllableUnitBusinessId}" }
                 logger.debug { "Accounting point used in lookup: $accountingPointBusinessId" }
 
-                // TODO: fix role
-                // The underlying query does not call a security definer function. It is a direct query against CU/AP,
-                // so it cannot be called with user role, we need to either rewrite this as a DB function or switch to a
-                // system role for this handler (flex_internal_data).
                 val controllableUnits = fetchControllableUnits(
                     request.controllableUnitBusinessId,
                     accountingPointBusinessId

--- a/kbackend/src/test/kotlin/no/elhub/flex/accountingpoint/AccountingPointServiceTest.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/accountingpoint/AccountingPointServiceTest.kt
@@ -5,7 +5,9 @@ import arrow.core.right
 import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.http.HttpStatusCode
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -65,7 +67,7 @@ class AccountingPointServiceTest : FunSpec({
             coVerify(exactly = 0) { with(internalPrincipal) { mockRepo.insertAccountingPointIfNotExists(any()) } }
         }
 
-        test("adapter not-found is swallowed and returns Right(Unit)") {
+        test("adapter not-found is not swallowed") {
             // given
             coEvery { mockAdapter.getAccountingPoint(GSRN, VALID_FROM) } returns
                 NotFoundError(GSRN).left()
@@ -74,7 +76,7 @@ class AccountingPointServiceTest : FunSpec({
             val result = service.synchronizeAccountingPoint(GSRN, VALID_FROM)
 
             // then
-            result.shouldBeRight()
+            result.shouldBeLeft().code shouldBe HttpStatusCode.NotFound
             coVerify(exactly = 0) { with(internalPrincipal) { mockRepo.insertAccountingPointIfNotExists(any()) } }
         }
 

--- a/kbackend/src/test/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepositoryTest.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepositoryTest.kt
@@ -10,6 +10,7 @@ import no.elhub.flex.model.domain.AccountingPoint
 import no.elhub.flex.model.domain.AccountingPointEndUser
 import no.elhub.flex.model.domain.AccountingPointEnergySupplier
 import no.elhub.flex.model.domain.db.DatabaseError
+import no.elhub.flex.model.domain.db.NoMatchError
 import no.elhub.flex.model.domain.db.NotFoundError
 import no.elhub.flex.util.gs1CheckDigit
 import no.elhub.flex.util.toKotlinInstant
@@ -124,7 +125,7 @@ class AccountingPointRepositoryTest : FunSpec({
             result shouldBe expectedEndUser
         }
 
-        test("returns NotFoundError when end user does not match accounting point") {
+        test("returns NoMatchError when end user does not match accounting point") {
             // given
             val targetApBusinessId = uniqueGsrn()
             val linkedEntityBusinessId = uniquePid()
@@ -139,10 +140,12 @@ class AccountingPointRepositoryTest : FunSpec({
             }
 
             // then
-            result.shouldBeLeft() shouldBe NotFoundError("End user does not match accounting point / controllable unit")
+            (result.shouldBeLeft() is NoMatchError) shouldBe true
         }
 
-        test("returns NotFoundError when accounting point does not exist") {
+        // the SQL function does not distinguish the cases so we always return 'no match', but the following case should
+        // not happen because a missing accounting point should be caught earlier in the handler (before calling this)
+        test("returns NoMatchError when accounting point does not exist") {
             // given
             val noiseApId = insertAccountingPoint(uniqueGsrn())
             linkApToEndUser(noiseApId, insertEndUserParty(uniquePid()))
@@ -153,7 +156,7 @@ class AccountingPointRepositoryTest : FunSpec({
             }
 
             // then
-            result.shouldBeLeft() shouldBe NotFoundError("End user does not match accounting point / controllable unit")
+            (result.shouldBeLeft() is NoMatchError) shouldBe true
         }
     }
 

--- a/local/accounting-point/main.py
+++ b/local/accounting-point/main.py
@@ -10,8 +10,6 @@ from client.models import (
     MeteringGridArea,
 )
 from datetime import datetime
-from client.types import UNSET
-
 
 app = Flask(__name__)
 
@@ -21,10 +19,10 @@ app = Flask(__name__)
 # Check the db/test_data package for how this stuff is generated.
 # Also https://elhub.github.io/flex-information-system/guides/test-data/
 
-TEST_DATA_SUFFIX_TO_ES_MGA = {
-    "000": ("1337000000020", "42Y-COMMON-SHA-W"),
-    "001": ("1337000100027", "42Y-TEST-SUITE-6"),
-    "002": ("1337000200024", "42Y-EMIL-POST--Q"),
+TEST_DATA_SUFFIX_TO_EU_ES_MGA = {
+    "000": ("13370000000", "1337000000020", "42Y-COMMON-SHA-W"),
+    "001": ("13370000001", "1337000100027", "42Y-TEST-SUITE-6"),
+    "002": ("emil.post@example.com", "1337000200024", "42Y-EMIL-POST--Q"),
 }
 
 
@@ -35,41 +33,54 @@ def read_accounting_point(gsrn: str):
 
     test_data_suffix = gsrn[11:14]
 
-    if test_data_suffix not in TEST_DATA_SUFFIX_TO_ES_MGA:
+    if test_data_suffix not in TEST_DATA_SUFFIX_TO_EU_ES_MGA:
         return "Invalid local test account", 404
 
-    test_data_es_gln, test_data_mga = TEST_DATA_SUFFIX_TO_ES_MGA[test_data_suffix]
+    test_data_eu, test_data_es_gln, test_data_mga = TEST_DATA_SUFFIX_TO_EU_ES_MGA[
+        test_data_suffix
+    ]
 
-    VALID_FROM = datetime.fromisoformat("2024-01-01T00:00:00+01:00")
-    VALID_TO = datetime.fromisoformat("2024-12-31T00:00:00+01:00")
+    T1 = datetime.fromisoformat("2023-05-01T00:00:00+02:00")
+    T2 = datetime.fromisoformat("2024-01-01T00:00:00+01:00")
+    T3 = datetime.fromisoformat("2099-01-01T00:00:00+01:00")
 
     return AccountingPoint(
         gsrn=gsrn,
         metering_grid_area=[
             MeteringGridArea(
                 business_id=test_data_mga,
-                valid_from=VALID_FROM,
+                valid_from=T1,
             )
         ],
         energy_supplier=[
             EnergySupplier(
+                business_id="1337000000020",
+                valid_from=T1,
+                valid_to=T2,
+            ),
+            EnergySupplier(
                 business_id=test_data_es_gln,
-                valid_from=VALID_FROM,
-            )
+                valid_from=T2,
+                valid_to=T3,
+            ),
         ],
         end_user=[
             EndUser(
-                business_id="13370000" + test_data_suffix,
+                "13370000000",
                 entity_type=EndUserEntityType.PERSON,
-                valid_from=VALID_FROM,
-                valid_to=VALID_TO,
-            )
+                valid_from=T1,
+                valid_to=T2,
+            ),
+            EndUser(
+                business_id=test_data_eu,
+                entity_type=EndUserEntityType.PERSON,
+                valid_from=T2,
+            ),
         ],
         energy_direction=[
             EnergyDirection(
-                direction=[EnergyDirectionDirectionItem.CONSUMPTION],
-                valid_from=VALID_FROM,
-                valid_to=UNSET,
+                direction=[EnergyDirectionDirectionItem.PRODUCTION],
+                valid_from=T2,
             )
         ],
     ).to_dict()

--- a/local/accounting-point/main.py
+++ b/local/accounting-point/main.py
@@ -22,7 +22,7 @@ app = Flask(__name__)
 TEST_DATA_SUFFIX_TO_EU_ES_MGA = {
     "000": ("13370000000", "1337000000020", "42Y-COMMON-SHA-W"),
     "001": ("13370000001", "1337000100027", "42Y-TEST-SUITE-6"),
-    "002": ("emil.post@example.com", "1337000200024", "42Y-EMIL-POST--Q"),
+    # "002": ("emil.post@example.com", "1337000200024", "42Y-EMIL-POST--Q"),
 }
 
 

--- a/test/api_client_tests/test_party.py
+++ b/test/api_client_tests/test_party.py
@@ -2,7 +2,6 @@ from security_token_service import (
     SecurityTokenService,
     TestEntity,
 )
-from flex import AuthenticatedClient
 from flex.models import (
     PartyResponse,
     PartyHistoryResponse,
@@ -13,6 +12,13 @@ from flex.models import (
     PartyRole,
     PartyType,
     PartyStatus,
+    EntityCreateRequest,
+    EntityBusinessIdType,
+    EntityType,
+    EntityResponse,
+)
+from flex.api.entity import (
+    create_entity,
 )
 from flex.api.party import (
     create_party,
@@ -28,6 +34,7 @@ from flex.api.party_membership import (
 import time
 from typing import cast
 import pytest
+from test_entity import random_email
 
 
 def unique_gln() -> str:
@@ -106,12 +113,18 @@ def sts():
 
 # RLS: PTY-FISO001
 def test_party_fiso(sts):
-    client_entity = sts.get_client(TestEntity.TEST)
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")
 
-    ent_id = sts.get_userinfo(
-        cast(AuthenticatedClient, client_entity),
-    )["entity_id"]
+    ent = create_entity.sync(
+        client=client_fiso,
+        body=EntityCreateRequest(
+            business_id=random_email(),
+            business_id_type=EntityBusinessIdType.EMAIL,
+            name="Test Entity",
+            type_=EntityType.PERSON,
+        ),
+    )
+    assert isinstance(ent, EntityResponse)
 
     # FISO can do everything on parties
 
@@ -126,7 +139,7 @@ def test_party_fiso(sts):
             name="New End User",
             role=PartyRole.FLEX_END_USER,
             type_=PartyType.END_USER,
-            entity_id=ent_id,
+            entity_id=ent.id,
             status=PartyStatus.ACTIVE,
         ),
     )
@@ -140,7 +153,7 @@ def test_party_fiso(sts):
             name="New End User",
             role=PartyRole.FLEX_END_USER,
             type_=PartyType.END_USER,
-            entity_id=ent_id,
+            entity_id=ent.id,
             status=PartyStatus.NEW,
         ),
     )
@@ -158,7 +171,7 @@ def test_party_fiso(sts):
             business_id_type=PartyBusinessIdType.EIC_X,
             role=PartyRole.FLEX_SERVICE_PROVIDER,
             type_=PartyType.SERVICE_PROVIDER,
-            entity_id=ent_id,
+            entity_id=ent.id,
         ),
     )
     assert isinstance(p, PartyResponse)
@@ -172,7 +185,7 @@ def test_party_fiso(sts):
             business_id_type=PartyBusinessIdType.GLN,
             role=PartyRole.FLEX_FLEXIBILITY_INFORMATION_SYSTEM_OPERATOR,
             type_=PartyType.FLEXIBILITY_INFORMATION_SYSTEM_OPERATOR,
-            entity_id=ent_id,
+            entity_id=ent.id,
         ),
     )
     assert isinstance(p, PartyResponse)


### PR DESCRIPTION
- test container for adapter copies test dataset so sync does no visible change and the rest of tests continues to work
- fix a merge commit issue that removed the HTTP 403 / HTTP 404 changes on lookup
- fix a party test where several end user parties were being created on the same entity
- some cleaning in the logs (less end user IDs displayed)