### PR TITLE
fix(test): pass APBZ test as SP again

### DIFF
--- a/test/api_client_tests/test_accounting_point_bidding_zone.py
+++ b/test/api_client_tests/test_accounting_point_bidding_zone.py
@@ -74,13 +74,15 @@ def test_apbz_sp(sts):
         [
             cast(AccountingPointBiddingZoneResponse, apbz)
             for apbz in apbzs
-            if apbz.accounting_point_id == 1003
+            # NB: here we need to use an AP where no other test creates CUSP
+            # impacting the same (AP, SP) pair (for example NOT 1003)
+            if apbz.accounting_point_id == 1001
         ],
         key=lambda apbz: str(apbz.valid_from),
     )
 
     assert len(apbzs_ap) >= 2, (
-        f"Expected at least 2 APBZ records for AP 1003, got {len(apbzs_ap)}"
+        f"Expected at least 2 APBZ records for AP 1001, got {len(apbzs_ap)}"
     )
 
     # We check that:


### PR DESCRIPTION
This PR fixes a small error because of tests crashing with each other. This is mainly because we don't create accounting points so we reuse the same ones, but we have plenty to choose from, we just did not do it apparently.

APBZ access as SP depends on CUSP, but other recently added tests seem to create CUSP contracts that cover the period where the APBZ test expects the SP should not manage any CU on the AP.

Fixed: just use another AP in this test.