### PR TITLE
fix(ui): better label generation on table headers (FLEX-1225)

### DIFF
--- a/frontend/src/components/EDS-ra/list/Datagrid.tsx
+++ b/frontend/src/components/EDS-ra/list/Datagrid.tsx
@@ -4,6 +4,7 @@ import React, {
   cloneElement,
   isValidElement,
 } from "react";
+import { humanize } from "inflection";
 import { useNavigate } from "react-router-dom";
 import {
   FieldTitle,
@@ -115,6 +116,11 @@ export const DataTable = <T extends RaRecord>({
                     label={label}
                     resource={reference ?? resource}
                   />
+                  {reference && !label && (
+                    <span className="text-neutral-500">
+                      ({humanize(reference)})
+                    </span>
+                  )}
                   {headerTooltip && source && (
                     <FieldTooltip resource={resource} field={source} />
                   )}

--- a/frontend/src/intl/intl.tsx
+++ b/frontend/src/intl/intl.tsx
@@ -49,6 +49,22 @@ export const useI18nProvider = () => {
         // custom text
         return customText[key.slice("text.".length) as TextKey] ?? key;
 
+      // React-Admin default field label gives
+      // "resources.{resource}.fields.{field}" which is not associated to
+      // anything special. We don't want the default RA translation because we
+      // get for example "Business" instead of "Business ID". Instead we now
+      // try to redirect to our fieldLabels.
+      if (key.startsWith("resources.") && key.includes(".fields.")) {
+        const withoutPrefix = key.slice("resources.".length);
+        const fieldsIdx = withoutPrefix.indexOf(".fields.");
+        const resource = withoutPrefix.slice(0, fieldsIdx);
+        const field = withoutPrefix.slice(fieldsIdx + ".fields.".length);
+        const fieldKey = `${resource}.${field}`;
+        // cast to less precise type because we don't want a failure here
+        const label = (fieldLabels as Record<string, string>)[fieldKey];
+        if (label !== undefined) return label;
+      }
+
       // default case: resort to React-Admin
       return defaultI18nProvider.translate(key, options);
     },


### PR DESCRIPTION
This PR fixes a bug in labels in table headers, where we had stuff like `Business` instead of `Business ID`.

When there was no label, the name of the field was sent to the default translator in React-Admin, and we got back poorly informative headers.

Instead now we try to go through our field names in the resources YAML, and reference fields include the name of the referenced resource, unless `label` is given.

---

Some examples:

CU list after fix (`Business ID`, and the AP suffix to tell one ID from the other)

<img width="1852" height="139" alt="Screenshot 2026-05-22 151648" src="https://github.com/user-attachments/assets/6f0338cc-2553-46df-8679-ec1fc30cb821" />

SPG list (first `Name` is SPG name, second `Name` is now clearly the SP's name, whereas before we had `Name` twice)

<img width="997" height="246" alt="Screenshot 2026-05-22 161557" src="https://github.com/user-attachments/assets/4ec05317-a4c3-40fe-bd09-4076cf727c4b" />
