### PR TITLE
feat(auth): create entity if not exists on successful IDP login (FLEX-1221)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ dist-docs
 docs/download
 docs/api/v0
 docs/auth/v0
+docs/api/v1
+docs/auth/v1
 out
 dist-ssr
 kbackend/bin

--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -543,7 +543,7 @@ func (auth *API) GetCallbackHandler(ctx *gin.Context) { //nolint:funlen,cyclop
 		return
 	}
 
-	id, idType := oidc.GetIdentifier(token)
+	id, idType, name := oidc.GetUserData(token)
 
 	slog.DebugContext(ctx, "callback", "token", idToken, "id", id)
 
@@ -554,7 +554,7 @@ func (auth *API) GetCallbackHandler(ctx *gin.Context) { //nolint:funlen,cyclop
 	}
 	defer tx.Commit(ctx)
 
-	entityID, eid, err := models.GetEntityOfBusinessID(ctx, tx, id, idType)
+	entityID, eid, err := models.GetOrCreateEntity(ctx, tx, id, idType, name)
 	if err != nil {
 		slog.DebugContext(ctx, "getting identity of person identifier failed", "token", idToken, "id", id, "idType", idType, "error", err)
 		ctx.AbortWithStatusJSON(http.StatusBadRequest, oauthErrorMessage{

--- a/backend/auth/models/models.go
+++ b/backend/auth/models/models.go
@@ -68,7 +68,7 @@ func GetEntityIdentityByExternalID(
 	return eid, clientID, scopes, nil
 }
 
-// GetOrCreateEntity gets or create an entity and external ID based on a
+// GetOrCreateEntity gets or creates an entity and external ID based on a
 // business ID and a name.
 func GetOrCreateEntity(
 	ctx context.Context,

--- a/backend/auth/models/models.go
+++ b/backend/auth/models/models.go
@@ -68,12 +68,14 @@ func GetEntityIdentityByExternalID(
 	return eid, clientID, scopes, nil
 }
 
-// GetEntityOfBusinessID gets the entity and external ID of a entity business id.
-func GetEntityOfBusinessID(
+// GetOrCreateEntity gets or create an entity and external ID based on a
+// business ID and a name.
+func GetOrCreateEntity(
 	ctx context.Context,
 	tx pgx.Tx,
 	businessID string,
 	businessIDType string,
+	name string,
 ) (int, string, error) {
 	var (
 		entityID int
@@ -82,9 +84,10 @@ func GetEntityOfBusinessID(
 
 	err := tx.QueryRow(
 		ctx,
-		"select entity_id, external_id from auth.entity_of_business_id($1, $2)",
+		"select entity_id, external_id from auth.get_or_create_entity($1, $2, $3)",
 		businessID,
 		businessIDType,
+		name,
 	).Scan(&entityID, &eid)
 	if err != nil {
 		return -1, "", fmt.Errorf("failed to get entity: %w", err)

--- a/backend/auth/oidc/oidc.go
+++ b/backend/auth/oidc/oidc.go
@@ -20,29 +20,46 @@ import (
 	"github.com/lestrrat-go/jwx/v4/jwt/openid"
 )
 
-// GetIdentifier returns the identifier and type from the token.
+// GetUserData returns the identifier, type, and name from the token.
 // Type is either "pid" (for person id) or "email".
-// This is just a convenience method since different OIDC providers have different claims for the identifier.
-func GetIdentifier(token openid.Token) (string, string) {
-	var id string
-	idType := "pid"
-	// iporten uses the pid claim
-	id, err := jwt.Get[string](token, "pid")
-	if err == nil {
-		return id, idType
+// This is just a convenience method since different OIDC providers have
+// different claims for the identifier.
+func GetUserData(token openid.Token) (string, string, string) {
+	// IDPorten uses the `pid` claim, and since we request the `profile` scope,
+	// we also get `given_name` and `family_name`.
+	// cf https://docs.digdir.no/docs/idporten/oidc/oidc_protocol_id_token.html
+	if pid, err := jwt.Get[string](token, "pid"); err == nil {
+		firstName, _ := jwt.Get[string](token, "given_name")
+		lastName, _ := jwt.Get[string](token, "family_name")
+		name := strings.TrimSpace(firstName + " " + lastName)
+		if name == "" {
+			name = pid
+		}
+		return pid, "pid", name
 	}
 
-	// authelia and entra uses the preferred_username claim
-	id, ok := token.PreferredUsername()
-	if !ok {
-		// oidcs uses the sub claim
+	// Entra and Authelia use the `preferred_username` claim, with `name`
+	// available when the `profile` scope is requested.
+	// cf https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference
+	// for Entra and the local config for Authelia.
+	var id string
+	if username, ok := token.PreferredUsername(); ok {
+		id = username
+	} else {
+		// Fall back to the `sub` claim for other providers.
 		id, _ = token.Subject()
 	}
 
+	idType := "pid"
 	if strings.Contains(id, "@") {
 		idType = "email"
 		id = strings.ToLower(id)
 	}
 
-	return id, idType
+	name, ok := token.Name()
+	if !ok || name == "" {
+		name = id
+	}
+
+	return id, idType, name
 }

--- a/db/auth/functions.sql
+++ b/db/auth/functions.sql
@@ -27,22 +27,48 @@ $$;
 GRANT EXECUTE ON FUNCTION auth.entity_of_credentials TO flex_anonymous;
 
 -- changeset flex:auth-entity-of-business-id runAlways:true endDelimiter:--
--- Gets entity details from the business id
-CREATE OR REPLACE FUNCTION auth.entity_of_business_id(
+-- Gets entity details from the business id, creating it if it does not exist.
+DROP FUNCTION IF EXISTS auth.entity_of_business_id(text, text);
+CREATE OR REPLACE FUNCTION auth.get_or_create_entity(
     in_business_id text,
-    in_business_id_type text
+    in_business_id_type text,
+    in_name text
 ) RETURNS TABLE (
     entity_id bigint,
     external_id uuid
 ) SECURITY DEFINER VOLATILE
-LANGUAGE sql
+LANGUAGE plpgsql
 AS $$
-    SELECT
-        e.id,
-        flex.identity_external_id(e.id, null, null) as external_id
+DECLARE
+    l_entity_id bigint;
+BEGIN
+    SELECT e.id INTO l_entity_id
     FROM flex.entity e
     WHERE e.business_id = in_business_id
-    AND e.business_id_type = in_business_id_type
+        AND e.business_id_type = in_business_id_type;
+
+    IF l_entity_id IS null THEN
+        INSERT INTO flex.entity (
+            name,
+            type,
+            business_id,
+            business_id_type,
+            recorded_by
+        ) VALUES (
+            in_name,
+            'person',
+            in_business_id,
+            in_business_id_type,
+            0
+        )
+        RETURNING id INTO l_entity_id;
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        l_entity_id AS entity_id,
+        flex.identity_external_id(l_entity_id, null, null) AS external_id;
+END;
 $$;
 
 -- changeset flex:auth-entity-client-by-uuid runAlways:true endDelimiter:--

--- a/db/auth/functions.sql
+++ b/db/auth/functions.sql
@@ -26,9 +26,11 @@ $$;
 -- changeset flex:auth-entity-of-credentials-execute runAlways:true endDelimiter:--
 GRANT EXECUTE ON FUNCTION auth.entity_of_credentials TO flex_anonymous;
 
--- changeset flex:auth-entity-of-business-id runAlways:true endDelimiter:--
--- Gets entity details from the business id, creating it if it does not exist.
+-- changeset flex:auth-entity-of-business-id-drop runAlways:true endDelimiter:--
 DROP FUNCTION IF EXISTS auth.entity_of_business_id(text, text);
+
+-- changeset flex:auth-get-or-create-entity runAlways:true endDelimiter:--
+-- Gets entity details from the business id, creating it if it does not exist.
 CREATE OR REPLACE FUNCTION auth.get_or_create_entity(
     in_business_id text,
     in_business_id_type text,

--- a/local/authelia/config/configuration.yml
+++ b/local/authelia/config/configuration.yml
@@ -102,7 +102,7 @@ identity_providers:
     # TODO see if we want to keep using preferred_username
     claims_policies:
       default:
-        id_token: ['preferred_username']
+        id_token: ['preferred_username', 'name']
     # https://www.authelia.com/configuration/identity-providers/openid-connect/clients/
     clients:
       - client_id: 'flex_oidc_client_id_value'

--- a/local/authelia/config/users.yml
+++ b/local/authelia/config/users.yml
@@ -16,3 +16,8 @@ users:
     displayname: Emil Post
     email: emil.post@example.com
     password: $argon2id$v=19$m=65536,t=3,p=4$gwGspsuAbuUOhDCsgbSpqw$ihRZwb6FTICgT/8LWhQFNgmNZK/q957xQEle6R1Wsog
+  'new.user@example.com':
+    disabled: false
+    displayname: New User
+    email: new.user@example.com
+    password: $argon2id$v=19$m=65536,t=3,p=4$gwGspsuAbuUOhDCsgbSpqw$ihRZwb6FTICgT/8LWhQFNgmNZK/q957xQEle6R1Wsog

--- a/test/auth_tests/test_scopes.py
+++ b/test/auth_tests/test_scopes.py
@@ -10,6 +10,7 @@ from security_token_service import (
     SecurityTokenService,
     TestEntity,
     AuthenticatedClient,
+    API_VERSION,
 )
 from flex.models import (
     EntityClientCreateRequest,
@@ -493,6 +494,7 @@ def test_scopes_embedding(jwt_keys):
         base_url=SecurityTokenService.api_url,
         token=party_token,
         verify_ssl=False,
+        headers={"Api-Version": API_VERSION},
     )
 
     # embed request fails because client cannot read party


### PR DESCRIPTION
This PR adds changes to the `/callback` endpoint in the auth API, so that a successful login in the IDP always causes an entity to exist for the user, so that they can get to the assume party page instead of getting a little user-friendly error message and having to contact their ORG admin to create their entity.

The auth mechanism translating an entity business ID into a technical ID now creates the entity if it does not already exist. All the call chain is updated. The name of the new entity is taken from the token, with various strategies based on the IDP, always falling back on the business ID itself on use of an unknown OIDC issuer.

One user without entity in the system has been added to the local config of Authelia so that we can test logging in and seeing the new entity created.