### PR TITLE
feat(deploy): set a specific liquibase context for loading test_data schema (FLEX-1160)

### DIFF
--- a/db/changelog.yml
+++ b/db/changelog.yml
@@ -51,7 +51,7 @@ databaseChangeLog:
       file: ./test_data/test_data.sql
       relativeToChangelogFile: true
       # `@` means run only when the context is explicitly set
-      context: "@with-test-data"
+      context: "@test"
   # make sure the changes made by Liquibase are exposed in PostgREST
   - changeSet:
       id: notify-postgrest

--- a/db/changelog.yml
+++ b/db/changelog.yml
@@ -50,6 +50,8 @@ databaseChangeLog:
   - include:
       file: ./test_data/test_data.sql
       relativeToChangelogFile: true
+      # `@` means run only when the context is explicitly set
+      context: "@with-test-data"
   # make sure the changes made by Liquibase are exposed in PostgREST
   - changeSet:
       id: notify-postgrest

--- a/justfile
+++ b/justfile
@@ -273,7 +273,7 @@ liquibase pghost='localhost' password='flex_password' action='update' changelog=
     LIQUIBASE_COMMAND_URL=jdbc:postgresql://{{ pghost }}:5432/flex \
     LIQUIBASE_COMMAND_USERNAME=flex \
     LIQUIBASE_COMMAND_PASSWORD={{ password }} \
-    LIQUIBASE_COMMAND_CONTEXT_FILTER="with-test-data" \
+    LIQUIBASE_COMMAND_CONTEXT_FILTER="test" \
     .bin/liquibase-{{ LIQUIBASE_VERSION }}/liquibase \
     --liquibaseSchemaName=flex \
     --defaultSchemaName=flex \

--- a/justfile
+++ b/justfile
@@ -273,8 +273,8 @@ liquibase pghost='localhost' password='flex_password' action='update' changelog=
     LIQUIBASE_COMMAND_URL=jdbc:postgresql://{{ pghost }}:5432/flex \
     LIQUIBASE_COMMAND_USERNAME=flex \
     LIQUIBASE_COMMAND_PASSWORD={{ password }} \
+    LIQUIBASE_COMMAND_CONTEXT_FILTER="with-test-data" \
     .bin/liquibase-{{ LIQUIBASE_VERSION }}/liquibase \
-    --contexts=local \
     --liquibaseSchemaName=flex \
     --defaultSchemaName=flex \
     --changeLogFile={{ changelog }} \


### PR DESCRIPTION
Activated on local.

`@` means that no further setup in Helm = no `test_data` schema in the environment.