### PR TITLE
feat(ui): sensitive info warning on additional information fields (FLEX-1247)

### DIFF
--- a/frontend/src/accounting_point/grid_location/AccountingPointGridLocationInput.tsx
+++ b/frontend/src/accounting_point/grid_location/AccountingPointGridLocationInput.tsx
@@ -104,6 +104,7 @@ export const AccountingPointGridLocationInput = ({
             {...fields.additional_information}
             tooltip={false}
             rows={5}
+            warning="Please remember not to write any sensitive information in this field."
           />
           <FormToolbar onCancel={onDone} />
         </FormContainer>

--- a/frontend/src/accounting_point/grid_location/AccountingPointGridLocationInput.tsx
+++ b/frontend/src/accounting_point/grid_location/AccountingPointGridLocationInput.tsx
@@ -104,7 +104,7 @@ export const AccountingPointGridLocationInput = ({
             {...fields.additional_information}
             tooltip={false}
             rows={5}
-            warning="Please remember not to write any sensitive information in this field."
+            warning="Please remember not to write any sensitive (power/market/personal) information in this field."
           />
           <FormToolbar onCancel={onDone} />
         </FormContainer>

--- a/frontend/src/components/EDS-ra/inputs/BaseInput.tsx
+++ b/frontend/src/components/EDS-ra/inputs/BaseInput.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { FormItem, FormItemLabel, FlexDiv } from "../../ui";
+import { FormItem, FormItemLabel, FlexDiv, Alert } from "../../ui";
 import { FormItemDescription } from "../../ui/types";
 import { usePermissions, useResourceContext, useTranslate } from "ra-core";
 import { Permissions, PermissionTarget } from "../../../auth/permissions";
@@ -17,6 +17,7 @@ export type BaseInputProps = {
   overrideLabel?: string;
   description?: boolean;
   descriptionOverride?: string;
+  warning?: string;
 };
 
 type BaseInputPropsWithChildren = BaseInputProps & {
@@ -35,6 +36,7 @@ export const BaseInput = ({
   error,
   description,
   descriptionOverride,
+  warning,
   children,
   resource: resourceProp,
   overrideLabel,
@@ -84,6 +86,7 @@ export const BaseInput = ({
       {description || descriptionOverride ? (
         <FormItemDescription>{descriptionText}</FormItemDescription>
       ) : null}
+      {warning ? <Alert variant="warning">{warning}</Alert> : null}
       {children}
     </FormItem>
   );

--- a/frontend/src/components/EDS-ra/inputs/TextAreaInput.tsx
+++ b/frontend/src/components/EDS-ra/inputs/TextAreaInput.tsx
@@ -20,6 +20,7 @@ export const TextAreaInput = ({
   disabled,
   description,
   descriptionOverride,
+  warning,
   ...rest
 }: TextAreaInputProps) => {
   const { id, field, fieldState } = useInput({ source, ...rest });
@@ -39,6 +40,7 @@ export const TextAreaInput = ({
       error={fieldState.error?.message}
       description={description}
       descriptionOverride={descriptionOverride}
+      warning={warning}
     >
       <Textarea
         id={id}

--- a/frontend/src/controllable_unit/ControllableUnitCreateForm.tsx
+++ b/frontend/src/controllable_unit/ControllableUnitCreateForm.tsx
@@ -215,7 +215,7 @@ export const ControllableUnitCreateForm = ({
             rows={5}
             description
             tooltip={false}
-            warning="Please remember not to write any sensitive information in this field."
+            warning="Please remember not to write any sensitive (power/market/personal) information in this field."
           />
         </div>
         <FormToolbar />

--- a/frontend/src/controllable_unit/ControllableUnitCreateForm.tsx
+++ b/frontend/src/controllable_unit/ControllableUnitCreateForm.tsx
@@ -18,6 +18,7 @@ import {
 } from "../components/ui";
 import {
   TextInput,
+  TextAreaInput,
   EnumInput,
   PartyReferenceInput,
   FormToolbar,
@@ -44,6 +45,8 @@ const zControllableUnitCreateForm = z.object({
     .refine((date) => isPast(date), {
       message: "Start date must be today or a past date",
     }),
+  additional_information:
+    zControllableUnitCreateRequest.shape.additional_information,
 });
 type ControllableUnitCreateFormValues = z.infer<
   typeof zControllableUnitCreateForm
@@ -204,6 +207,12 @@ export const ControllableUnitCreateForm = ({
               { label: "MW", scale: 1000 },
             ]}
             disabled={!!savedControllableUnitId}
+            description
+            tooltip={false}
+          />
+          <TextAreaInput
+            {...fields.additional_information}
+            rows={5}
             description
             tooltip={false}
           />

--- a/frontend/src/controllable_unit/ControllableUnitCreateForm.tsx
+++ b/frontend/src/controllable_unit/ControllableUnitCreateForm.tsx
@@ -215,6 +215,7 @@ export const ControllableUnitCreateForm = ({
             rows={5}
             description
             tooltip={false}
+            warning="Please remember not to write any sensitive information in this field."
           />
         </div>
         <FormToolbar />

--- a/frontend/src/controllable_unit/ControllableUnitInput.tsx
+++ b/frontend/src/controllable_unit/ControllableUnitInput.tsx
@@ -83,6 +83,7 @@ export const ControllableUnitInput = () => {
             rows={5}
             description
             tooltip={false}
+            warning="Please remember not to write any sensitive information in this field."
           />
         </FlexDiv>
 

--- a/frontend/src/controllable_unit/ControllableUnitInput.tsx
+++ b/frontend/src/controllable_unit/ControllableUnitInput.tsx
@@ -83,7 +83,7 @@ export const ControllableUnitInput = () => {
             rows={5}
             description
             tooltip={false}
-            warning="Please remember not to write any sensitive information in this field."
+            warning="Please remember not to write any sensitive (power/market/personal) information in this field."
           />
         </FlexDiv>
 

--- a/frontend/src/controllable_unit/technical_resource/TechnicalResourceInput.tsx
+++ b/frontend/src/controllable_unit/technical_resource/TechnicalResourceInput.tsx
@@ -107,6 +107,7 @@ export const TechnicalResourceInput = () => {
             rows={8}
             description
             tooltip={false}
+            warning="Please remember not to write any sensitive information in this field."
           />
         </FlexDiv>
 

--- a/frontend/src/controllable_unit/technical_resource/TechnicalResourceInput.tsx
+++ b/frontend/src/controllable_unit/technical_resource/TechnicalResourceInput.tsx
@@ -107,7 +107,7 @@ export const TechnicalResourceInput = () => {
             rows={8}
             description
             tooltip={false}
-            warning="Please remember not to write any sensitive information in this field."
+            warning="Please remember not to write any sensitive (power/market/personal) information in this field."
           />
         </FlexDiv>
 

--- a/frontend/src/service_providing_group/input/ServiceProvidingGroupFields.tsx
+++ b/frontend/src/service_providing_group/input/ServiceProvidingGroupFields.tsx
@@ -48,7 +48,7 @@ export const ServiceProvidingGroupFields = ({ isEdit }: Props) => {
         rows={5}
         description
         tooltip={false}
-        warning="Please remember not to write any sensitive information in this field."
+        warning="Please remember not to write any sensitive (power/market/personal) information in this field."
       />
     </>
   );

--- a/frontend/src/service_providing_group/input/ServiceProvidingGroupFields.tsx
+++ b/frontend/src/service_providing_group/input/ServiceProvidingGroupFields.tsx
@@ -48,6 +48,7 @@ export const ServiceProvidingGroupFields = ({ isEdit }: Props) => {
         rows={5}
         description
         tooltip={false}
+        warning="Please remember not to write any sensitive information in this field."
       />
     </>
   );

--- a/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationInput.tsx
+++ b/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationInput.tsx
@@ -144,7 +144,7 @@ export const ServiceProvidingGroupProductApplicationInput = () => {
           rows={8}
           description
           tooltip={false}
-          warning="Please remember not to write any sensitive information in this field."
+          warning="Please remember not to write any sensitive (power/market/personal) information in this field."
         />
         <DateTimeInput
           {...fields.prequalified_at}

--- a/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationInput.tsx
+++ b/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationInput.tsx
@@ -144,6 +144,7 @@ export const ServiceProvidingGroupProductApplicationInput = () => {
           rows={8}
           description
           tooltip={false}
+          warning="Please remember not to write any sensitive information in this field."
         />
         <DateTimeInput
           {...fields.prequalified_at}


### PR DESCRIPTION
This PR adds possibility to write additional information when creating a new CU, and adds a warning to all such fields across the app to prevent users from writing sensitive information there.

The technical solution for the latter change is factored into a `warning` prop on input components, so we can generalise this later if needed.

<img width="1267" height="214" alt="Screenshot 2026-06-01 162659" src="https://github.com/user-attachments/assets/6d2b5edf-25fb-42a1-b421-a27cbb0aa397" />
