### PR TITLE
fix(ui): make assume party list non clickable again

### DIFF
--- a/frontend/src/AssumePartyPage.tsx
+++ b/frontend/src/AssumePartyPage.tsx
@@ -146,7 +146,7 @@ export const AssumePartyPage = () => {
           disableSyncWithLocation
         >
           <PartyMembershipEmpty />
-          <Datagrid emptyNode={null}>
+          <Datagrid emptyNode={null} rowClick={false}>
             <TextField hideLabel label="ID" source="party_id" />
             <ReferenceField
               hideLabel


### PR DESCRIPTION
This probably got lost in the migration to EDS.