### PR TITLE
refactor: move policies from drop+runAlways to runOnChange+drop pattern (FLEX-1245)

### DIFF
--- a/db/flex/accounting_point_end_user_rls.sql
+++ b/db/flex/accounting_point_end_user_rls.sql
@@ -1,12 +1,13 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:accounting-point-end-user-rls runAlways:true endDelimiter:;
+-- changeset flex:accounting-point-end-user-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS accounting_point_end_user
 ENABLE ROW LEVEL SECURITY;
 
 GRANT SELECT ON accounting_point_end_user
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "APEU_INTERNAL_EVENT_NOTIFICATION" ON accounting_point_end_user;
 CREATE POLICY "APEU_INTERNAL_EVENT_NOTIFICATION"
 ON accounting_point_end_user
 FOR SELECT
@@ -15,6 +16,8 @@ USING (true);
 
 GRANT SELECT ON accounting_point_end_user_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "APEUH_INTERNAL_EVENT_NOTIFICATION"
+ON accounting_point_end_user_history;
 CREATE POLICY "APEUH_INTERNAL_EVENT_NOTIFICATION"
 ON accounting_point_end_user_history
 FOR SELECT
@@ -28,6 +31,7 @@ GRANT SELECT ON accounting_point_end_user
 TO flex_common;
 
 GRANT INSERT, SELECT, UPDATE, DELETE ON accounting_point_end_user TO flex_internal_data;
+DROP POLICY IF EXISTS "APEU_INTERNAL_DATA" ON accounting_point_end_user;
 CREATE POLICY "APEU_INTERNAL_DATA"
 ON accounting_point_end_user
 FOR ALL

--- a/db/flex/accounting_point_energy_supplier_rls.sql
+++ b/db/flex/accounting_point_energy_supplier_rls.sql
@@ -1,13 +1,15 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:accounting-point-energy-supplier-rls runAlways:true endDelimiter:;
+-- changeset flex:accounting-point-energy-supplier-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS accounting_point_energy_supplier
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON accounting_point_energy_supplier
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "APES_INTERNAL_EVENT_NOTIFICATION"
+ON accounting_point_energy_supplier;
 CREATE POLICY "APES_INTERNAL_EVENT_NOTIFICATION"
 ON accounting_point_energy_supplier
 FOR SELECT
@@ -16,6 +18,8 @@ USING (true);
 
 GRANT SELECT ON accounting_point_energy_supplier_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "APESH_INTERNAL_EVENT_NOTIFICATION"
+ON accounting_point_energy_supplier_history;
 CREATE POLICY "APESH_INTERNAL_EVENT_NOTIFICATION"
 ON accounting_point_energy_supplier_history
 FOR SELECT
@@ -24,6 +28,7 @@ USING (true);
 
 GRANT SELECT ON accounting_point_energy_supplier
 TO flex_common;
+DROP POLICY IF EXISTS "APES_INTERNAL_COMMON" ON accounting_point_energy_supplier;
 CREATE POLICY "APES_INTERNAL_COMMON"
 ON accounting_point_energy_supplier
 FOR SELECT
@@ -34,6 +39,7 @@ GRANT INSERT,
 SELECT,
 UPDATE,
 DELETE ON accounting_point_energy_supplier TO flex_internal_data;
+DROP POLICY IF EXISTS "APES_INTERNAL_DATA" ON accounting_point_energy_supplier;
 CREATE POLICY "APES_INTERNAL_DATA"
 ON accounting_point_energy_supplier
 FOR ALL

--- a/db/flex/accounting_point_grid_location_history_audit.sql
+++ b/db/flex/accounting_point_grid_location_history_audit.sql
@@ -25,11 +25,13 @@ ALTER TABLE IF EXISTS
 flex.accounting_point_grid_location_history
 ENABLE ROW LEVEL SECURITY;
 
--- changeset flex:accounting-point-grid-location-history-rls-com runAlways:true endDelimiter:--
+-- changeset flex:accounting-point-grid-location-history-rls-com runOnChange:true endDelimiter:--
 -- RLS: APGL-COM001
 GRANT SELECT ON flex.accounting_point_grid_location_history
 TO flex_common;
 
+DROP POLICY IF EXISTS "APGL_COM001"
+ON flex.accounting_point_grid_location_history;
 CREATE POLICY "APGL_COM001"
 ON flex.accounting_point_grid_location_history
 FOR SELECT

--- a/db/flex/accounting_point_grid_location_rls.sql
+++ b/db/flex/accounting_point_grid_location_rls.sql
@@ -1,13 +1,15 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:accounting-point-grid-location-rls runAlways:true endDelimiter:;
+-- changeset flex:accounting-point-grid-location-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS accounting_point_grid_location
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON accounting_point_grid_location
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "APGL_INTERNAL_EVENT_NOTIFICATION"
+ON accounting_point_grid_location;
 CREATE POLICY "APGL_INTERNAL_EVENT_NOTIFICATION" ON accounting_point_grid_location
 FOR SELECT
 TO flex_internal_event_notification
@@ -16,6 +18,7 @@ USING (true);
 -- RLS: APGL-FISO001
 GRANT SELECT, INSERT, UPDATE ON accounting_point_grid_location
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "APGL_FISO001" ON accounting_point_grid_location;
 CREATE POLICY "APGL_FISO001" ON accounting_point_grid_location
 FOR ALL
 TO flex_flexibility_information_system_operator
@@ -24,6 +27,7 @@ USING (true);
 -- RLS: APGL-SO001
 GRANT SELECT, INSERT, UPDATE ON accounting_point_grid_location
 TO flex_system_operator;
+DROP POLICY IF EXISTS "APGL_SO001" ON accounting_point_grid_location;
 CREATE POLICY "APGL_SO001" ON accounting_point_grid_location
 FOR ALL
 TO flex_system_operator

--- a/db/flex/accounting_point_metering_grid_area_rls.sql
+++ b/db/flex/accounting_point_metering_grid_area_rls.sql
@@ -1,12 +1,13 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:accounting-point-metering-grid-area-rls runAlways:true endDelimiter:;
+-- changeset flex:accounting-point-metering-grid-area-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS accounting_point_metering_grid_area
 ENABLE ROW LEVEL SECURITY;
 
 GRANT SELECT ON accounting_point_metering_grid_area
 TO flex_common;
+DROP POLICY IF EXISTS "APMGA_INTERNAL_COMMON" ON accounting_point_metering_grid_area;
 CREATE POLICY "APMGA_INTERNAL_COMMON"
 ON accounting_point_metering_grid_area
 FOR SELECT

--- a/db/flex/accounting_point_rls.sql
+++ b/db/flex/accounting_point_rls.sql
@@ -1,12 +1,13 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:accounting-point-rls runAlways:true endDelimiter:;
+-- changeset flex:accounting-point-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS accounting_point ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON accounting_point
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "AP_INTERNAL_EVENT_NOTIFICATION" ON accounting_point;
 CREATE POLICY "AP_INTERNAL_EVENT_NOTIFICATION"
 ON accounting_point
 FOR SELECT
@@ -15,6 +16,7 @@ USING (true);
 
 GRANT SELECT ON accounting_point_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "APH_INTERNAL_EVENT_NOTIFICATION" ON accounting_point_history;
 CREATE POLICY "APH_INTERNAL_EVENT_NOTIFICATION"
 ON accounting_point_history
 FOR SELECT
@@ -24,6 +26,7 @@ USING (true);
 -- RLS: AP-FISO001
 GRANT SELECT ON accounting_point
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "AP_FISO001" ON accounting_point;
 CREATE POLICY "AP_FISO001"
 ON accounting_point
 FOR SELECT
@@ -33,6 +36,7 @@ USING (true);
 -- RLS: AP-SO001
 GRANT SELECT ON accounting_point
 TO flex_system_operator;
+DROP POLICY IF EXISTS "AP_SO001" ON accounting_point;
 CREATE POLICY "AP_SO001"
 ON accounting_point
 FOR SELECT
