### PR TITLE
feat: Include party type in PartyReferenceInput label where needed (FLEX-1240)

### DIFF
--- a/frontend/src/components/EDS-ra/inputs/AutocompleteReferenceInput.tsx
+++ b/frontend/src/components/EDS-ra/inputs/AutocompleteReferenceInput.tsx
@@ -1,4 +1,5 @@
 import {
+  RaRecord,
   ReferenceInput,
   UseReferenceInputControllerParams,
   useResourceContext,
@@ -13,6 +14,7 @@ type AutocompleteReferenceInputProps = Omit<
   BaseInputProps & {
     reference: string;
     fieldName?: string;
+    optionText?: (record: RaRecord) => string;
   };
 
 export const AutocompleteReferenceInput = ({
@@ -20,6 +22,7 @@ export const AutocompleteReferenceInput = ({
   required,
   reference,
   fieldName,
+  optionText,
   overrideLabel,
   readOnly,
   disabled,
@@ -42,6 +45,7 @@ export const AutocompleteReferenceInput = ({
         required={required}
         overrideLabel={overrideLabel}
         fieldName={fieldName}
+        optionText={optionText}
         readOnly={readOnly}
         resource={resource}
         disabled={disabled}

--- a/frontend/src/components/EDS-ra/inputs/PartyReferenceInput.tsx
+++ b/frontend/src/components/EDS-ra/inputs/PartyReferenceInput.tsx
@@ -1,6 +1,9 @@
+import { RaRecord } from "ra-core";
 import { ReferenceInputProps } from "react-admin";
 import { AutocompleteReferenceInput } from "./AutocompleteReferenceInput";
 import { BaseInputProps } from "./BaseInput";
+import { EnumLabel } from "../../../intl/enum-labels";
+import { useTranslateEnum } from "../../../intl/intl";
 
 type PartyReferenceInputProps = Omit<
   ReferenceInputProps,
@@ -8,25 +11,33 @@ type PartyReferenceInputProps = Omit<
 > &
   BaseInputProps & {
     noTypeFilter?: boolean;
+    optionText?: (record: RaRecord) => string;
   };
 
 // Specialized version of AutocompleteReferenceInput for party fields
 // Automatically filters by party type derived from the source field name
 // e.g., source="service_provider_id" filters to type="service_provider"
+// Option labels include the translated party type, e.g. "Acme (Service Provider)"
 export const PartyReferenceInput = ({
   noTypeFilter,
   source,
   filter,
+  optionText,
   ...rest
 }: PartyReferenceInputProps) => {
+  const translateEnum = useTranslateEnum();
   const choiceFilter =
     filter || (noTypeFilter ? undefined : { type: source.replace("_id", "") });
+
+  const defaultOptionText = (record: RaRecord) =>
+    `${record.name} (${translateEnum(`party.type.${record.type}` as EnumLabel)})`;
 
   return (
     <AutocompleteReferenceInput
       source={source}
       reference="party"
       filter={choiceFilter}
+      optionText={optionText ?? defaultOptionText}
       {...rest}
     />
   );

--- a/frontend/src/components/EDS-ra/inputs/ReferenceComboboxInput.tsx
+++ b/frontend/src/components/EDS-ra/inputs/ReferenceComboboxInput.tsx
@@ -1,5 +1,6 @@
 import { Combobox } from "../../ui";
 import {
+  RaRecord,
   useChoicesContext,
   useGetRecordRepresentation,
   useInput,
@@ -9,6 +10,7 @@ import { BaseInput, BaseInputProps } from "./BaseInput";
 
 type ReferenceComboboxInputProps = BaseInputProps & {
   fieldName?: string;
+  optionText?: (record: RaRecord) => string;
 };
 
 export const ReferenceComboboxInput = ({
@@ -16,6 +18,7 @@ export const ReferenceComboboxInput = ({
   required,
   tooltip,
   fieldName,
+  optionText,
   overrideLabel,
   readOnly,
   disabled,
@@ -34,7 +37,9 @@ export const ReferenceComboboxInput = ({
   const getRecordRepresentation = useGetRecordRepresentation(resource);
 
   const options = allChoices?.map((choice) => ({
-    label: String(getRecordRepresentation(choice)),
+    label: String(
+      optionText ? optionText(choice) : getRecordRepresentation(choice),
+    ),
     value: String(choice.id),
     id: choice.id,
   }));

--- a/frontend/src/service_provider_product_application/ServiceProviderProductApplicationInput.tsx
+++ b/frontend/src/service_provider_product_application/ServiceProviderProductApplicationInput.tsx
@@ -91,8 +91,12 @@ export const ServiceProviderProductApplicationInput = () => {
         <PartyReferenceInput
           {...fields.service_provider_id}
           readOnly={isServiceProvider}
+          optionText={(record) => record.name}
         />
-        <PartyReferenceInput {...fields.system_operator_id} />
+        <PartyReferenceInput
+          {...fields.system_operator_id}
+          optionText={(record) => record.name}
+        />
         <ProductTypesInput {...fields.product_type_ids} />
 
         <VerticalSpace size="small" />

--- a/frontend/src/service_provider_product_application/ServiceProviderProductApplicationList.tsx
+++ b/frontend/src/service_provider_product_application/ServiceProviderProductApplicationList.tsx
@@ -40,10 +40,12 @@ export const ServiceProviderProductApplicationList = () => {
     <PartyReferenceInput
       key="service_provider_id"
       source="service_provider_id"
+      optionText={(record) => record.name}
     />,
     <PartyReferenceInput
       key="system_operator_id"
       source="system_operator_id"
+      optionText={(record) => record.name}
     />,
     <EnumArrayInput
       key="status"

--- a/frontend/src/system_operator_product_type/SystemOperatorProductTypeInput.tsx
+++ b/frontend/src/system_operator_product_type/SystemOperatorProductTypeInput.tsx
@@ -49,6 +49,7 @@ export const SystemOperatorProductTypeInput = () => {
           <PartyReferenceInput
             {...fields.system_operator_id}
             readOnly={isSystemOperator}
+            optionText={(record) => record.name}
           />
           <ProductTypeInput
             source="product_type_id"

--- a/frontend/src/system_operator_product_type/SystemOperatorProductTypeList.tsx
+++ b/frontend/src/system_operator_product_type/SystemOperatorProductTypeList.tsx
@@ -45,6 +45,7 @@ export const SystemOperatorProductTypeList = () => {
     <PartyReferenceInput
       key="system_operator_id"
       source={fields.system_operator_id.source}
+      optionText={(record) => record.name}
     />,
     <ProductTypeArrayInput key="product_type_id" source="product_type_id@in" />,
     <EnumArrayInput


### PR DESCRIPTION
In Party List: 
<img width="1559" height="745" alt="image" src="https://github.com/user-attachments/assets/11fe28be-50aa-422f-a1a9-dd9c102aefe0" />

Dropdown for specific roles does not include party type:
<img width="1140" height="483" alt="image" src="https://github.com/user-attachments/assets/ebcc087b-a5a6-40db-8015-0684082c5c83" />
