### PR TITLE
revert: move eslint and prettier hooks from pre-commit to pre-push (#698)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -212,7 +212,6 @@ repos:
           - css
           - scss
         exclude: "(local/mkdocs/.*|frontend/src/intl/.*-labels.ts|frontend/src/generated-client/.*)"
-        stages: [pre-push]
 
   - repo: local
     hooks:
@@ -223,7 +222,6 @@ repos:
         language: script
         types_or: [ts, tsx, javascript]
         pass_filenames: false
-        stages: [pre-push]
 
   - repo: local
     hooks:


### PR DESCRIPTION
This reverts commit c9fc8741a91865e33a683703a7a7ed90d7abdd40.

Since I think we want it this way (?)