@@ -95,6 +99,7 @@ USING (
 -- RLS: AP-SP001
 GRANT SELECT ON accounting_point
 TO flex_service_provider;
+DROP POLICY IF EXISTS "AP_SP001" ON accounting_point;
 CREATE POLICY "AP_SP001"
 ON accounting_point
 FOR SELECT
@@ -115,6 +120,7 @@ USING (
 );
 
 GRANT INSERT, SELECT, UPDATE, DELETE ON accounting_point TO flex_internal_data;
+DROP POLICY IF EXISTS "AP_INTERNAL_DATA" ON accounting_point;
 CREATE POLICY "AP_INTERNAL_DATA"
 ON accounting_point
 FOR ALL

--- a/db/flex/changelog.yml
+++ b/db/flex/changelog.yml
@@ -15,27 +15,6 @@ databaseChangeLog:
       changes:
         - sql: SELECT set_config('flex.current_identity', '0', false);
 
-  # Dropping policies to provide a clean slate on every migration
-  - changeSet:
-      id: drop-policies
-      author: flex
-
-      runAlways: true
-      changes:
-        - sql:
-            endDelimiter: "/"
-            sql: |
-              DO
-              $$
-              declare
-                rec record;
-              begin
-                for rec in (SELECT tablename, schemaname, policyname FROM pg_policies where schemaname = 'flex')
-                loop
-                  execute 'drop policy "'||rec.policyname||'" on '||rec.schemaname||'.'||rec.tablename;
-                end loop;
-              end;
-              $$;
   # Current user setting logic
   - include:
       file: ./current_user_setting.sql

--- a/db/flex/controllable_unit_rls.sql
+++ b/db/flex/controllable_unit_rls.sql
@@ -1,23 +1,26 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:controllable-unit-rls runAlways:true endDelimiter:;
+-- changeset flex:controllable-unit-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS controllable_unit ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON controllable_unit TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "CU_INTERNAL_EVENT_NOTIFICATION" ON controllable_unit;
 CREATE POLICY "CU_INTERNAL_EVENT_NOTIFICATION" ON controllable_unit
 FOR SELECT
 TO flex_internal_event_notification
 USING (true);
 
 GRANT SELECT ON controllable_unit_history TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "CUH_INTERNAL_EVENT_NOTIFICATION" ON controllable_unit_history;
 CREATE POLICY "CUH_INTERNAL_EVENT_NOTIFICATION" ON controllable_unit_history
 FOR SELECT
 TO flex_internal_event_notification
 USING (true);
 
 GRANT SELECT ON controllable_unit TO flex_internal_data;
+DROP POLICY IF EXISTS "CU_INTERNAL_DATA" ON controllable_unit;
 CREATE POLICY "CU_INTERNAL_DATA" ON controllable_unit
 FOR SELECT
 TO flex_internal_data
@@ -26,6 +29,7 @@ USING (true);
 -- RLS: CU-FISO001
 GRANT SELECT, INSERT, UPDATE ON controllable_unit
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "CU_FISO001" ON controllable_unit;
 CREATE POLICY "CU_FISO001" ON controllable_unit
 FOR ALL
 TO flex_flexibility_information_system_operator
@@ -33,6 +37,7 @@ USING (true);
 
 -- RLS: CU-SO001
 GRANT SELECT, UPDATE ON controllable_unit TO flex_system_operator;
+DROP POLICY IF EXISTS "CU_SO001" ON controllable_unit;
 CREATE POLICY "CU_SO001" ON controllable_unit
 FOR ALL
 TO flex_system_operator
@@ -47,6 +52,7 @@ USING (
 );
 
 -- RLS: CU-SO002
+DROP POLICY IF EXISTS "CU_SO002" ON controllable_unit;
 CREATE POLICY "CU_SO002" ON controllable_unit
 FOR SELECT
 TO flex_system_operator
@@ -60,6 +66,7 @@ USING (
 GRANT SELECT, INSERT, UPDATE ON controllable_unit TO flex_service_provider;
 -- RLS: CU-SP001
 -- RLS: CU-SP005
+DROP POLICY IF EXISTS "CU_SP001_SP005" ON controllable_unit;
 CREATE POLICY "CU_SP001_SP005" ON controllable_unit
 FOR SELECT
 TO flex_service_provider
@@ -81,12 +88,14 @@ USING (
 );
 
 -- RLS: CU-SP002
+DROP POLICY IF EXISTS "CU_SP002" ON controllable_unit;
 CREATE POLICY "CU_SP002" ON controllable_unit
 FOR INSERT
 TO flex_service_provider
 WITH CHECK (true);
 
 -- RLS: CU-SP003
+DROP POLICY IF EXISTS "CU_SP003" ON controllable_unit;
 CREATE POLICY "CU_SP003" ON controllable_unit
 FOR UPDATE
 TO flex_service_provider
@@ -104,6 +113,7 @@ USING (
 
 -- RLS: CU-EU001
 GRANT SELECT ON controllable_unit TO flex_end_user;
+DROP POLICY IF EXISTS "CU_EU001" ON controllable_unit;
 CREATE POLICY "CU_EU001" ON controllable_unit
 FOR SELECT
 TO flex_end_user
@@ -119,6 +129,7 @@ USING (
 
 -- RLS: CU-ES001
 GRANT SELECT ON controllable_unit TO flex_energy_supplier;
+DROP POLICY IF EXISTS "CU_ES001" ON controllable_unit;
 CREATE POLICY "CU_ES001" ON controllable_unit
 FOR SELECT
 TO flex_energy_supplier
@@ -134,6 +145,7 @@ USING (
 
 -- RLS: CU-BRP001
 GRANT SELECT ON controllable_unit TO flex_balance_responsible_party;
+DROP POLICY IF EXISTS "CU_BRP001" ON controllable_unit;
 CREATE POLICY "CU_BRP001" ON controllable_unit
 FOR SELECT
 TO flex_balance_responsible_party
@@ -152,6 +164,7 @@ ENABLE ROW LEVEL SECURITY;
 
 -- RLS: CU-EU002
 GRANT SELECT ON controllable_unit_history TO flex_end_user;
+DROP POLICY IF EXISTS "CU_EU002" ON controllable_unit_history;
 CREATE POLICY "CU_EU002"
 ON controllable_unit_history
 FOR SELECT
@@ -170,6 +183,7 @@ USING (
 
 -- RLS: CU-ES002
 GRANT SELECT ON controllable_unit_history TO flex_energy_supplier;
+DROP POLICY IF EXISTS "CU_ES002" ON controllable_unit_history;
 CREATE POLICY "CU_ES002"
 ON controllable_unit_history
 FOR SELECT
@@ -188,6 +202,7 @@ USING (
 
 -- RLS: CU-BRP002
 GRANT SELECT ON controllable_unit_history TO flex_balance_responsible_party;
+DROP POLICY IF EXISTS "CU_BRP002" ON controllable_unit_history;
 CREATE POLICY "CU_BRP002"
 ON controllable_unit_history
 FOR SELECT
@@ -207,6 +222,7 @@ USING (
 -- RLS: CU-FISO002
 GRANT SELECT ON controllable_unit_history
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "CU_FISO002" ON controllable_unit_history;
 CREATE POLICY "CU_FISO002"
 ON controllable_unit_history
 FOR SELECT
@@ -216,6 +232,7 @@ USING (true);
 -- RLS: CU-SO003
 GRANT SELECT ON controllable_unit_history
 TO flex_system_operator;
+DROP POLICY IF EXISTS "CU_SO003" ON controllable_unit_history;
 CREATE POLICY "CU_SO003"
 ON controllable_unit_history
 FOR SELECT
@@ -231,6 +248,7 @@ USING (
 -- RLS: CU-SP004
 GRANT SELECT ON controllable_unit_history
 TO flex_service_provider;
+DROP POLICY IF EXISTS "CU_SP004" ON controllable_unit_history;
 CREATE POLICY "CU_SP004"
 ON controllable_unit_history
 FOR SELECT

--- a/db/flex/controllable_unit_service_provider_rls.sql
+++ b/db/flex/controllable_unit_service_provider_rls.sql
@@ -1,13 +1,15 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:controllable-unit-service-provider-rls runAlways:true endDelimiter:;
+-- changeset flex:controllable-unit-service-provider-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS controllable_unit_service_provider
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON controllable_unit_service_provider
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "CUSP_INTERNAL_EVENT_NOTIFICATION"
+ON controllable_unit_service_provider;
 CREATE POLICY "CUSP_INTERNAL_EVENT_NOTIFICATION"
 ON controllable_unit_service_provider
 FOR SELECT
@@ -16,6 +18,8 @@ USING (true);
 
 GRANT SELECT ON controllable_unit_service_provider_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "CUSPH_INTERNAL_EVENT_NOTIFICATION"
+ON controllable_unit_service_provider_history;
 CREATE POLICY "CUSPH_INTERNAL_EVENT_NOTIFICATION"
 ON controllable_unit_service_provider_history
 FOR SELECT
@@ -25,6 +29,7 @@ USING (true);
 -- RLS: CUSP-FISO001
 GRANT SELECT, INSERT, UPDATE, DELETE ON controllable_unit_service_provider
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "CUSP_FISO001" ON controllable_unit_service_provider;
 CREATE POLICY "CUSP_FISO001"
 ON controllable_unit_service_provider
 FOR ALL
@@ -35,6 +40,8 @@ USING (true);
 GRANT SELECT ON controllable_unit_service_provider
 TO flex_system_operator;
 
+DROP POLICY IF EXISTS controllable_unit_service_provider_so
+ON controllable_unit_service_provider;
 CREATE POLICY controllable_unit_service_provider_so
 ON controllable_unit_service_provider
 FOR ALL
@@ -50,6 +57,8 @@ USING (
 -- RLS: CUSP-SP001
 GRANT SELECT, INSERT, UPDATE, DELETE ON controllable_unit_service_provider
 TO flex_service_provider;
+DROP POLICY IF EXISTS controllable_unit_service_provider_sp
+ON controllable_unit_service_provider;
 CREATE POLICY controllable_unit_service_provider_sp
 ON controllable_unit_service_provider
 FOR ALL
@@ -58,6 +67,7 @@ USING (service_provider_id = (SELECT current_party()));
 
 -- RLS: CUSP-EU001
 GRANT SELECT ON controllable_unit_service_provider TO flex_end_user;
+DROP POLICY IF EXISTS "CUSP_EU001" ON controllable_unit_service_provider;
 CREATE POLICY "CUSP_EU001"
 ON controllable_unit_service_provider
 FOR SELECT
@@ -78,6 +88,7 @@ ENABLE ROW LEVEL SECURITY;
 -- RLS: CUSP-EU002
 GRANT SELECT ON controllable_unit_service_provider_history
 TO flex_end_user;
+DROP POLICY IF EXISTS "CUSP_EU002" ON controllable_unit_service_provider_history;
 CREATE POLICY "CUSP_EU002"
 ON controllable_unit_service_provider_history
 FOR SELECT
@@ -87,9 +98,9 @@ USING (
         SELECT 1
         FROM controllable_unit_end_user AS cueu
         WHERE cueu.controllable_unit_id = controllable_unit_service_provider_history.controllable_unit_id -- noqa
-            -- this version of the CUSP in the history puts the contract in the
-            -- period when the current party is the end user of the AP
-            AND cueu.end_user_id = (SELECT current_party())
+        -- this version of the CUSP in the history puts the contract in the
+        -- period when the current party is the end user of the AP
+        AND cueu.end_user_id = (SELECT current_party())
             AND cueu.valid_time_range && controllable_unit_service_provider_history.valid_time_range -- noqa
     )
 );
@@ -97,6 +108,7 @@ USING (
 -- RLS: CUSP-FISO002
 GRANT SELECT ON controllable_unit_service_provider_history
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "CUSP_FISO001" ON controllable_unit_service_provider_history;
 CREATE POLICY "CUSP_FISO001"
 ON controllable_unit_service_provider_history
 FOR SELECT
@@ -112,6 +124,7 @@ USING (
 -- RLS: CUSP-SO002
 GRANT SELECT ON controllable_unit_service_provider_history
 TO flex_system_operator;
+DROP POLICY IF EXISTS "CUSP_SO002" ON controllable_unit_service_provider_history;
 CREATE POLICY "CUSP_SO002"
 ON controllable_unit_service_provider_history
 FOR SELECT
@@ -127,6 +140,7 @@ USING (
 -- RLS: CUSP-SP002
 GRANT SELECT ON controllable_unit_service_provider_history
 TO flex_service_provider;
+DROP POLICY IF EXISTS "CUSP_SP002" ON controllable_unit_service_provider_history;
 CREATE POLICY "CUSP_SP002"
 ON controllable_unit_service_provider_history
 FOR SELECT

--- a/db/flex/controllable_unit_suspension_comment_rls.sql
+++ b/db/flex/controllable_unit_suspension_comment_rls.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 -- GENERATED CODE -- DO NOT EDIT (scripts/openapi_to_db.py)
 
--- changeset flex:controllable-unit-suspension-comment-rls runAlways:true endDelimiter:;
+-- changeset flex:controllable-unit-suspension-comment-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS
 controllable_unit_suspension_comment
 ENABLE ROW LEVEL SECURITY;
@@ -10,6 +10,8 @@ ENABLE ROW LEVEL SECURITY;
 GRANT SELECT
 ON controllable_unit_suspension_comment
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "CUSC_INTERNAL_EVENT_NOTIFICATION"
+ON controllable_unit_suspension_comment;
 CREATE POLICY "CUSC_INTERNAL_EVENT_NOTIFICATION"
 ON controllable_unit_suspension_comment
 FOR SELECT
@@ -19,6 +21,8 @@ USING (true);
 GRANT SELECT
 ON controllable_unit_suspension_comment_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "CUSCH_INTERNAL_EVENT_NOTIFICATION"
+ON controllable_unit_suspension_comment_history;
 CREATE POLICY "CUSCH_INTERNAL_EVENT_NOTIFICATION"
 ON controllable_unit_suspension_comment_history
 FOR SELECT
@@ -30,6 +34,8 @@ ON controllable_unit_suspension_comment
 TO flex_common;
 
 -- RLS: CUSC-COM001
+DROP POLICY IF EXISTS "CUSC_COM001"
+ON controllable_unit_suspension_comment;
 CREATE POLICY "CUSC_COM001"
 ON controllable_unit_suspension_comment
 FOR UPDATE
@@ -38,6 +44,8 @@ USING (created_by = (SELECT flex.current_identity()));
 
 -- RLS: CUSC-SO001
 -- RLS: CUSC-SP001
+DROP POLICY IF EXISTS "CUSC_SO001_SP001"
+ON controllable_unit_suspension_comment;
 CREATE POLICY "CUSC_SO001_SP001"
 ON controllable_unit_suspension_comment
 FOR INSERT
@@ -53,6 +61,8 @@ WITH CHECK (
 
 -- RLS: CUSC-SO002
 -- RLS: CUSC-SP002
+DROP POLICY IF EXISTS "CUSC_SO002_SP002_same_party"
+ON controllable_unit_suspension_comment;
 CREATE POLICY "CUSC_SO002_SP002_same_party"
 ON controllable_unit_suspension_comment
 FOR SELECT
@@ -68,6 +78,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "CUSC_SO002_SP002_any_involved_party"
+ON controllable_unit_suspension_comment;
 CREATE POLICY "CUSC_SO002_SP002_any_involved_party"
 ON controllable_unit_suspension_comment
 FOR SELECT
@@ -115,6 +127,8 @@ $$;
 GRANT SELECT
 ON controllable_unit_suspension_comment_history
 TO flex_system_operator, flex_service_provider;
+DROP POLICY IF EXISTS "CUSC_SO003_SP003_same_party"
+ON controllable_unit_suspension_comment_history;
 CREATE POLICY "CUSC_SO003_SP003_same_party"
 ON controllable_unit_suspension_comment_history
 FOR SELECT
@@ -132,6 +146,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "CUSC_SO003_SP003_any_involved_party"
+ON controllable_unit_suspension_comment_history;
 CREATE POLICY "CUSC_SO003_SP003_any_involved_party"
 ON controllable_unit_suspension_comment_history
 FOR SELECT
@@ -149,6 +165,8 @@ USING (
 );
 
 -- RLS: CUSC-FISO001
+DROP POLICY IF EXISTS "CUSC_FISO001"
+ON controllable_unit_suspension_comment;
 CREATE POLICY "CUSC_FISO001"
 ON controllable_unit_suspension_comment
 FOR ALL
@@ -156,6 +174,8 @@ TO flex_flexibility_information_system_operator
 USING (true);
 
 -- RLS: CUSC-FISO002
+DROP POLICY IF EXISTS "CUSC_FISO002"
+ON controllable_unit_suspension_comment_history;
 CREATE POLICY "CUSC_FISO002"
 ON controllable_unit_suspension_comment_history
 FOR ALL

--- a/db/flex/controllable_unit_suspension_rls.sql
+++ b/db/flex/controllable_unit_suspension_rls.sql
@@ -1,13 +1,14 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:controllable-unit-suspension-rls runAlways:true endDelimiter:;
+-- changeset flex:controllable-unit-suspension-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS controllable_unit_suspension
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON controllable_unit_suspension
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "CUS_INTERNAL_EVENT_NOTIFICATION" ON controllable_unit_suspension;
 CREATE POLICY "CUS_INTERNAL_EVENT_NOTIFICATION"
 ON controllable_unit_suspension
 FOR SELECT
@@ -16,6 +17,8 @@ USING (true);
 
 GRANT SELECT ON controllable_unit_suspension_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "CUS_HISTORY_INTERNAL_EVENT_NOTIFICATION"
+ON controllable_unit_suspension_history;
 CREATE POLICY "CUS_HISTORY_INTERNAL_EVENT_NOTIFICATION"
 ON controllable_unit_suspension_history
 FOR SELECT
@@ -25,6 +28,7 @@ USING (true);
 -- RLS: CUS-FISO001
 GRANT SELECT, INSERT, UPDATE, DELETE ON controllable_unit_suspension
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "CUS_FISO001" ON controllable_unit_suspension;
 CREATE POLICY "CUS_FISO001"
 ON controllable_unit_suspension
 FOR ALL
@@ -34,6 +38,7 @@ USING (true);
 -- RLS: CUS-FISO002
 GRANT SELECT ON controllable_unit_suspension_history
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "CUS_FISO002" ON controllable_unit_suspension_history;
 CREATE POLICY "CUS_FISO002"
 ON controllable_unit_suspension_history
 FOR SELECT
@@ -43,6 +48,7 @@ USING (true);
 -- RLS: CUS-SP001
 GRANT SELECT ON controllable_unit_suspension
 TO flex_service_provider;
+DROP POLICY IF EXISTS "CUS_SP001" ON controllable_unit_suspension;
 CREATE POLICY "CUS_SP001"
 ON controllable_unit_suspension
 FOR SELECT
@@ -51,7 +57,8 @@ USING (
     EXISTS (
         SELECT 1
         FROM flex.controllable_unit_service_provider AS cusp
-        WHERE cusp.controllable_unit_id
+        WHERE
+            cusp.controllable_unit_id
         = controllable_unit_suspension.controllable_unit_id -- noqa
             AND cusp.service_provider_id = (SELECT flex.current_party())
             AND cusp.valid_time_range
@@ -62,6 +69,7 @@ USING (
 -- RLS: CUS-SP002
 GRANT SELECT ON controllable_unit_suspension_history
 TO flex_service_provider;
+DROP POLICY IF EXISTS "CUS_SP002" ON controllable_unit_suspension_history;
 CREATE POLICY "CUS_SP002"
 ON controllable_unit_suspension_history
 FOR SELECT
@@ -70,7 +78,8 @@ USING (
     EXISTS (
         SELECT 1
         FROM flex.controllable_unit_service_provider AS cusp
-        WHERE cusp.controllable_unit_id
+        WHERE
+            cusp.controllable_unit_id
         = controllable_unit_suspension_history.controllable_unit_id -- noqa
             AND cusp.service_provider_id = (SELECT flex.current_party())
             AND cusp.valid_time_range
@@ -81,6 +90,7 @@ USING (
 -- RLS: CUS-SO001
 GRANT SELECT, INSERT, UPDATE, DELETE ON controllable_unit_suspension
 TO flex_system_operator;
+DROP POLICY IF EXISTS "CUS_SO001" ON controllable_unit_suspension;
 CREATE POLICY "CUS_SO001"
 ON controllable_unit_suspension
 FOR ALL
@@ -90,6 +100,7 @@ USING (impacted_system_operator_id = (SELECT flex.current_party()));
 -- RLS: CUS-SO002
 GRANT SELECT ON controllable_unit_suspension_history
 TO flex_system_operator;
+DROP POLICY IF EXISTS "CUS_SO002" ON controllable_unit_suspension_history;
 CREATE POLICY "CUS_SO002"
 ON controllable_unit_suspension_history
 FOR SELECT
@@ -97,6 +108,7 @@ TO flex_system_operator
 USING (impacted_system_operator_id = (SELECT flex.current_party()));
 
 -- RLS: CUS-SO003
+DROP POLICY IF EXISTS "CUS_SO003" ON controllable_unit_suspension;
 CREATE POLICY "CUS_SO003"
 ON controllable_unit_suspension
 FOR SELECT
@@ -110,6 +122,7 @@ USING (
 );
 
 -- RLS: CUS-SO004
+DROP POLICY IF EXISTS "CUS_SO004" ON controllable_unit_suspension_history;
 CREATE POLICY "CUS_SO004"
 ON controllable_unit_suspension_history
 FOR SELECT

--- a/db/flex/energy_supplier_balance_responsibility_rls.sql
+++ b/db/flex/energy_supplier_balance_responsibility_rls.sql
@@ -1,12 +1,13 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:energy-supplier-balance-responsibility-rls runAlways:true endDelimiter:;
+-- changeset flex:energy-supplier-balance-responsibility-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS energy_supplier_balance_responsibility
 ENABLE ROW LEVEL SECURITY;
 
 GRANT SELECT ON energy_supplier_balance_responsibility
 TO flex_common;
+DROP POLICY IF EXISTS "ESBR_INTERNAL_COMMON" ON energy_supplier_balance_responsibility;
 CREATE POLICY "ESBR_INTERNAL_COMMON"
 ON energy_supplier_balance_responsibility
 FOR SELECT

--- a/db/flex/entity_client_rls.sql
+++ b/db/flex/entity_client_rls.sql
@@ -1,11 +1,12 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:entity-client-rls runAlways:true endDelimiter:;
+-- changeset flex:entity-client-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS entity_client ENABLE ROW LEVEL SECURITY;
 
 -- RLS: ECL-ENT001
 GRANT INSERT, SELECT, UPDATE, DELETE ON entity_client TO flex_entity;
+DROP POLICY IF EXISTS "ECL_ENT001" ON entity_client;
 CREATE POLICY "ECL_ENT001" ON entity_client
 FOR ALL
 TO flex_entity
@@ -14,6 +15,7 @@ USING (
 );
 
 -- RLS: ECL-FISO001
+DROP POLICY IF EXISTS "ECL_FISO001" ON entity_client;
 CREATE POLICY "ECL_FISO001" ON entity_client
 FOR SELECT
 TO flex_flexibility_information_system_operator
@@ -37,6 +39,7 @@ $$;
 
 GRANT INSERT, SELECT, UPDATE, DELETE ON entity_client TO flex_organisation;
 -- RLS: ECL-ORG001
+DROP POLICY IF EXISTS "ECL_ORG001" ON entity_client;
 CREATE POLICY "ECL_ORG001" ON entity_client
 FOR SELECT
 TO flex_organisation
@@ -44,6 +47,7 @@ USING (
     entity_id = (SELECT flex.current_party_owner())
 );
 -- RLS: ECL-ORG002
+DROP POLICY IF EXISTS "ECL_ORG002_INSERT" ON entity_client;
 CREATE POLICY "ECL_ORG002_INSERT" ON entity_client
 FOR INSERT
 TO flex_organisation
@@ -51,6 +55,7 @@ WITH CHECK (
     (SELECT user_is_human())
     AND entity_id = (SELECT flex.current_party_owner())
 );
+DROP POLICY IF EXISTS "ECL_ORG002_UPDATE" ON entity_client;
 CREATE POLICY "ECL_ORG002_UPDATE" ON entity_client
 FOR UPDATE
 TO flex_organisation
@@ -58,6 +63,7 @@ USING (
     (SELECT user_is_human())
     AND entity_id = (SELECT flex.current_party_owner())
 );
+DROP POLICY IF EXISTS "ECL_ORG002_DELETE" ON entity_client;
 CREATE POLICY "ECL_ORG002_DELETE" ON entity_client
 FOR DELETE
 TO flex_organisation

--- a/db/flex/entity_rls.sql
+++ b/db/flex/entity_rls.sql
@@ -1,18 +1,20 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:entity-rls runAlways:true endDelimiter:;
+-- changeset flex:entity-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS entity ENABLE ROW LEVEL SECURITY;
 
 -- RLS: ENT-COM001
 -- RLS: ENT-ENT001
 GRANT SELECT ON entity TO flex_common;
+DROP POLICY IF EXISTS "ENT_COM001_ENT001" ON entity;
 CREATE POLICY "ENT_COM001_ENT001" ON entity
 FOR SELECT
 TO flex_common
 USING (type = 'organisation' OR id = (SELECT flex.current_entity()));
 
 GRANT SELECT ON entity TO flex_entity;
+DROP POLICY IF EXISTS "ENT_ENT001" ON entity;
 CREATE POLICY "ENT_ENT001" ON entity
 FOR SELECT
 TO flex_entity
@@ -20,6 +22,7 @@ USING (id = (SELECT flex.current_entity()));
 
 -- RLS: ENT-COM002
 -- RLS: ENT-COM003
+DROP POLICY IF EXISTS "ENT_COM002_COM003" ON entity;
 CREATE POLICY "ENT_COM002_COM003" ON entity
 FOR SELECT
 TO flex_common
@@ -35,12 +38,14 @@ USING (EXISTS (
 
 -- RLS: ENT-FISO001
 GRANT SELECT, INSERT ON entity TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "ENT_FISO001" ON entity;
 CREATE POLICY "ENT_FISO001" ON entity
 FOR ALL
 TO flex_flexibility_information_system_operator
 USING (true);
 
 GRANT SELECT, INSERT ON entity TO flex_internal_data;
+DROP POLICY IF EXISTS "ENT_INTERNAL_DATA" ON entity;
 CREATE POLICY "ENT_INTERNAL_DATA" ON entity
 FOR ALL
 TO flex_internal_data
@@ -48,6 +53,7 @@ USING (true);
 
 -- RLS: ENT-ORG001
 GRANT SELECT ON entity TO flex_organisation;
+DROP POLICY IF EXISTS "ENT_ORG001" ON entity;
 CREATE POLICY "ENT_ORG001" ON entity
 FOR SELECT
 TO flex_organisation
@@ -65,6 +71,7 @@ USING (
 );
 
 -- RLS: ENT-ORG002
+DROP POLICY IF EXISTS "ENT_ORG002" ON entity;
 CREATE POLICY "ENT_ORG002" ON entity
 FOR SELECT
 TO flex_organisation

--- a/db/flex/event_rls.sql
+++ b/db/flex/event_rls.sql
@@ -44,17 +44,19 @@ EXCEPTION
 END;
 $$;
 
--- changeset flex:event-rls runAlways:true endDelimiter:;
+-- changeset flex:event-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS event ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON event TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "EVENT_INTERNAL_EVENT_NOTIFICATION_SELECT" ON event;
 CREATE POLICY "EVENT_INTERNAL_EVENT_NOTIFICATION_SELECT" ON event
 FOR SELECT
 TO flex_internal_event_notification
 USING (true);
 
 GRANT UPDATE (processed) ON event TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "EVENT_INTERNAL_EVENT_NOTIFICATION_UPDATE" ON event;
 CREATE POLICY "EVENT_INTERNAL_EVENT_NOTIFICATION_UPDATE" ON event
 FOR UPDATE
 TO flex_internal_event_notification
@@ -66,6 +68,7 @@ GRANT SELECT ON event TO flex_end_user;
 -- RLS: EVENT-EU001
 -- RLS: EVENT-EU002
 -- RLS: EVENT-EU003
+DROP POLICY IF EXISTS "EVENT_EU001_002_003" ON event;
 CREATE POLICY "EVENT_EU001_002_003" ON event
 FOR SELECT
 TO flex_end_user
@@ -81,6 +84,7 @@ USING (
 
 -- RLS: EVENT-FISO001
 GRANT SELECT ON event TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "EVENT_FISO001" ON event;
 CREATE POLICY "EVENT_FISO001" ON event
 FOR SELECT
 TO flex_flexibility_information_system_operator
@@ -88,6 +92,7 @@ USING (true);
 
 -- RLS: EVENT-COM001
 GRANT SELECT ON event TO flex_common;
+DROP POLICY IF EXISTS "EVENT_COM001" ON event;
 CREATE POLICY "EVENT_COM001" ON event
 FOR SELECT
 TO flex_common

--- a/db/flex/identity_rls.sql
+++ b/db/flex/identity_rls.sql
@@ -1,11 +1,12 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:identity-rls runAlways:true endDelimiter:;
+-- changeset flex:identity-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS identity ENABLE ROW LEVEL SECURITY;
 
 -- RLS: ID-ENT001
 GRANT SELECT ON identity TO flex_entity;
+DROP POLICY IF EXISTS "ID_ENT001" ON identity;
 CREATE POLICY "ID_ENT001" ON identity
 FOR SELECT
 TO flex_entity
@@ -13,6 +14,7 @@ USING (true);
 
 -- RLS: ID-COM001
 GRANT SELECT ON identity TO flex_common;
+DROP POLICY IF EXISTS "ID_COM001" ON identity;
 CREATE POLICY "ID_COM001" ON identity
 FOR SELECT
 TO flex_common

--- a/db/flex/metering_grid_area_rls.sql
+++ b/db/flex/metering_grid_area_rls.sql
@@ -1,11 +1,12 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:metering-grid-area-rls runAlways:true endDelimiter:;
+-- changeset flex:metering-grid-area-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS metering_grid_area ENABLE ROW LEVEL SECURITY;
 
 -- RLS: MGA-COM001
 GRANT SELECT ON metering_grid_area TO flex_common;
+DROP POLICY IF EXISTS "MGA_COM001" ON metering_grid_area;
 CREATE POLICY "MGA_COM001" ON metering_grid_area
 FOR SELECT
 TO flex_common

--- a/db/flex/notice_rls.sql
+++ b/db/flex/notice_rls.sql
@@ -1,17 +1,19 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:notice-rls runAlways:true endDelimiter:;
+-- changeset flex:notice-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS notice ENABLE ROW LEVEL SECURITY;
 
 -- RLS: NOTICE-COM001
 GRANT SELECT, UPDATE ON notice TO flex_common;
+DROP POLICY IF EXISTS "NOTICE_COM001" ON notice;
 CREATE POLICY "NOTICE_COM001" ON notice
 FOR ALL
 TO flex_common
 USING (party_id = (SELECT flex.current_party()));
 
 -- RLS: NOTICE-FISO001
+DROP POLICY IF EXISTS "NOTICE_FISO001" ON notice;
 CREATE POLICY "NOTICE_FISO001" ON notice
 FOR SELECT
 TO flex_flexibility_information_system_operator
@@ -20,6 +22,7 @@ USING (true);
 -- internal: used for reading events on notices (notice history is not exposed)
 -- user can read history when they can read a notice
 GRANT SELECT ON notice_history TO flex_common;
+DROP POLICY IF EXISTS "NOTICEH_INTERNAL" ON notice_history;
 CREATE POLICY "NOTICEH_INTERNAL" ON notice_history
 FOR SELECT
 TO flex_common

--- a/db/flex/notification_rls.sql
+++ b/db/flex/notification_rls.sql
@@ -1,12 +1,13 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:notification-rls runAlways:true endDelimiter:;
+-- changeset flex:notification-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS notification ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT, INSERT ON notification
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "NOTIFICATION_INTERNAL_EVENT_NOTIFICATION" ON notification;
 CREATE POLICY "NOTIFICATION_INTERNAL_EVENT_NOTIFICATION"
 ON notification
 FOR ALL
@@ -15,6 +16,8 @@ USING (true);
 
 GRANT SELECT, INSERT ON notification_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "NOTIFICATIONH_INTERNAL_EVENT_NOTIFICATION"
+ON notification_history;
 CREATE POLICY "NOTIFICATIONH_INTERNAL_EVENT_NOTIFICATION"
 ON notification_history
 FOR SELECT
@@ -23,12 +26,14 @@ USING (true);
 
 -- RLS: NOT-COM001
 GRANT SELECT, UPDATE ON notification TO flex_common;
+DROP POLICY IF EXISTS "NOT_COM001" ON notification;
 CREATE POLICY "NOT_COM001" ON notification
 FOR ALL
 TO flex_common
 USING (party_id = (SELECT flex.current_party()));
 
 -- RLS: NOT-FISO001
+DROP POLICY IF EXISTS "NOT_FISO001" ON notification;
 CREATE POLICY "NOT_FISO001" ON notification
 FOR SELECT
 TO flex_flexibility_information_system_operator

--- a/db/flex/party_history_audit.sql
+++ b/db/flex/party_history_audit.sql
@@ -25,11 +25,13 @@ ALTER TABLE IF EXISTS
 flex.party_history
 ENABLE ROW LEVEL SECURITY;
 
--- changeset flex:party-history-rls-com runAlways:true endDelimiter:--
+-- changeset flex:party-history-rls-com runOnChange:true endDelimiter:--
 -- RLS: PTY-COM001
 GRANT SELECT ON flex.party_history
 TO flex_common;
 
+DROP POLICY IF EXISTS "PTY_COM001"
+ON flex.party_history;
 CREATE POLICY "PTY_COM001"
 ON flex.party_history
 FOR SELECT

--- a/db/flex/party_membership_rls.sql
+++ b/db/flex/party_membership_rls.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:party-membership-rls runAlways:true endDelimiter:;
+-- changeset flex:party-membership-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS party_membership ENABLE ROW LEVEL SECURITY;
 
 -- RLS: PTYM-FISO001
@@ -9,6 +9,7 @@ GRANT INSERT,
 SELECT,
 UPDATE,
 DELETE ON party_membership TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "PTYM_FISO001" ON party_membership;
 CREATE POLICY "PTYM_FISO001" ON party_membership
 FOR ALL
 TO flex_flexibility_information_system_operator
@@ -17,6 +18,7 @@ USING (true);
 -- RLS: PTYM-FISO002
 GRANT SELECT ON party_membership
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "PTYM_FISO002" ON party_membership_history;
 CREATE POLICY "PTYM_FISO002" ON party_membership_history
 FOR SELECT
 TO flex_flexibility_information_system_operator
@@ -24,6 +26,7 @@ USING (true);
 
 -- RLS: PTYM-ENT001
 GRANT SELECT ON party_membership TO flex_entity;
+DROP POLICY IF EXISTS "PTYM_ENT001" ON party_membership;
 CREATE POLICY "PTYM_ENT001" ON party_membership
 FOR SELECT
 TO flex_entity
@@ -45,6 +48,7 @@ AS $$
 $$;
 
 -- RLS: PTYM-ENT002
+DROP POLICY IF EXISTS "PTYM_ENT002" ON party_membership;
 CREATE POLICY "PTYM_ENT002" ON party_membership
 FOR SELECT
 TO flex_entity
@@ -52,12 +56,14 @@ USING (entity_owns_party((SELECT current_entity()), party_id));
 
 -- RLS: PTYM-COM001
 GRANT SELECT ON party_membership TO flex_common;
+DROP POLICY IF EXISTS "PTYM_COM001" ON party_membership;
 CREATE POLICY "PTYM_COM001" ON party_membership
 FOR SELECT
 TO flex_common
 USING (party_id = (SELECT current_party()));
 
 -- RLS: PTYM-COM002
+DROP POLICY IF EXISTS "PTYM_COM002" ON party_membership_history;
 CREATE POLICY "PTYM_COM002" ON party_membership_history
 FOR SELECT
 TO flex_common
@@ -65,6 +71,7 @@ USING (party_id = (SELECT current_party()));
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON party_membership TO flex_organisation;
 -- RLS: PTYM-ORG001
+DROP POLICY IF EXISTS "PTYM_ORG001" ON party_membership;
 CREATE POLICY "PTYM_ORG001" ON party_membership
 FOR ALL
 TO flex_organisation
@@ -74,6 +81,7 @@ USING (entity_owns_party((SELECT flex.current_party_owner()), party_id));
 -- can use the same check as the main table policy because entity/party are
 -- not deletable and owning party is immutable
 GRANT SELECT ON party_membership_history TO flex_organisation;
+DROP POLICY IF EXISTS "PTYM_ORG002" ON party_membership_history;
 CREATE POLICY "PTYM_ORG002" ON party_membership_history
 FOR SELECT
 TO flex_organisation

--- a/db/flex/party_rls.sql
+++ b/db/flex/party_rls.sql
@@ -1,17 +1,19 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:party-rls runAlways:true endDelimiter:;
+-- changeset flex:party-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS party ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON party TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "PTY_INTERNAL_EVENT_NOTIFICATION" ON party;
 CREATE POLICY "PTY_INTERNAL_EVENT_NOTIFICATION" ON party
 FOR SELECT
 TO flex_internal_event_notification
 USING (true);
 
 GRANT SELECT ON party_history TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "PTYH_INTERNAL_EVENT_NOTIFICATION" ON party;
 CREATE POLICY "PTYH_INTERNAL_EVENT_NOTIFICATION" ON party
 FOR SELECT
 TO flex_internal_event_notification
@@ -19,6 +21,7 @@ USING (true);
 
 -- RLS: PTY-ENT001
 GRANT SELECT ON party TO flex_entity;
+DROP POLICY IF EXISTS "PTY_ENT001" ON party;
 CREATE POLICY "PTY_ENT001" ON party
 FOR SELECT
 TO flex_entity
@@ -27,6 +30,7 @@ USING (
 );
 
 -- RLS: PTY-ENT002
+DROP POLICY IF EXISTS "PTY_ENT002" ON party;
 CREATE POLICY "PTY_ENT002" ON party
 FOR SELECT
 TO flex_entity
@@ -35,6 +39,7 @@ USING (entity_id = (SELECT current_entity()));
 -- RLS: PTY-COM002
 -- RLS: PTY-COM003
 GRANT SELECT ON party TO flex_common;
+DROP POLICY IF EXISTS "PTY_COM002" ON party;
 CREATE POLICY "PTY_COM002" ON party
 FOR SELECT
 TO flex_common
@@ -45,12 +50,14 @@ USING (type != 'end_user' OR EXISTS (
 -- RLS: PTY-FISO001
 GRANT INSERT, SELECT, UPDATE ON party
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "PTY_FISO001" ON party;
 CREATE POLICY "PTY_FISO001" ON party
 FOR ALL
 TO flex_flexibility_information_system_operator
 USING (true);
 
 GRANT INSERT, SELECT, UPDATE ON party TO flex_internal_data;
+DROP POLICY IF EXISTS "PTY_INTERNAL_DATA" ON party;
 CREATE POLICY "PTY_INTERNAL_DATA" ON party
 FOR ALL
 TO flex_internal_data

--- a/db/flex/product_type_rls.sql
+++ b/db/flex/product_type_rls.sql
@@ -1,11 +1,12 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:product-type-rls runAlways:true endDelimiter:;
+-- changeset flex:product-type-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS product_type ENABLE ROW LEVEL SECURITY;
 
 -- RLS: PT-COM001
 GRANT SELECT ON product_type TO flex_common;
+DROP POLICY IF EXISTS "PT_COM001" ON product_type;
 CREATE POLICY "PT_COM001" ON product_type
 FOR SELECT
 TO flex_common

--- a/db/flex/service_provider_product_application_comment_rls.sql
+++ b/db/flex/service_provider_product_application_comment_rls.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 -- GENERATED CODE -- DO NOT EDIT (scripts/openapi_to_db.py)
 
--- changeset flex:service-provider-product-application-comment-rls runAlways:true endDelimiter:;
+-- changeset flex:service-provider-product-application-comment-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS
 service_provider_product_application_comment
 ENABLE ROW LEVEL SECURITY;
@@ -10,6 +10,8 @@ ENABLE ROW LEVEL SECURITY;
 GRANT SELECT
 ON service_provider_product_application_comment
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPPAC_INTERNAL_EVENT_NOTIFICATION"
+ON service_provider_product_application_comment;
 CREATE POLICY "SPPAC_INTERNAL_EVENT_NOTIFICATION"
 ON service_provider_product_application_comment
 FOR SELECT
@@ -19,6 +21,8 @@ USING (true);
 GRANT SELECT
 ON service_provider_product_application_comment_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPPACH_INTERNAL_EVENT_NOTIFICATION"
+ON service_provider_product_application_comment_history;
 CREATE POLICY "SPPACH_INTERNAL_EVENT_NOTIFICATION"
 ON service_provider_product_application_comment_history
 FOR SELECT
@@ -30,6 +34,8 @@ ON service_provider_product_application_comment
 TO flex_common;
 
 -- RLS: SPPAC-COM001
+DROP POLICY IF EXISTS "SPPAC_COM001"
+ON service_provider_product_application_comment;
 CREATE POLICY "SPPAC_COM001"
 ON service_provider_product_application_comment
 FOR UPDATE
@@ -38,6 +44,8 @@ USING (created_by = (SELECT flex.current_identity()));
 
 -- RLS: SPPAC-SO001
 -- RLS: SPPAC-SP001
+DROP POLICY IF EXISTS "SPPAC_SO001_SP001"
+ON service_provider_product_application_comment;
 CREATE POLICY "SPPAC_SO001_SP001"
 ON service_provider_product_application_comment
 FOR INSERT
@@ -53,6 +61,8 @@ WITH CHECK (
 
 -- RLS: SPPAC-SO002
 -- RLS: SPPAC-SP002
+DROP POLICY IF EXISTS "SPPAC_SO002_SP002_same_party"
+ON service_provider_product_application_comment;
 CREATE POLICY "SPPAC_SO002_SP002_same_party"
 ON service_provider_product_application_comment
 FOR SELECT
@@ -68,6 +78,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPPAC_SO002_SP002_any_involved_party"
+ON service_provider_product_application_comment;
 CREATE POLICY "SPPAC_SO002_SP002_any_involved_party"
 ON service_provider_product_application_comment
 FOR SELECT
@@ -115,6 +127,8 @@ $$;
 GRANT SELECT
 ON service_provider_product_application_comment_history
 TO flex_system_operator, flex_service_provider;
+DROP POLICY IF EXISTS "SPPAC_SO003_SP003_same_party"
+ON service_provider_product_application_comment_history;
 CREATE POLICY "SPPAC_SO003_SP003_same_party"
 ON service_provider_product_application_comment_history
 FOR SELECT
@@ -132,6 +146,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPPAC_SO003_SP003_any_involved_party"
+ON service_provider_product_application_comment_history;
 CREATE POLICY "SPPAC_SO003_SP003_any_involved_party"
 ON service_provider_product_application_comment_history
 FOR SELECT
@@ -149,6 +165,8 @@ USING (
 );
 
 -- RLS: SPPAC-FISO001
+DROP POLICY IF EXISTS "SPPAC_FISO001"
+ON service_provider_product_application_comment;
 CREATE POLICY "SPPAC_FISO001"
 ON service_provider_product_application_comment
 FOR ALL
@@ -156,6 +174,8 @@ TO flex_flexibility_information_system_operator
 USING (true);
 
 -- RLS: SPPAC-FISO002
+DROP POLICY IF EXISTS "SPPAC_FISO002"
+ON service_provider_product_application_comment_history;
 CREATE POLICY "SPPAC_FISO002"
 ON service_provider_product_application_comment_history
 FOR ALL

--- a/db/flex/service_provider_product_application_history_audit.sql
+++ b/db/flex/service_provider_product_application_history_audit.sql
@@ -25,11 +25,13 @@ ALTER TABLE IF EXISTS
 flex.service_provider_product_application_history
 ENABLE ROW LEVEL SECURITY;
 
--- changeset flex:service-provider-product-application-history-rls-com runAlways:true endDelimiter:--
+-- changeset flex:service-provider-product-application-history-rls-com runOnChange:true endDelimiter:--
 -- RLS: SPPA-COM001
 GRANT SELECT ON flex.service_provider_product_application_history
 TO flex_common;
 
+DROP POLICY IF EXISTS "SPPA_COM001"
+ON flex.service_provider_product_application_history;
 CREATE POLICY "SPPA_COM001"
 ON flex.service_provider_product_application_history
 FOR SELECT

--- a/db/flex/service_provider_product_application_rls.sql
+++ b/db/flex/service_provider_product_application_rls.sql
@@ -1,13 +1,15 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:service-provider-product-application-rls runAlways:true endDelimiter:;
+-- changeset flex:service-provider-product-application-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS service_provider_product_application
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON service_provider_product_application
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPPA_INTERNAL_EVENT_NOTIFICATION"
+ON service_provider_product_application;
 CREATE POLICY "SPPA_INTERNAL_EVENT_NOTIFICATION"
 ON service_provider_product_application
 FOR SELECT
@@ -16,6 +18,8 @@ USING (true);
 
 GRANT SELECT ON service_provider_product_application_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPPA_HISTORY_INTERNAL_EVENT_NOTIFICATION"
+ON service_provider_product_application_history;
 CREATE POLICY "SPPA_HISTORY_INTERNAL_EVENT_NOTIFICATION"
 ON service_provider_product_application_history
 FOR SELECT
@@ -25,6 +29,7 @@ USING (true);
 -- RLS: SPPA-FISO001
 GRANT SELECT, UPDATE ON service_provider_product_application
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SPPA_FISO001" ON service_provider_product_application;
 CREATE POLICY "SPPA_FISO001"
 ON service_provider_product_application
 FOR ALL
@@ -34,6 +39,7 @@ USING (true);
 -- RLS: SPPA-SP001
 GRANT SELECT, INSERT, UPDATE ON service_provider_product_application
 TO flex_service_provider;
+DROP POLICY IF EXISTS "SPPA_SP001" ON service_provider_product_application;
 CREATE POLICY "SPPA_SP001"
 ON service_provider_product_application
 FOR ALL
@@ -45,6 +51,7 @@ USING (
 -- RLS: SPPA-SO001
 GRANT SELECT, UPDATE ON service_provider_product_application
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SPPA_SO001" ON service_provider_product_application;
 CREATE POLICY "SPPA_SO001"
 ON service_provider_product_application
 FOR SELECT
@@ -52,6 +59,7 @@ TO flex_system_operator
 USING (true);
 
 -- RLS: SPPA-SO002
+DROP POLICY IF EXISTS "SPPA_SO002" ON service_provider_product_application;
 CREATE POLICY "SPPA_SO002"
 ON service_provider_product_application
 FOR UPDATE

--- a/db/flex/service_provider_product_suspension_comment_rls.sql
+++ b/db/flex/service_provider_product_suspension_comment_rls.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 -- GENERATED CODE -- DO NOT EDIT (scripts/openapi_to_db.py)
 
--- changeset flex:service-provider-product-suspension-comment-rls runAlways:true endDelimiter:;
+-- changeset flex:service-provider-product-suspension-comment-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS
 service_provider_product_suspension_comment
 ENABLE ROW LEVEL SECURITY;
@@ -10,6 +10,8 @@ ENABLE ROW LEVEL SECURITY;
 GRANT SELECT
 ON service_provider_product_suspension_comment
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPPSC_INTERNAL_EVENT_NOTIFICATION"
+ON service_provider_product_suspension_comment;
 CREATE POLICY "SPPSC_INTERNAL_EVENT_NOTIFICATION"
 ON service_provider_product_suspension_comment
 FOR SELECT
@@ -19,6 +21,8 @@ USING (true);
 GRANT SELECT
 ON service_provider_product_suspension_comment_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPPSCH_INTERNAL_EVENT_NOTIFICATION"
+ON service_provider_product_suspension_comment_history;
 CREATE POLICY "SPPSCH_INTERNAL_EVENT_NOTIFICATION"
 ON service_provider_product_suspension_comment_history
 FOR SELECT
@@ -30,6 +34,8 @@ ON service_provider_product_suspension_comment
 TO flex_common;
 
 -- RLS: SPPSC-COM001
+DROP POLICY IF EXISTS "SPPSC_COM001"
+ON service_provider_product_suspension_comment;
 CREATE POLICY "SPPSC_COM001"
 ON service_provider_product_suspension_comment
 FOR UPDATE
@@ -38,6 +44,8 @@ USING (created_by = (SELECT flex.current_identity()));
 
 -- RLS: SPPSC-SO001
 -- RLS: SPPSC-SP001
+DROP POLICY IF EXISTS "SPPSC_SO001_SP001"
+ON service_provider_product_suspension_comment;
 CREATE POLICY "SPPSC_SO001_SP001"
 ON service_provider_product_suspension_comment
 FOR INSERT
@@ -53,6 +61,8 @@ WITH CHECK (
 
 -- RLS: SPPSC-SO002
 -- RLS: SPPSC-SP002
+DROP POLICY IF EXISTS "SPPSC_SO002_SP002_same_party"
+ON service_provider_product_suspension_comment;
 CREATE POLICY "SPPSC_SO002_SP002_same_party"
 ON service_provider_product_suspension_comment
 FOR SELECT
@@ -68,6 +78,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPPSC_SO002_SP002_any_involved_party"
+ON service_provider_product_suspension_comment;
 CREATE POLICY "SPPSC_SO002_SP002_any_involved_party"
 ON service_provider_product_suspension_comment
 FOR SELECT
@@ -115,6 +127,8 @@ $$;
 GRANT SELECT
 ON service_provider_product_suspension_comment_history
 TO flex_system_operator, flex_service_provider;
+DROP POLICY IF EXISTS "SPPSC_SO003_SP003_same_party"
+ON service_provider_product_suspension_comment_history;
 CREATE POLICY "SPPSC_SO003_SP003_same_party"
 ON service_provider_product_suspension_comment_history
 FOR SELECT
@@ -132,6 +146,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPPSC_SO003_SP003_any_involved_party"
+ON service_provider_product_suspension_comment_history;
 CREATE POLICY "SPPSC_SO003_SP003_any_involved_party"
 ON service_provider_product_suspension_comment_history
 FOR SELECT
@@ -149,6 +165,8 @@ USING (
 );
 
 -- RLS: SPPSC-FISO001
+DROP POLICY IF EXISTS "SPPSC_FISO001"
+ON service_provider_product_suspension_comment;
 CREATE POLICY "SPPSC_FISO001"
 ON service_provider_product_suspension_comment
 FOR ALL
@@ -156,6 +174,8 @@ TO flex_flexibility_information_system_operator
 USING (true);
 
 -- RLS: SPPSC-FISO002
+DROP POLICY IF EXISTS "SPPSC_FISO002"
+ON service_provider_product_suspension_comment_history;
 CREATE POLICY "SPPSC_FISO002"
 ON service_provider_product_suspension_comment_history
 FOR ALL

--- a/db/flex/service_provider_product_suspension_rls.sql
+++ b/db/flex/service_provider_product_suspension_rls.sql
@@ -1,13 +1,15 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:service-provider-product-suspension-rls runAlways:true endDelimiter:;
+-- changeset flex:service-provider-product-suspension-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS service_provider_product_suspension
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON service_provider_product_suspension
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPPS_INTERNAL_EVENT_NOTIFICATION"
+ON service_provider_product_suspension;
 CREATE POLICY "SPPS_INTERNAL_EVENT_NOTIFICATION"
 ON service_provider_product_suspension
 FOR SELECT
@@ -16,6 +18,8 @@ USING (true);
 
 GRANT SELECT ON service_provider_product_suspension_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPPS_HISTORY_INTERNAL_EVENT_NOTIFICATION"
+ON service_provider_product_suspension_history;
 CREATE POLICY "SPPS_HISTORY_INTERNAL_EVENT_NOTIFICATION"
 ON service_provider_product_suspension_history
 FOR SELECT
@@ -25,6 +29,7 @@ USING (true);
 -- RLS: SPPS-FISO001
 GRANT SELECT, INSERT, UPDATE, DELETE ON service_provider_product_suspension
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SPPS_FISO001" ON service_provider_product_suspension;
 CREATE POLICY "SPPS_FISO001"
 ON service_provider_product_suspension
 FOR ALL
@@ -34,6 +39,7 @@ USING (true);
 -- RLS: SPPS-FISO002
 GRANT SELECT ON service_provider_product_suspension_history
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SPPS_FISO002" ON service_provider_product_suspension_history;
 CREATE POLICY "SPPS_FISO002"
 ON service_provider_product_suspension_history
 FOR SELECT
@@ -43,6 +49,7 @@ USING (true);
 -- RLS: SPPS-SP001
 GRANT SELECT ON service_provider_product_suspension
 TO flex_service_provider;
+DROP POLICY IF EXISTS "SPPS_SP001" ON service_provider_product_suspension;
 CREATE POLICY "SPPS_SP001"
 ON service_provider_product_suspension
 FOR SELECT
@@ -52,6 +59,7 @@ USING (service_provider_id = (SELECT flex.current_party()));
 -- RLS: SPPS-SP002
 GRANT SELECT ON service_provider_product_suspension_history
 TO flex_service_provider;
+DROP POLICY IF EXISTS "SPPS_SP002" ON service_provider_product_suspension_history;
 CREATE POLICY "SPPS_SP002"
 ON service_provider_product_suspension_history
 FOR SELECT
@@ -61,6 +69,7 @@ USING (service_provider_id = (SELECT flex.current_party()));
 -- RLS: SPPS-SO001
 GRANT SELECT, INSERT, UPDATE, DELETE ON service_provider_product_suspension
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SPPS_SO001" ON service_provider_product_suspension;
 CREATE POLICY "SPPS_SO001"
 ON service_provider_product_suspension
 FOR ALL
@@ -70,6 +79,7 @@ USING (procuring_system_operator_id = (SELECT flex.current_party()));
 -- RLS: SPPS-SO002
 GRANT SELECT ON service_provider_product_suspension_history
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SPPS_SO002" ON service_provider_product_suspension_history;
 CREATE POLICY "SPPS_SO002"
 ON service_provider_product_suspension_history
 FOR SELECT
@@ -77,6 +87,7 @@ TO flex_system_operator
 USING (procuring_system_operator_id = (SELECT flex.current_party()));
 
 -- RLS: SPPS-SO003
+DROP POLICY IF EXISTS "SPPS_SO003" ON service_provider_product_suspension;
 CREATE POLICY "SPPS_SO003"
 ON service_provider_product_suspension
 FOR SELECT
@@ -85,7 +96,8 @@ USING (
     EXISTS (
         SELECT 1
         FROM flex.service_provider_product_application AS sppa
-        WHERE sppa.service_provider_id
+        WHERE
+            sppa.service_provider_id
             = service_provider_product_suspension.service_provider_id -- noqa
             AND sppa.system_operator_id = (SELECT flex.current_party())
             AND sppa.status = 'qualified'
@@ -97,6 +109,7 @@ USING (
 -- RLS: SPPS-SO004
 -- same check as above but with history tables, so that qualification can be
 -- removed later and/or suspension deleted, but history should still be readable
+DROP POLICY IF EXISTS "SPPS_SO004" ON service_provider_product_suspension_history;
 CREATE POLICY "SPPS_SO004"
 ON service_provider_product_suspension_history
 FOR SELECT
@@ -112,7 +125,8 @@ USING (
                     sppah.record_time_range,
                     sppah.status
                 FROM flex.service_provider_product_application_history AS sppah
-                WHERE sppah.service_provider_id
+                WHERE
+                    sppah.service_provider_id
                     = service_provider_product_suspension_history.service_provider_id -- noqa
                     AND sppah.system_operator_id = (SELECT flex.current_party())
                 UNION ALL
@@ -121,14 +135,16 @@ USING (
                     sppa.record_time_range,
                     sppa.status
                 FROM flex.service_provider_product_application AS sppa
-                WHERE sppa.service_provider_id
+                WHERE
+                    sppa.service_provider_id
                     = service_provider_product_suspension_history.service_provider_id -- noqa
                     AND sppa.system_operator_id = (SELECT flex.current_party())
             )
 
         SELECT 1
         FROM sppa_sp_so_history
-        WHERE sppa_sp_so_history.record_time_range
+        WHERE
+            sppa_sp_so_history.record_time_range
             && service_provider_product_suspension_history.record_time_range -- noqa
             AND sppa_sp_so_history.status = 'qualified'
             AND service_provider_product_suspension_history.product_type_ids -- noqa

--- a/db/flex/service_providing_group_grid_prequalification_comment_rls.sql
+++ b/db/flex/service_providing_group_grid_prequalification_comment_rls.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 -- GENERATED CODE -- DO NOT EDIT (scripts/openapi_to_db.py)
 
--- changeset flex:service-providing-group-grid-prequalification-comment-rls runAlways:true endDelimiter:;
+-- changeset flex:service-providing-group-grid-prequalification-comment-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS
 service_providing_group_grid_prequalification_comment
 ENABLE ROW LEVEL SECURITY;
@@ -10,6 +10,8 @@ ENABLE ROW LEVEL SECURITY;
 GRANT SELECT
 ON service_providing_group_grid_prequalification_comment
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGGPC_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_grid_prequalification_comment;
 CREATE POLICY "SPGGPC_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_grid_prequalification_comment
 FOR SELECT
@@ -19,6 +21,8 @@ USING (true);
 GRANT SELECT
 ON service_providing_group_grid_prequalification_comment_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGGPCH_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_grid_prequalification_comment_history;
 CREATE POLICY "SPGGPCH_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_grid_prequalification_comment_history
 FOR SELECT
@@ -30,6 +34,8 @@ ON service_providing_group_grid_prequalification_comment
 TO flex_common;
 
 -- RLS: SPGGPC-COM001
+DROP POLICY IF EXISTS "SPGGPC_COM001"
+ON service_providing_group_grid_prequalification_comment;
 CREATE POLICY "SPGGPC_COM001"
 ON service_providing_group_grid_prequalification_comment
 FOR UPDATE
@@ -38,6 +44,8 @@ USING (created_by = (SELECT flex.current_identity()));
 
 -- RLS: SPGGPC-SO001
 -- RLS: SPGGPC-SP001
+DROP POLICY IF EXISTS "SPGGPC_SO001_SP001"
+ON service_providing_group_grid_prequalification_comment;
 CREATE POLICY "SPGGPC_SO001_SP001"
 ON service_providing_group_grid_prequalification_comment
 FOR INSERT
@@ -53,6 +61,8 @@ WITH CHECK (
 
 -- RLS: SPGGPC-SO002
 -- RLS: SPGGPC-SP002
+DROP POLICY IF EXISTS "SPGGPC_SO002_SP002_same_party"
+ON service_providing_group_grid_prequalification_comment;
 CREATE POLICY "SPGGPC_SO002_SP002_same_party"
 ON service_providing_group_grid_prequalification_comment
 FOR SELECT
@@ -68,6 +78,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPGGPC_SO002_SP002_any_involved_party"
+ON service_providing_group_grid_prequalification_comment;
 CREATE POLICY "SPGGPC_SO002_SP002_any_involved_party"
 ON service_providing_group_grid_prequalification_comment
 FOR SELECT
@@ -115,6 +127,8 @@ $$;
 GRANT SELECT
 ON service_providing_group_grid_prequalification_comment_history
 TO flex_system_operator, flex_service_provider;
+DROP POLICY IF EXISTS "SPGGPC_SO003_SP003_same_party"
+ON service_providing_group_grid_prequalification_comment_history;
 CREATE POLICY "SPGGPC_SO003_SP003_same_party"
 ON service_providing_group_grid_prequalification_comment_history
 FOR SELECT
@@ -132,6 +146,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPGGPC_SO003_SP003_any_involved_party"
+ON service_providing_group_grid_prequalification_comment_history;
 CREATE POLICY "SPGGPC_SO003_SP003_any_involved_party"
 ON service_providing_group_grid_prequalification_comment_history
 FOR SELECT
@@ -149,6 +165,8 @@ USING (
 );
 
 -- RLS: SPGGPC-FISO001
+DROP POLICY IF EXISTS "SPGGPC_FISO001"
+ON service_providing_group_grid_prequalification_comment;
 CREATE POLICY "SPGGPC_FISO001"
 ON service_providing_group_grid_prequalification_comment
 FOR ALL
@@ -156,6 +174,8 @@ TO flex_flexibility_information_system_operator
 USING (true);
 
 -- RLS: SPGGPC-FISO002
+DROP POLICY IF EXISTS "SPGGPC_FISO002"
+ON service_providing_group_grid_prequalification_comment_history;
 CREATE POLICY "SPGGPC_FISO002"
 ON service_providing_group_grid_prequalification_comment_history
 FOR ALL

--- a/db/flex/service_providing_group_grid_prequalification_history_audit.sql
+++ b/db/flex/service_providing_group_grid_prequalification_history_audit.sql
@@ -25,11 +25,13 @@ ALTER TABLE IF EXISTS
 flex.service_providing_group_grid_prequalification_history
 ENABLE ROW LEVEL SECURITY;
 
--- changeset flex:service-providing-group-grid-prequalification-history-rls-com runAlways:true endDelimiter:--
+-- changeset flex:service-providing-group-grid-prequalification-history-rls-com runOnChange:true endDelimiter:--
 -- RLS: SPGGP-COM001
 GRANT SELECT ON flex.service_providing_group_grid_prequalification_history
 TO flex_common;
 
+DROP POLICY IF EXISTS "SPGGP_COM001"
+ON flex.service_providing_group_grid_prequalification_history;
 CREATE POLICY "SPGGP_COM001"
 ON flex.service_providing_group_grid_prequalification_history
 FOR SELECT

--- a/db/flex/service_providing_group_grid_prequalification_rls.sql
+++ b/db/flex/service_providing_group_grid_prequalification_rls.sql
@@ -1,13 +1,15 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:service-providing-group-grid-prequalification-rls runAlways:true endDelimiter:;
+-- changeset flex:service-providing-group-grid-prequalification-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS service_providing_group_grid_prequalification
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON service_providing_group_grid_prequalification
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGGP_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_grid_prequalification;
 CREATE POLICY "SPGGP_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_grid_prequalification
 FOR SELECT
@@ -16,6 +18,8 @@ USING (true);
 
 GRANT SELECT ON service_providing_group_grid_prequalification_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGGPH_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_grid_prequalification_history;
 CREATE POLICY "SPGGPH_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_grid_prequalification_history
 FOR SELECT
@@ -26,6 +30,7 @@ USING (true);
 GRANT SELECT, INSERT, UPDATE ON service_providing_group_grid_prequalification
 TO flex_flexibility_information_system_operator;
 
+DROP POLICY IF EXISTS "SPGGP_FISO001" ON service_providing_group_grid_prequalification;
 CREATE POLICY "SPGGP_FISO001"
 ON service_providing_group_grid_prequalification
 FOR ALL
@@ -36,6 +41,7 @@ USING (true);
 GRANT SELECT ON service_providing_group_grid_prequalification
 TO flex_service_provider;
 
+DROP POLICY IF EXISTS "SPGGP_SP001" ON service_providing_group_grid_prequalification;
 CREATE POLICY "SPGGP_SP001"
 ON service_providing_group_grid_prequalification
 FOR ALL
@@ -53,6 +59,7 @@ USING (
 GRANT SELECT, UPDATE ON service_providing_group_grid_prequalification
 TO flex_system_operator;
 
+DROP POLICY IF EXISTS "SPGGP_SO001" ON service_providing_group_grid_prequalification;
 CREATE POLICY "SPGGP_SO001"
 ON service_providing_group_grid_prequalification
 FOR ALL
@@ -82,6 +89,7 @@ SELECT EXISTS (
 )
 $$;
 
+DROP POLICY IF EXISTS "SPGGP_SO002" ON service_providing_group_grid_prequalification;
 CREATE POLICY "SPGGP_SO002"
 ON service_providing_group_grid_prequalification
 FOR SELECT

--- a/db/flex/service_providing_group_grid_suspension_comment_rls.sql
+++ b/db/flex/service_providing_group_grid_suspension_comment_rls.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 -- GENERATED CODE -- DO NOT EDIT (scripts/openapi_to_db.py)
 
--- changeset flex:service-providing-group-grid-suspension-comment-rls runAlways:true endDelimiter:;
+-- changeset flex:service-providing-group-grid-suspension-comment-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS
 service_providing_group_grid_suspension_comment
 ENABLE ROW LEVEL SECURITY;
@@ -10,6 +10,8 @@ ENABLE ROW LEVEL SECURITY;
 GRANT SELECT
 ON service_providing_group_grid_suspension_comment
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGGSC_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_grid_suspension_comment;
 CREATE POLICY "SPGGSC_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_grid_suspension_comment
 FOR SELECT
@@ -19,6 +21,8 @@ USING (true);
 GRANT SELECT
 ON service_providing_group_grid_suspension_comment_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGGSCH_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_grid_suspension_comment_history;
 CREATE POLICY "SPGGSCH_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_grid_suspension_comment_history
 FOR SELECT
@@ -30,6 +34,8 @@ ON service_providing_group_grid_suspension_comment
 TO flex_common;
 
 -- RLS: SPGGSC-COM001
+DROP POLICY IF EXISTS "SPGGSC_COM001"
+ON service_providing_group_grid_suspension_comment;
 CREATE POLICY "SPGGSC_COM001"
 ON service_providing_group_grid_suspension_comment
 FOR UPDATE
@@ -38,6 +44,8 @@ USING (created_by = (SELECT flex.current_identity()));
 
 -- RLS: SPGGSC-SO001
 -- RLS: SPGGSC-SP001
+DROP POLICY IF EXISTS "SPGGSC_SO001_SP001"
+ON service_providing_group_grid_suspension_comment;
 CREATE POLICY "SPGGSC_SO001_SP001"
 ON service_providing_group_grid_suspension_comment
 FOR INSERT
@@ -53,6 +61,8 @@ WITH CHECK (
 
 -- RLS: SPGGSC-SO002
 -- RLS: SPGGSC-SP002
+DROP POLICY IF EXISTS "SPGGSC_SO002_SP002_same_party"
+ON service_providing_group_grid_suspension_comment;
 CREATE POLICY "SPGGSC_SO002_SP002_same_party"
 ON service_providing_group_grid_suspension_comment
 FOR SELECT
@@ -68,6 +78,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPGGSC_SO002_SP002_any_involved_party"
+ON service_providing_group_grid_suspension_comment;
 CREATE POLICY "SPGGSC_SO002_SP002_any_involved_party"
 ON service_providing_group_grid_suspension_comment
 FOR SELECT
@@ -115,6 +127,8 @@ $$;
 GRANT SELECT
 ON service_providing_group_grid_suspension_comment_history
 TO flex_system_operator, flex_service_provider;
+DROP POLICY IF EXISTS "SPGGSC_SO003_SP003_same_party"
+ON service_providing_group_grid_suspension_comment_history;
 CREATE POLICY "SPGGSC_SO003_SP003_same_party"
 ON service_providing_group_grid_suspension_comment_history
 FOR SELECT
@@ -132,6 +146,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPGGSC_SO003_SP003_any_involved_party"
+ON service_providing_group_grid_suspension_comment_history;
 CREATE POLICY "SPGGSC_SO003_SP003_any_involved_party"
 ON service_providing_group_grid_suspension_comment_history
 FOR SELECT
@@ -149,6 +165,8 @@ USING (
 );
 
 -- RLS: SPGGSC-FISO001
+DROP POLICY IF EXISTS "SPGGSC_FISO001"
+ON service_providing_group_grid_suspension_comment;
 CREATE POLICY "SPGGSC_FISO001"
 ON service_providing_group_grid_suspension_comment
 FOR ALL
@@ -156,6 +174,8 @@ TO flex_flexibility_information_system_operator
 USING (true);
 
 -- RLS: SPGGSC-FISO002
+DROP POLICY IF EXISTS "SPGGSC_FISO002"
+ON service_providing_group_grid_suspension_comment_history;
 CREATE POLICY "SPGGSC_FISO002"
 ON service_providing_group_grid_suspension_comment_history
 FOR ALL

--- a/db/flex/service_providing_group_grid_suspension_rls.sql
+++ b/db/flex/service_providing_group_grid_suspension_rls.sql
@@ -1,13 +1,15 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:service-providing-group-grid-suspension-rls runAlways:true endDelimiter:;
+-- changeset flex:service-providing-group-grid-suspension-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS service_providing_group_grid_suspension
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON service_providing_group_grid_suspension
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGGS_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_grid_suspension;
 CREATE POLICY "SPGGS_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_grid_suspension
 FOR SELECT
@@ -16,6 +18,8 @@ USING (true);
 
 GRANT SELECT ON service_providing_group_grid_suspension_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGGS_HISTORY_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_grid_suspension_history;
 CREATE POLICY "SPGGS_HISTORY_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_grid_suspension_history
 FOR SELECT
@@ -25,6 +29,7 @@ USING (true);
 -- RLS: SPGGS-FISO001
 GRANT SELECT, INSERT, UPDATE, DELETE ON service_providing_group_grid_suspension
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SPGGS_FISO001" ON service_providing_group_grid_suspension;
 CREATE POLICY "SPGGS_FISO001"
 ON service_providing_group_grid_suspension
 FOR ALL
@@ -34,6 +39,8 @@ USING (true);
 -- RLS: SPGGS-FISO002
 GRANT SELECT ON service_providing_group_grid_suspension_history
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SPGGS_FISO002"
+ON service_providing_group_grid_suspension_history;
 CREATE POLICY "SPGGS_FISO002"
 ON service_providing_group_grid_suspension_history
 FOR SELECT
@@ -43,6 +50,7 @@ USING (true);
 -- RLS: SPGGS-SP001
 GRANT SELECT ON service_providing_group_grid_suspension
 TO flex_service_provider;
+DROP POLICY IF EXISTS "SPGGS_SP001" ON service_providing_group_grid_suspension;
 CREATE POLICY "SPGGS_SP001"
 ON service_providing_group_grid_suspension
 FOR SELECT
@@ -59,6 +67,7 @@ USING (
 -- RLS: SPGGS-SP002
 GRANT SELECT ON service_providing_group_grid_suspension_history
 TO flex_service_provider;
+DROP POLICY IF EXISTS "SPGGS_SP002" ON service_providing_group_grid_suspension_history;
 CREATE POLICY "SPGGS_SP002"
 ON service_providing_group_grid_suspension_history
 FOR SELECT
@@ -75,6 +84,7 @@ USING (
 -- RLS: SPGGS-SO001
 GRANT SELECT, INSERT, UPDATE, DELETE ON service_providing_group_grid_suspension
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SPGGS_SO001" ON service_providing_group_grid_suspension;
 CREATE POLICY "SPGGS_SO001"
 ON service_providing_group_grid_suspension
 FOR ALL
@@ -84,6 +94,7 @@ USING (impacted_system_operator_id = (SELECT flex.current_party()));
 -- RLS: SPGGS-SO002
 GRANT SELECT ON service_providing_group_grid_suspension_history
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SPGGS_SO002" ON service_providing_group_grid_suspension_history;
 CREATE POLICY "SPGGS_SO002"
 ON service_providing_group_grid_suspension_history
 FOR SELECT
@@ -91,6 +102,7 @@ TO flex_system_operator
 USING (impacted_system_operator_id = (SELECT flex.current_party()));
 
 -- RLS: SPGGS-SO003
+DROP POLICY IF EXISTS "SPGGS_SO003" ON service_providing_group_grid_suspension;
 CREATE POLICY "SPGGS_SO003"
 ON service_providing_group_grid_suspension
 FOR SELECT
@@ -99,12 +111,14 @@ USING (
     EXISTS (
         SELECT 1
         FROM flex.service_providing_group AS spg
-        WHERE spg.id
+        WHERE
+            spg.id
             = service_providing_group_grid_suspension.service_providing_group_id -- noqa
     )
 );
 
 -- RLS: SPGGS-SO004
+DROP POLICY IF EXISTS "SPGGS_SO004" ON service_providing_group_grid_suspension_history;
 CREATE POLICY "SPGGS_SO004"
 ON service_providing_group_grid_suspension_history
 FOR SELECT
@@ -113,12 +127,14 @@ USING (
     EXISTS (
         SELECT 1
         FROM flex.service_providing_group AS spg
-        WHERE spg.id
+        WHERE
+            spg.id
             = service_providing_group_grid_suspension_history.service_providing_group_id -- noqa
         UNION ALL
         SELECT 1
         FROM flex.service_providing_group_history AS spgh
-        WHERE spgh.id
+        WHERE
+            spgh.id
             = service_providing_group_grid_suspension_history.service_providing_group_id -- noqa
             AND spgh.record_time_range && service_providing_group_grid_suspension_history.record_time_range -- noqa
     )

--- a/db/flex/service_providing_group_history_audit.sql
+++ b/db/flex/service_providing_group_history_audit.sql
@@ -25,11 +25,13 @@ ALTER TABLE IF EXISTS
 flex.service_providing_group_history
 ENABLE ROW LEVEL SECURITY;
 
--- changeset flex:service-providing-group-history-rls-com runAlways:true endDelimiter:--
+-- changeset flex:service-providing-group-history-rls-com runOnChange:true endDelimiter:--
 -- RLS: SPG-COM001
 GRANT SELECT ON flex.service_providing_group_history
 TO flex_common;
 
+DROP POLICY IF EXISTS "SPG_COM001"
+ON flex.service_providing_group_history;
 CREATE POLICY "SPG_COM001"
 ON flex.service_providing_group_history
 FOR SELECT

--- a/db/flex/service_providing_group_membership_rls.sql
+++ b/db/flex/service_providing_group_membership_rls.sql
@@ -1,13 +1,15 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:service-providing-group-membership-rls runAlways:true endDelimiter:;
+-- changeset flex:service-providing-group-membership-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS service_providing_group_membership
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON service_providing_group_membership
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGM_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_membership;
 CREATE POLICY "SPGM_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_membership
 FOR SELECT
@@ -16,6 +18,8 @@ USING (true);
 
 GRANT SELECT ON service_providing_group_membership_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGMH_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_membership_history;
 CREATE POLICY "SPGMH_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_membership_history
 FOR SELECT
@@ -25,6 +29,7 @@ USING (true);
 -- RLS: SPGM-FISO001
 GRANT SELECT, INSERT, UPDATE, DELETE ON service_providing_group_membership
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SPGM_FISO001" ON service_providing_group_membership;
 CREATE POLICY "SPGM_FISO001"
 ON service_providing_group_membership
 FOR ALL
@@ -34,6 +39,7 @@ USING (true);
 -- RLS: SPGM-FISO002
 GRANT SELECT ON service_providing_group_membership_history
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SPGM_FISO002" ON service_providing_group_membership_history;
 CREATE POLICY "SPGM_FISO002"
 ON service_providing_group_membership_history
 FOR ALL
@@ -46,6 +52,7 @@ TO flex_service_provider;
 
 -- RLS: SPGM-SP001
 -- RLS: SPGM-SP002
+DROP POLICY IF EXISTS "SPGM_SP001_SP002" ON service_providing_group_membership;
 CREATE POLICY "SPGM_SP001_SP002"
 ON service_providing_group_membership
 FOR ALL
@@ -67,7 +74,8 @@ WITH CHECK (
                 FROM controllable_unit_service_provider AS cusp
                     INNER JOIN service_providing_group AS spg
                         ON cusp.service_provider_id = spg.service_provider_id
-                WHERE spg.service_provider_id = (SELECT current_party())
+                WHERE
+                    spg.service_provider_id = (SELECT current_party())
                     AND cusp.controllable_unit_id
                     = service_providing_group_membership.controllable_unit_id -- noqa
                     AND spg.id
@@ -87,6 +95,7 @@ WITH CHECK (
 -- SPG cannot be deleted, SP ID is stable, no need to use history
 GRANT SELECT ON service_providing_group_membership_history
 TO flex_service_provider;
+DROP POLICY IF EXISTS "SPGM_SP003" ON service_providing_group_membership_history;
 CREATE POLICY "SPGM_SP003"
 ON service_providing_group_membership_history
 FOR SELECT
@@ -102,6 +111,7 @@ USING (EXISTS (
 -- RLS: SPGM-SO001
 GRANT SELECT ON service_providing_group_membership
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SPGM_SO001" ON service_providing_group_membership;
 CREATE POLICY "SPGM_SO001"
 ON service_providing_group_membership
 FOR SELECT
@@ -120,6 +130,7 @@ USING (
 -- so we can use SPG for SO in a history policy as well
 GRANT SELECT ON service_providing_group_membership_history
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SPGM_SO002" ON service_providing_group_membership_history;
 CREATE POLICY "SPGM_SO002"
 ON service_providing_group_membership_history
 FOR SELECT

--- a/db/flex/service_providing_group_product_application_comment_rls.sql
+++ b/db/flex/service_providing_group_product_application_comment_rls.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 -- GENERATED CODE -- DO NOT EDIT (scripts/openapi_to_db.py)
 
--- changeset flex:service-providing-group-product-application-comment-rls runAlways:true endDelimiter:;
+-- changeset flex:service-providing-group-product-application-comment-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS
 service_providing_group_product_application_comment
 ENABLE ROW LEVEL SECURITY;
@@ -10,6 +10,8 @@ ENABLE ROW LEVEL SECURITY;
 GRANT SELECT
 ON service_providing_group_product_application_comment
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGPAC_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_product_application_comment;
 CREATE POLICY "SPGPAC_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_product_application_comment
 FOR SELECT
@@ -19,6 +21,8 @@ USING (true);
 GRANT SELECT
 ON service_providing_group_product_application_comment_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGPACH_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_product_application_comment_history;
 CREATE POLICY "SPGPACH_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_product_application_comment_history
 FOR SELECT
@@ -30,6 +34,8 @@ ON service_providing_group_product_application_comment
 TO flex_common;
 
 -- RLS: SPGPAC-COM001
+DROP POLICY IF EXISTS "SPGPAC_COM001"
+ON service_providing_group_product_application_comment;
 CREATE POLICY "SPGPAC_COM001"
 ON service_providing_group_product_application_comment
 FOR UPDATE
@@ -38,6 +44,8 @@ USING (created_by = (SELECT flex.current_identity()));
 
 -- RLS: SPGPAC-SO001
 -- RLS: SPGPAC-SP001
+DROP POLICY IF EXISTS "SPGPAC_SO001_SP001"
+ON service_providing_group_product_application_comment;
 CREATE POLICY "SPGPAC_SO001_SP001"
 ON service_providing_group_product_application_comment
 FOR INSERT
@@ -53,6 +61,8 @@ WITH CHECK (
 
 -- RLS: SPGPAC-SO002
 -- RLS: SPGPAC-SP002
+DROP POLICY IF EXISTS "SPGPAC_SO002_SP002_same_party"
+ON service_providing_group_product_application_comment;
 CREATE POLICY "SPGPAC_SO002_SP002_same_party"
 ON service_providing_group_product_application_comment
 FOR SELECT
@@ -68,6 +78,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPGPAC_SO002_SP002_any_involved_party"
+ON service_providing_group_product_application_comment;
 CREATE POLICY "SPGPAC_SO002_SP002_any_involved_party"
 ON service_providing_group_product_application_comment
 FOR SELECT
@@ -115,6 +127,8 @@ $$;
 GRANT SELECT
 ON service_providing_group_product_application_comment_history
 TO flex_system_operator, flex_service_provider;
+DROP POLICY IF EXISTS "SPGPAC_SO003_SP003_same_party"
+ON service_providing_group_product_application_comment_history;
 CREATE POLICY "SPGPAC_SO003_SP003_same_party"
 ON service_providing_group_product_application_comment_history
 FOR SELECT
@@ -132,6 +146,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPGPAC_SO003_SP003_any_involved_party"
+ON service_providing_group_product_application_comment_history;
 CREATE POLICY "SPGPAC_SO003_SP003_any_involved_party"
 ON service_providing_group_product_application_comment_history
 FOR SELECT
@@ -149,6 +165,8 @@ USING (
 );
 
 -- RLS: SPGPAC-FISO001
+DROP POLICY IF EXISTS "SPGPAC_FISO001"
+ON service_providing_group_product_application_comment;
 CREATE POLICY "SPGPAC_FISO001"
 ON service_providing_group_product_application_comment
 FOR ALL
@@ -156,6 +174,8 @@ TO flex_flexibility_information_system_operator
 USING (true);
 
 -- RLS: SPGPAC-FISO002
+DROP POLICY IF EXISTS "SPGPAC_FISO002"
+ON service_providing_group_product_application_comment_history;
 CREATE POLICY "SPGPAC_FISO002"
 ON service_providing_group_product_application_comment_history
 FOR ALL

--- a/db/flex/service_providing_group_product_application_history_audit.sql
+++ b/db/flex/service_providing_group_product_application_history_audit.sql
@@ -25,11 +25,13 @@ ALTER TABLE IF EXISTS
 flex.service_providing_group_product_application_history
 ENABLE ROW LEVEL SECURITY;
 
--- changeset flex:service-providing-group-product-application-history-rls-com runAlways:true endDelimiter:--
+-- changeset flex:service-providing-group-product-application-history-rls-com runOnChange:true endDelimiter:--
 -- RLS: SPGPA-COM001
 GRANT SELECT ON flex.service_providing_group_product_application_history
 TO flex_common;
 
+DROP POLICY IF EXISTS "SPGPA_COM001"
+ON flex.service_providing_group_product_application_history;
 CREATE POLICY "SPGPA_COM001"
 ON flex.service_providing_group_product_application_history
 FOR SELECT

--- a/db/flex/service_providing_group_product_application_rls.sql
+++ b/db/flex/service_providing_group_product_application_rls.sql
@@ -1,13 +1,15 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:service-providing-group-product-application-rls runAlways:true endDelimiter:;
+-- changeset flex:service-providing-group-product-application-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS service_providing_group_product_application
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON service_providing_group_product_application
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGPA_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_product_application;
 CREATE POLICY "SPGPA_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_product_application
 FOR SELECT
@@ -16,6 +18,8 @@ USING (true);
 
 GRANT SELECT ON service_providing_group_product_application_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGPA_HISTORY_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_product_application_history;
 CREATE POLICY "SPGPA_HISTORY_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_product_application_history
 FOR SELECT
@@ -25,6 +29,7 @@ USING (true);
 -- RLS: SPGPA-FISO001
 GRANT SELECT, UPDATE ON service_providing_group_product_application
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SPGPA_FISO001" ON service_providing_group_product_application;
 CREATE POLICY "SPGPA_FISO001"
 ON service_providing_group_product_application
 FOR ALL
@@ -34,6 +39,7 @@ USING (true);
 -- RLS: SPGPA-SP001
 GRANT SELECT, INSERT, UPDATE ON service_providing_group_product_application
 TO flex_service_provider;
+DROP POLICY IF EXISTS "SPGPA_SP001" ON service_providing_group_product_application;
 CREATE POLICY "SPGPA_SP001"
 ON service_providing_group_product_application
 FOR ALL
@@ -67,6 +73,7 @@ $$;
 
 GRANT SELECT, UPDATE ON service_providing_group_product_application
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SPGPA_SO001" ON service_providing_group_product_application;
 CREATE POLICY "SPGPA_SO001"
 ON service_providing_group_product_application
 FOR SELECT
@@ -78,6 +85,7 @@ USING (
 );
 
 -- RLS: SPGPA-SO002
+DROP POLICY IF EXISTS "SPGPA_SO002" ON service_providing_group_product_application;
 CREATE POLICY "SPGPA_SO002"
 ON service_providing_group_product_application
 FOR UPDATE
@@ -104,6 +112,7 @@ SELECT EXISTS (
 $$;
 
 -- RLS: SPGPA-SO003
+DROP POLICY IF EXISTS "SPGPA_SO003" ON service_providing_group_product_application;
 CREATE POLICY "SPGPA_SO003"
 ON service_providing_group_product_application
 FOR SELECT

--- a/db/flex/service_providing_group_product_suspension_comment_rls.sql
+++ b/db/flex/service_providing_group_product_suspension_comment_rls.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 -- GENERATED CODE -- DO NOT EDIT (scripts/openapi_to_db.py)
 
--- changeset flex:service-providing-group-product-suspension-comment-rls runAlways:true endDelimiter:;
+-- changeset flex:service-providing-group-product-suspension-comment-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS
 service_providing_group_product_suspension_comment
 ENABLE ROW LEVEL SECURITY;
@@ -10,6 +10,8 @@ ENABLE ROW LEVEL SECURITY;
 GRANT SELECT
 ON service_providing_group_product_suspension_comment
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGPSC_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_product_suspension_comment;
 CREATE POLICY "SPGPSC_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_product_suspension_comment
 FOR SELECT
@@ -19,6 +21,8 @@ USING (true);
 GRANT SELECT
 ON service_providing_group_product_suspension_comment_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGPSCH_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_product_suspension_comment_history;
 CREATE POLICY "SPGPSCH_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_product_suspension_comment_history
 FOR SELECT
@@ -30,6 +34,8 @@ ON service_providing_group_product_suspension_comment
 TO flex_common;
 
 -- RLS: SPGPSC-COM001
+DROP POLICY IF EXISTS "SPGPSC_COM001"
+ON service_providing_group_product_suspension_comment;
 CREATE POLICY "SPGPSC_COM001"
 ON service_providing_group_product_suspension_comment
 FOR UPDATE
@@ -38,6 +44,8 @@ USING (created_by = (SELECT flex.current_identity()));
 
 -- RLS: SPGPSC-SO001
 -- RLS: SPGPSC-SP001
+DROP POLICY IF EXISTS "SPGPSC_SO001_SP001"
+ON service_providing_group_product_suspension_comment;
 CREATE POLICY "SPGPSC_SO001_SP001"
 ON service_providing_group_product_suspension_comment
 FOR INSERT
@@ -53,6 +61,8 @@ WITH CHECK (
 
 -- RLS: SPGPSC-SO002
 -- RLS: SPGPSC-SP002
+DROP POLICY IF EXISTS "SPGPSC_SO002_SP002_same_party"
+ON service_providing_group_product_suspension_comment;
 CREATE POLICY "SPGPSC_SO002_SP002_same_party"
 ON service_providing_group_product_suspension_comment
 FOR SELECT
@@ -68,6 +78,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPGPSC_SO002_SP002_any_involved_party"
+ON service_providing_group_product_suspension_comment;
 CREATE POLICY "SPGPSC_SO002_SP002_any_involved_party"
 ON service_providing_group_product_suspension_comment
 FOR SELECT
@@ -115,6 +127,8 @@ $$;
 GRANT SELECT
 ON service_providing_group_product_suspension_comment_history
 TO flex_system_operator, flex_service_provider;
+DROP POLICY IF EXISTS "SPGPSC_SO003_SP003_same_party"
+ON service_providing_group_product_suspension_comment_history;
 CREATE POLICY "SPGPSC_SO003_SP003_same_party"
 ON service_providing_group_product_suspension_comment_history
 FOR SELECT
@@ -132,6 +146,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "SPGPSC_SO003_SP003_any_involved_party"
+ON service_providing_group_product_suspension_comment_history;
 CREATE POLICY "SPGPSC_SO003_SP003_any_involved_party"
 ON service_providing_group_product_suspension_comment_history
 FOR SELECT
@@ -149,6 +165,8 @@ USING (
 );
 
 -- RLS: SPGPSC-FISO001
+DROP POLICY IF EXISTS "SPGPSC_FISO001"
+ON service_providing_group_product_suspension_comment;
 CREATE POLICY "SPGPSC_FISO001"
 ON service_providing_group_product_suspension_comment
 FOR ALL
@@ -156,6 +174,8 @@ TO flex_flexibility_information_system_operator
 USING (true);
 
 -- RLS: SPGPSC-FISO002
+DROP POLICY IF EXISTS "SPGPSC_FISO002"
+ON service_providing_group_product_suspension_comment_history;
 CREATE POLICY "SPGPSC_FISO002"
 ON service_providing_group_product_suspension_comment_history
 FOR ALL

--- a/db/flex/service_providing_group_product_suspension_rls.sql
+++ b/db/flex/service_providing_group_product_suspension_rls.sql
@@ -1,13 +1,15 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:service-providing-group-product-suspension-rls runAlways:true endDelimiter:;
+-- changeset flex:service-providing-group-product-suspension-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS service_providing_group_product_suspension
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON service_providing_group_product_suspension
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGPS_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_product_suspension;
 CREATE POLICY "SPGPS_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_product_suspension
 FOR SELECT
@@ -16,6 +18,8 @@ USING (true);
 
 GRANT SELECT ON service_providing_group_product_suspension_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGPS_HISTORY_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_product_suspension_history;
 CREATE POLICY "SPGPS_HISTORY_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_product_suspension_history
 FOR SELECT
@@ -26,6 +30,7 @@ USING (true);
 GRANT SELECT, INSERT, UPDATE, DELETE
 ON service_providing_group_product_suspension
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SPGPS_FISO001" ON service_providing_group_product_suspension;
 CREATE POLICY "SPGPS_FISO001"
 ON service_providing_group_product_suspension
 FOR ALL
@@ -35,6 +40,8 @@ USING (true);
 -- RLS: SPGPS-FISO002
 GRANT SELECT ON service_providing_group_product_suspension_history
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SPGPS_FISO002"
+ON service_providing_group_product_suspension_history;
 CREATE POLICY "SPGPS_FISO002"
 ON service_providing_group_product_suspension_history
 FOR SELECT
@@ -44,6 +51,7 @@ USING (true);
 -- RLS: SPGPS-SP001
 GRANT SELECT ON service_providing_group_product_suspension
 TO flex_service_provider;
+DROP POLICY IF EXISTS "SPGPS_SP001" ON service_providing_group_product_suspension;
 CREATE POLICY "SPGPS_SP001"
 ON service_providing_group_product_suspension
 FOR SELECT
@@ -60,6 +68,8 @@ USING (
 -- RLS: SPGPS-SP002
 GRANT SELECT ON service_providing_group_product_suspension_history
 TO flex_service_provider;
+DROP POLICY IF EXISTS "SPGPS_SP002"
+ON service_providing_group_product_suspension_history;
 CREATE POLICY "SPGPS_SP002"
 ON service_providing_group_product_suspension_history
 FOR SELECT
@@ -79,6 +89,7 @@ INSERT,
 UPDATE,
 DELETE ON service_providing_group_product_suspension
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SPGPS_SO001" ON service_providing_group_product_suspension;
 CREATE POLICY "SPGPS_SO001"
 ON service_providing_group_product_suspension
 FOR ALL
@@ -88,6 +99,8 @@ USING (procuring_system_operator_id = (SELECT flex.current_party()));
 -- RLS: SPGPS-SO002
 GRANT SELECT ON service_providing_group_product_suspension_history
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SPGPS_SO002"
+ON service_providing_group_product_suspension_history;
 CREATE POLICY "SPGPS_SO002"
 ON service_providing_group_product_suspension_history
 FOR SELECT
@@ -95,6 +108,7 @@ TO flex_system_operator
 USING (procuring_system_operator_id = (SELECT flex.current_party()));
 
 -- RLS: SPGPS-SO003
+DROP POLICY IF EXISTS "SPGPS_SO003" ON service_providing_group_product_suspension;
 CREATE POLICY "SPGPS_SO003"
 ON service_providing_group_product_suspension
 FOR SELECT
@@ -103,7 +117,8 @@ USING (
     EXISTS (
         SELECT 1
         FROM flex.service_providing_group_product_application AS spgpa
-        WHERE spgpa.service_providing_group_id
+        WHERE
+            spgpa.service_providing_group_id
         = service_providing_group_product_suspension.service_providing_group_id -- noqa
             AND spgpa.procuring_system_operator_id
             = (SELECT flex.current_party())
@@ -114,6 +129,8 @@ USING (
 );
 
 -- RLS: SPGPS-SO004
+DROP POLICY IF EXISTS "SPGPS_SO004"
+ON service_providing_group_product_suspension_history;
 CREATE POLICY "SPGPS_SO004"
 ON service_providing_group_product_suspension_history
 FOR SELECT
@@ -132,7 +149,8 @@ USING (
                 FROM
                     flex.service_providing_group_product_application_history
                     AS spgpah -- noqa
-                WHERE spgpah.service_providing_group_id
+                WHERE
+                    spgpah.service_providing_group_id
                 = service_providing_group_product_suspension_history.service_providing_group_id -- noqa
                     AND spgpah.procuring_system_operator_id
                     = (SELECT flex.current_party())
@@ -144,7 +162,8 @@ USING (
                     spgpa.prequalified_at,
                     spgpa.verified_at
                 FROM flex.service_providing_group_product_application AS spgpa
-                WHERE spgpa.service_providing_group_id
+                WHERE
+                    spgpa.service_providing_group_id
                 = service_providing_group_product_suspension_history.service_providing_group_id -- noqa
                     AND spgpa.procuring_system_operator_id
                     = (SELECT flex.current_party())
@@ -152,7 +171,8 @@ USING (
 
         SELECT 1
         FROM spgpa_history
-        WHERE spgpa_history.record_time_range
+        WHERE
+            spgpa_history.record_time_range
             && service_providing_group_product_suspension_history.record_time_range -- noqa
             AND spg_product_application_ready_for_market_check(spgpa_history) -- noqa
             AND service_providing_group_product_suspension_history.product_type_ids -- noqa

--- a/db/flex/service_providing_group_rls.sql
+++ b/db/flex/service_providing_group_rls.sql
@@ -1,12 +1,13 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:service-providing-group-rls runAlways:true endDelimiter:;
+-- changeset flex:service-providing-group-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS service_providing_group ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON service_providing_group
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPG_INTERNAL_EVENT_NOTIFICATION" ON service_providing_group;
 CREATE POLICY "SPG_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group
 FOR SELECT
@@ -15,6 +16,8 @@ USING (true);
 
 GRANT SELECT ON service_providing_group_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SPGH_INTERNAL_EVENT_NOTIFICATION"
+ON service_providing_group_history;
 CREATE POLICY "SPGH_INTERNAL_EVENT_NOTIFICATION"
 ON service_providing_group_history
 FOR SELECT
@@ -24,6 +27,7 @@ USING (true);
 -- RLS: SPG-FISO001
 GRANT SELECT, INSERT, UPDATE ON service_providing_group
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SPG_FISO001" ON service_providing_group;
 CREATE POLICY "SPG_FISO001" ON service_providing_group
 FOR ALL
 TO flex_flexibility_information_system_operator
@@ -32,6 +36,7 @@ USING (true);
 -- RLS: SPG-SP001
 GRANT SELECT, INSERT, UPDATE ON service_providing_group
 TO flex_service_provider;
+DROP POLICY IF EXISTS "SPG_SP001" ON service_providing_group;
 CREATE POLICY "SPG_SP001" ON service_providing_group
 FOR ALL
 TO flex_service_provider
@@ -40,6 +45,7 @@ USING (service_provider_id = (SELECT current_party()));
 -- RLS: SPG-SO001
 GRANT SELECT ON service_providing_group
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SPG_SO001" ON service_providing_group;
 CREATE POLICY "SPG_SO001" ON service_providing_group
 FOR SELECT
 TO flex_system_operator
@@ -51,6 +57,7 @@ USING (
 );
 
 -- RLS: SPG-SO002
+DROP POLICY IF EXISTS "SPG_SO002" ON service_providing_group;
 CREATE POLICY "SPG_SO002" ON service_providing_group
 FOR SELECT
 TO flex_system_operator

--- a/db/flex/system_operator_product_type_history_audit.sql
+++ b/db/flex/system_operator_product_type_history_audit.sql
@@ -25,11 +25,13 @@ ALTER TABLE IF EXISTS
 flex.system_operator_product_type_history
 ENABLE ROW LEVEL SECURITY;
 
--- changeset flex:system-operator-product-type-history-rls-com runAlways:true endDelimiter:--
+-- changeset flex:system-operator-product-type-history-rls-com runOnChange:true endDelimiter:--
 -- RLS: SOPT-COM001
 GRANT SELECT ON flex.system_operator_product_type_history
 TO flex_common;
 
+DROP POLICY IF EXISTS "SOPT_COM001"
+ON flex.system_operator_product_type_history;
 CREATE POLICY "SOPT_COM001"
 ON flex.system_operator_product_type_history
 FOR SELECT

--- a/db/flex/system_operator_product_type_rls.sql
+++ b/db/flex/system_operator_product_type_rls.sql
@@ -1,13 +1,15 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:system-operator-product-type-rls runAlways:true endDelimiter:;
+-- changeset flex:system-operator-product-type-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS system_operator_product_type
 ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON system_operator_product_type
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SOPT_INTERNAL_EVENT_NOTIFICATION"
+ON system_operator_product_type;
 CREATE POLICY "SOPT_INTERNAL_EVENT_NOTIFICATION"
 ON system_operator_product_type
 FOR SELECT
@@ -16,6 +18,8 @@ USING (true);
 
 GRANT SELECT ON system_operator_product_type_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "SOPTH_INTERNAL_EVENT_NOTIFICATION"
+ON system_operator_product_type_history;
 CREATE POLICY "SOPTH_INTERNAL_EVENT_NOTIFICATION"
 ON system_operator_product_type_history
 FOR SELECT
@@ -25,6 +29,7 @@ USING (true);
 -- RLS: SOPT-FISO001
 GRANT SELECT, INSERT, UPDATE ON system_operator_product_type
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "SOPT_FISO001" ON system_operator_product_type;
 CREATE POLICY "SOPT_FISO001"
 ON system_operator_product_type
 FOR ALL
@@ -34,6 +39,7 @@ USING (true);
 -- RLS: SOPT-COM002
 GRANT SELECT ON system_operator_product_type
 TO flex_common;
+DROP POLICY IF EXISTS "SOPT_COM002" ON system_operator_product_type;
 CREATE POLICY "SOPT_COM002"
 ON system_operator_product_type
 FOR SELECT
@@ -43,6 +49,7 @@ USING (true);
 -- RLS: SOPT-SO001
 GRANT SELECT, INSERT, UPDATE ON system_operator_product_type
 TO flex_system_operator;
+DROP POLICY IF EXISTS "SOPT_SO001" ON system_operator_product_type;
 CREATE POLICY "SOPT_SO001"
 ON system_operator_product_type
 FOR ALL

--- a/db/flex/technical_resource_rls.sql
+++ b/db/flex/technical_resource_rls.sql
@@ -1,24 +1,27 @@
 --liquibase formatted sql
 -- Manually managed file
 
--- changeset flex:technical-resource-rls runAlways:true endDelimiter:;
+-- changeset flex:technical-resource-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS technical_resource ENABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS technical_resource_history ENABLE ROW LEVEL SECURITY;
 
 -- internal
 GRANT SELECT ON technical_resource TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "TRG_INTERNAL_EVENT_NOTIFICATION" ON technical_resource;
 CREATE POLICY "TRG_INTERNAL_EVENT_NOTIFICATION" ON technical_resource
 FOR SELECT
 TO flex_internal_event_notification
 USING (true);
 
 GRANT SELECT ON technical_resource_history TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "TRH_INTERNAL_EVENT_NOTIFICATION" ON technical_resource_history;
 CREATE POLICY "TRH_INTERNAL_EVENT_NOTIFICATION" ON technical_resource_history
 FOR SELECT
 TO flex_internal_event_notification
 USING (true);
 
 GRANT SELECT ON technical_resource TO flex_internal_data;
+DROP POLICY IF EXISTS "TR_INTERNAL_DATA" ON technical_resource;
 CREATE POLICY "TR_INTERNAL_DATA" ON technical_resource
 FOR SELECT
 TO flex_internal_data
@@ -26,6 +29,7 @@ USING (true);
 
 -- RLS: TR-BRP001
 GRANT SELECT ON technical_resource TO flex_balance_responsible_party;
+DROP POLICY IF EXISTS "TR_BRP001" ON technical_resource;
 CREATE POLICY "TR_BRP001" ON technical_resource
 FOR SELECT
 TO flex_balance_responsible_party
@@ -41,6 +45,7 @@ USING (
 
 -- RLS: TR-BRP002
 GRANT SELECT ON technical_resource_history TO flex_balance_responsible_party;
+DROP POLICY IF EXISTS "TR_BRP002" ON technical_resource_history;
 CREATE POLICY "TR_BRP002"
 ON technical_resource_history
 FOR SELECT
@@ -59,6 +64,7 @@ USING (
 
 -- RLS: TR-EU001
 GRANT SELECT ON technical_resource TO flex_end_user;
+DROP POLICY IF EXISTS "TR_EU001" ON technical_resource;
 CREATE POLICY "TR_EU001" ON technical_resource
 FOR SELECT
 TO flex_end_user
@@ -74,6 +80,7 @@ USING (
 
 -- RLS: TR-EU002
 GRANT SELECT ON technical_resource_history TO flex_end_user;
+DROP POLICY IF EXISTS "TR_EU002" ON technical_resource_history;
 CREATE POLICY "TR_EU002"
 ON technical_resource_history
 FOR SELECT
@@ -92,6 +99,7 @@ USING (
 
 -- RLS: TR-ES001
 GRANT SELECT ON technical_resource TO flex_energy_supplier;
+DROP POLICY IF EXISTS "TR_ES001" ON technical_resource;
 CREATE POLICY "TR_ES001" ON technical_resource
 FOR SELECT
 TO flex_energy_supplier
@@ -107,6 +115,7 @@ USING (
 
 -- RLS: TR-ES002
 GRANT SELECT ON technical_resource_history TO flex_energy_supplier;
+DROP POLICY IF EXISTS "TR_ES002" ON technical_resource_history;
 CREATE POLICY "TR_ES002"
 ON technical_resource_history
 FOR SELECT
@@ -128,6 +137,7 @@ GRANT INSERT,
 SELECT,
 UPDATE,
 DELETE ON technical_resource TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "TR_FISO001" ON technical_resource;
 CREATE POLICY "TR_FISO001" ON technical_resource
 FOR ALL
 TO flex_flexibility_information_system_operator
@@ -136,6 +146,7 @@ USING (true);
 -- RLS: TR-FISO002
 GRANT SELECT ON technical_resource_history
 TO flex_flexibility_information_system_operator;
+DROP POLICY IF EXISTS "TR_FISO002" ON technical_resource_history;
 CREATE POLICY "TR_FISO002" ON technical_resource_history
 FOR SELECT
 TO flex_flexibility_information_system_operator
@@ -143,6 +154,7 @@ USING (true);
 
 -- RLS: TR-SO001
 GRANT SELECT ON technical_resource TO flex_system_operator;
+DROP POLICY IF EXISTS "TR_SO001" ON technical_resource;
 CREATE POLICY "TR_SO001" ON technical_resource
 FOR SELECT
 TO flex_system_operator
@@ -157,6 +169,7 @@ USING (
 -- RLS: TR-SO002
 GRANT SELECT ON technical_resource_history
 TO flex_system_operator;
+DROP POLICY IF EXISTS "TR_SO002" ON technical_resource_history;
 CREATE POLICY "TR_SO002"
 ON technical_resource_history
 FOR SELECT
@@ -171,6 +184,7 @@ USING (
 
 -- RLS: TR-SP001
 GRANT INSERT, UPDATE, DELETE ON technical_resource TO flex_service_provider;
+DROP POLICY IF EXISTS "TR_SP001" ON technical_resource;
 CREATE POLICY "TR_SP001" ON technical_resource
 FOR ALL
 TO flex_service_provider
@@ -186,6 +200,7 @@ USING (
 
 -- RLS: TR-SP002
 GRANT SELECT ON technical_resource TO flex_service_provider;
+DROP POLICY IF EXISTS "TR_SP002" ON technical_resource;
 CREATE POLICY "TR_SP002" ON technical_resource
 FOR SELECT
 TO flex_service_provider
@@ -204,6 +219,7 @@ USING (
 -- RLS: TR-SP003
 GRANT SELECT ON technical_resource_history
 TO flex_service_provider;
+DROP POLICY IF EXISTS "TR_SP003" ON technical_resource_history;
 CREATE POLICY "TR_SP003"
 ON technical_resource_history
 FOR SELECT

--- a/docs-dev/db-migration.md
+++ b/docs-dev/db-migration.md
@@ -19,8 +19,6 @@ definition, like triggers, functions, _etc._, can be changed without a
 migration.
 This is also why a lot of SQL definitions leverage `IF NOT EXISTS`,
 `CREATE OR REPLACE`, _etc_, as well as `runOnChange` in Liquibase.
-Some types of objects (_e.g._, policies) are marked `runAlways` so we always
-drop and recreate them.
 
 ## Writing the migration
 
@@ -31,10 +29,11 @@ migrations that were applied to it, to get an idea of what a table looks like.
 
 Instead, we choose to also make the definition evolve alongside the migrations,
 for documentation purposes, and also because this allows deleting the migrations
-over time, once they have been run on the live environment.
-However, this means the definition must only be run once, when the system is
-launched for the first time.
-Therefore, we mark the table definitions with `runOnChange:false`.
+over time, once they have been run on the live environment. The table must only
+be created once, when the system is launched for the first time. We ensure that
+by using `IF NOT EXISTS` in the `CREATE TABLE` statement, so that it does not
+throw an error if the table already exists. We mark the table definitions
+changeset with `runOnChange:false` to avoid liquibase checksum errors.
 
 In order to apply a migration to a database table, you need to add a new
 _changeset_ in Liquibase where the actual changes are made on the table.

--- a/local/scripts/templates/comment_rls.j2.sql
+++ b/local/scripts/templates/comment_rls.j2.sql
@@ -4,7 +4,7 @@
 {%- set liquibase_resource = resource | replace("_", "-") %}
 {%- set lower_acronym = data.acronym | lower %}
 
--- changeset flex:{{ liquibase_resource }}-comment-rls runAlways:true endDelimiter:;
+-- changeset flex:{{ liquibase_resource }}-comment-rls runOnChange:true endDelimiter:;
 ALTER TABLE IF EXISTS
 {{ resource }}_comment
 ENABLE ROW LEVEL SECURITY;
@@ -13,6 +13,8 @@ ENABLE ROW LEVEL SECURITY;
 GRANT SELECT
 ON {{ resource }}_comment
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "{{ data.acronym }}C_INTERNAL_EVENT_NOTIFICATION"
+ON {{ resource }}_comment;
 CREATE POLICY "{{ data.acronym }}C_INTERNAL_EVENT_NOTIFICATION"
 ON {{ resource }}_comment
 FOR SELECT
@@ -22,6 +24,8 @@ USING (true);
 GRANT SELECT
 ON {{ resource }}_comment_history
 TO flex_internal_event_notification;
+DROP POLICY IF EXISTS "{{ data.acronym }}CH_INTERNAL_EVENT_NOTIFICATION"
+ON {{ resource }}_comment_history;
 CREATE POLICY "{{ data.acronym }}CH_INTERNAL_EVENT_NOTIFICATION"
 ON {{ resource }}_comment_history
 FOR SELECT
@@ -33,6 +37,8 @@ ON {{ resource }}_comment
 TO flex_common;
 
 -- RLS: {{ data.acronym }}C-COM001
+DROP POLICY IF EXISTS "{{ data.acronym }}C_COM001"
+ON {{ resource }}_comment;
 CREATE POLICY "{{ data.acronym }}C_COM001"
 ON {{ resource }}_comment
 FOR UPDATE
@@ -41,6 +47,8 @@ USING (created_by = (SELECT flex.current_identity()));
 
 -- RLS: {{ data.acronym }}C-SO001
 -- RLS: {{ data.acronym }}C-SP001
+DROP POLICY IF EXISTS "{{ data.acronym }}C_SO001_SP001"
+ON {{ resource }}_comment;
 CREATE POLICY "{{ data.acronym }}C_SO001_SP001"
 ON {{ resource }}_comment
 FOR INSERT
@@ -56,6 +64,8 @@ WITH CHECK (
 
 -- RLS: {{ data.acronym }}C-SO002
 -- RLS: {{ data.acronym }}C-SP002
+DROP POLICY IF EXISTS "{{ data.acronym }}C_SO002_SP002_same_party"
+ON {{ resource }}_comment;
 CREATE POLICY "{{ data.acronym }}C_SO002_SP002_same_party"
 ON {{ resource }}_comment
 FOR SELECT
@@ -71,6 +81,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "{{ data.acronym }}C_SO002_SP002_any_involved_party"
+ON {{ resource }}_comment;
 CREATE POLICY "{{ data.acronym }}C_SO002_SP002_any_involved_party"
 ON {{ resource }}_comment
 FOR SELECT
@@ -118,6 +130,8 @@ $$;
 GRANT SELECT
 ON {{ resource }}_comment_history
 TO flex_system_operator, flex_service_provider;
+DROP POLICY IF EXISTS "{{ data.acronym }}C_SO003_SP003_same_party"
+ON {{ resource }}_comment_history;
 CREATE POLICY "{{ data.acronym }}C_SO003_SP003_same_party"
 ON {{ resource }}_comment_history
 FOR SELECT
@@ -135,6 +149,8 @@ USING (
     )
 );
 
+DROP POLICY IF EXISTS "{{ data.acronym }}C_SO003_SP003_any_involved_party"
+ON {{ resource }}_comment_history;
 CREATE POLICY "{{ data.acronym }}C_SO003_SP003_any_involved_party"
 ON {{ resource }}_comment_history
 FOR SELECT
@@ -152,6 +168,8 @@ USING (
 );
 
 -- RLS: {{ data.acronym }}C-FISO001
+DROP POLICY IF EXISTS "{{ data.acronym }}C_FISO001"
+ON {{ resource }}_comment;
 CREATE POLICY "{{ data.acronym }}C_FISO001"
 ON {{ resource }}_comment
 FOR ALL
@@ -159,6 +177,8 @@ TO flex_flexibility_information_system_operator
 USING (true);
 
 -- RLS: {{ data.acronym }}C-FISO002
+DROP POLICY IF EXISTS "{{ data.acronym }}C_FISO002"
+ON {{ resource }}_comment_history;
 CREATE POLICY "{{ data.acronym }}C_FISO002"
 ON {{ resource }}_comment_history
 FOR ALL

--- a/local/scripts/templates/resource_history_audit.j2.sql
+++ b/local/scripts/templates/resource_history_audit.j2.sql
@@ -27,11 +27,13 @@ ENABLE ROW LEVEL SECURITY;
 
 {%- if data.get('history_rls')%}
 
--- changeset flex:{{ resource | replace("_", "-") }}-history-rls-com runAlways:true endDelimiter:--
+-- changeset flex:{{ resource | replace("_", "-") }}-history-rls-com runOnChange:true endDelimiter:--
 -- RLS: {{ data.acronym }}-COM001
 GRANT SELECT ON flex.{{ resource }}_history
 TO flex_common;
 
+DROP POLICY IF EXISTS "{{ data.acronym }}_COM001"
+ON flex.{{ resource }}_history;
 CREATE POLICY "{{ data.acronym }}_COM001"
 ON flex.{{ resource }}_history
 FOR SELECT


### PR DESCRIPTION
This makes the LB changeset better resistant to errors and avoids having a few seconds on deploy where all policies are missing.

The existing strategy was not ment for production use.

The consequence of this change is that we must remember to drop policies explicitly.
