### PR TITLE
feat: ORG admins can no longer see person entities having email business ID (FLEX-1241)

### DIFF
--- a/db/flex/entity_rls.sql
+++ b/db/flex/entity_rls.sql
@@ -70,11 +70,5 @@ USING (
     )
 );
 
--- RLS: ENT-ORG002
+-- TODO: delete after migration has run once
 DROP POLICY IF EXISTS "ENT_ORG002" ON entity;
-CREATE POLICY "ENT_ORG002" ON entity
-FOR SELECT
-TO flex_organisation
-USING (
-    business_id_type = 'email'
-);

--- a/docs/resources/entity.md
+++ b/docs/resources/entity.md
@@ -100,7 +100,6 @@ No policies.
 | Policy key | Policy                                                                                                                                    | Status |
 |------------|-------------------------------------------------------------------------------------------------------------------------------------------|--------|
 | ENT-ORG001 | Read all entities belonging to parties owned by the organisation.                                                                         | DONE   |
-| ENT-ORG002 | Read all entities with business id type `email`. Temporary policy for test environments with email based entities for professional users. | DONE   |
 
 #### System Operator
 

--- a/test/api_client_tests/test_entity.py
+++ b/test/api_client_tests/test_entity.py
@@ -295,13 +295,6 @@ def test_entity_org(sts):
     )
     assert not isinstance(d, ErrorMessage)
 
-    # organisation should by default see the entity with email business id type
-    # TODO this is a temporary solution for pilot testing w/ email based entities
-    # RLS: ENT-ORG002
-    ent = list_entity.sync(client=client_org, business_id_type="eq.email")
-    assert isinstance(ent, list)
-    assert len(ent) >= 1
-
 
 def test_entity_com(sts):
     client_fiso = sts.get_client(TestEntity.TEST, "FISO")


### PR DESCRIPTION
This PR removes `ENT-ORG002` and thereby makes it impossible for ORG admins to read email entities.

This was a temporary policy in testing, but now that we have the entity lookup flow, ORG admins can add users to their parties by entering their email and name, so they do not need to be able to pick entities from a readable list. Also a good way to show even less information about the existing users in the system.