### PR TITLE
fix: failing event tests due to insufficient_privilege

### DIFF
--- a/db/flex/event_rls.sql
+++ b/db/flex/event_rls.sql
@@ -38,6 +38,9 @@ BEGIN
     USING in_resource_id, in_event_time;
 
     RETURN l_is_resource_visible_at_event_time;
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        RETURN false;
 END;
 $$;
 


### PR DESCRIPTION
This ensures that the event visibiliy check just returns false (and not an error) when the user is lacking select privileges on the mentioned resource table.