### PR TITLE
feat(dashboard): surface all three actions a org rep can do (FLEX-1242)

### DIFF
--- a/frontend/src/dashboard/organisation/EntityCard.tsx
+++ b/frontend/src/dashboard/organisation/EntityCard.tsx
@@ -26,12 +26,17 @@ export const EntityCard = ({ entity }: Props) => {
           .
         </p>
         <p>
-          This allows you to view and manage people and access for parties that
-          belong to this organisation.
-        </p>
-        <p>
-          The organisation has the following parties. Click a party to view more
-          details or manage people and accesses for them.
+          This allows you to manage
+          <dl className="pl-2">
+            <dt className="mt-2 font-semibold">Party access</dt>
+            <dd>
+              Allow people to act on behalf of the organisations market parties.
+            </dd>
+            <dt className="mt-2 font-semibold">API clients</dt>
+            <dd>Manage entity clients for the organisation.</dd>
+            <dt className="mt-2 font-semibold">Organisation representatives</dt>
+            <dd>Add and remove representatives for the organisation.</dd>
+          </dl>
         </p>
       </CardContent>
     </Card>

--- a/frontend/src/dashboard/organisation/EntityCard.tsx
+++ b/frontend/src/dashboard/organisation/EntityCard.tsx
@@ -23,21 +23,18 @@ export const EntityCard = ({ entity }: Props) => {
           >
             {entity.name} ({entity.business_id})
           </Link>
-          .
+          . You can now manage
         </p>
-        <p>
-          This allows you to manage
-          <dl className="pl-2">
-            <dt className="mt-2 font-semibold">Party access</dt>
-            <dd>
-              Allow people to act on behalf of the organisations market parties.
-            </dd>
-            <dt className="mt-2 font-semibold">API clients</dt>
-            <dd>Manage entity clients for the organisation.</dd>
-            <dt className="mt-2 font-semibold">Organisation representatives</dt>
-            <dd>Add and remove representatives for the organisation.</dd>
-          </dl>
-        </p>
+        <dl className="pl-2">
+          <dt className="mt-2 font-semibold">Party access</dt>
+          <dd>
+            Allow people to act on behalf of the organisations market parties.
+          </dd>
+          <dt className="mt-2 font-semibold">API clients</dt>
+          <dd>Manage entity clients for the organisation.</dd>
+          <dt className="mt-2 font-semibold">Organisation representatives</dt>
+          <dd>Add and remove representatives for the organisation.</dd>
+        </dl>
       </CardContent>
     </Card>
   );

--- a/frontend/src/dashboard/organisation/OrgDashboard.tsx
+++ b/frontend/src/dashboard/organisation/OrgDashboard.tsx
@@ -1,5 +1,6 @@
 import { FlexPartyIdentity } from "../../auth/authProvider";
-import { Alert, Heading, Loader } from "../../components/ui";
+import { Alert, Button, Heading, Loader } from "../../components/ui";
+import { Link } from "react-router-dom";
 import { useOrgParties } from "../hooks/useOrgParties";
 import { OrgPartiesTable } from "./OrgPartiesTable";
 import { EntityCard } from "./EntityCard";
@@ -14,9 +15,40 @@ export const OrgDashboard = ({ identity }: { identity: FlexPartyIdentity }) => {
     <div>
       {data?.entity && <EntityCard entity={data.entity} />}
       <Heading size="medium" className="mb-2">
-        Parties
+        Party access management
       </Heading>
+      <p className="mb-6">
+        The organisation has the following parties. Click a party to view more
+        details or manage people and accesses for them.
+      </p>
       <OrgPartiesTable parties={data?.entity?.party ?? []} />
+      <Heading size="medium" className="mb-2 mt-6">
+        API client management
+      </Heading>
+      <p>API clients are managed on the entity and called entity clients.</p>
+      {data?.entity && (
+        <Button asChild className="mt-3">
+          <Link to={`/entity/${data.entity.id}/show`}>
+            Manage API clients for {data.entity.name}
+          </Link>
+        </Button>
+      )}
+      <Heading size="medium" className="mb-2 mt-6">
+        Organisation representatives
+      </Heading>
+      <p>
+        An organisation representative is managed through party memberships on
+        the entity&apos;s organisation party. A representative can manage party
+        access and API clients for the organisation, as well as add and remove
+        other representatives.
+      </p>
+      {data?.id && (
+        <Button asChild className="mt-3">
+          <Link to={`/party/${data.id}/show`}>
+            Manage organisation representatives on {data.name}
+          </Link>
+        </Button>
+      )}
     </div>
   );
 };

--- a/frontend/src/dashboard/organisation/OrgDashboard.tsx
+++ b/frontend/src/dashboard/organisation/OrgDashboard.tsx
@@ -19,7 +19,7 @@ export const OrgDashboard = ({ identity }: { identity: FlexPartyIdentity }) => {
       </Heading>
       <p className="mb-6">
         The organisation has the following parties. Click a party to view more
-        details or manage people and accesses for them.
+        details or manage people and access for them.
       </p>
       <OrgPartiesTable parties={data?.entity?.party ?? []} />
       <Heading size="medium" className="mb-2 mt-6">

--- a/frontend/src/dashboard/organisation/OrgPartiesTable.tsx
+++ b/frontend/src/dashboard/organisation/OrgPartiesTable.tsx
@@ -15,7 +15,7 @@ export const OrgPartiesTable = ({ parties }: Props) => {
   const columns: Column<Party>[] = [
     {
       key: "name",
-      header: "Name",
+      header: "Party",
       render: (_, row) => (
         <div>
           <div className="font-medium text-semantic-text">{row.name}</div>
@@ -48,7 +48,7 @@ export const OrgPartiesTable = ({ parties }: Props) => {
   return (
     <SimpleTable
       columns={columns}
-      data={parties}
+      data={parties.filter((p) => p.type !== "organisation")}
       empty="No parties found."
       className="w-full"
       rowClick={(party) => navigate(`/party/${party.id}/show`)}


### PR DESCRIPTION
Not the prettiest, but suggesting this as the next iteration where we make the three actions org reps can do explicit and available in the dashboard.

<img width="1353" height="1222" alt="bilde" src="https://github.com/user-attachments/assets/e704d1dc-2342-44fa-9eb8-bfee49d0a84e" />
