### PR TITLE
fix(backend): midnight-align CU lookup validFrom on Norwegian timezone (FLEX-1262)

### DIFF
--- a/kbackend/src/main/kotlin/no/elhub/flex/Application.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/Application.kt
@@ -3,6 +3,7 @@ package no.elhub.flex
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.netty.EngineMain
+import kotlinx.datetime.TimeZone
 import no.elhub.flex.auth.FlexAuthentication
 import no.elhub.flex.config.Tracing
 import no.elhub.flex.config.configureDatabase
@@ -52,6 +53,7 @@ fun Application.module() {
         "accounting-point-adapter.base-url" to { it },
         "accounting-point-adapter.api-key" to { it },
         "accounting-point-adapter.sync-enabled" to { it.toBoolean() },
+        "flex.timezone" to { TimeZone.of(it) },
     )
 
     startKoin<FlexApp> {

--- a/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.raise.either
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.routing.RoutingCall
+import kotlinx.datetime.TimeZone
 import no.elhub.flex.accountingpoint.AccountingPointService
 import no.elhub.flex.auth.AccessTokenKey
 import no.elhub.flex.auth.FlexPrincipal
@@ -20,11 +21,11 @@ import no.elhub.flex.model.error.AppError
 import no.elhub.flex.model.error.BadRequestError
 import no.elhub.flex.model.error.InternalServerError
 import no.elhub.flex.util.TraceIdUtil.Companion.traceIdOrUnknown
-import no.elhub.flex.util.asNorwegianMidnightInstant
+import no.elhub.flex.util.asLocalMidnightInstant
 import no.elhub.flex.util.body
 import no.elhub.flex.util.logger
 import no.elhub.flex.util.respondJson
-import no.elhub.flex.util.todayNorwegianMidnight
+import no.elhub.flex.util.todayLocalMidnight
 import org.koin.core.annotation.Property
 import org.koin.core.annotation.Single
 import kotlin.time.Instant
@@ -38,6 +39,7 @@ class ControllableUnitLookup(
     private val repo: ControllableUnitRepository,
     private val accountingPointService: AccountingPointService,
     @Property("accounting-point-adapter.sync-enabled") private val accountingPointAdapterSyncEnabled: Boolean = true,
+    @Property("flex.timezone") private val timezone: TimeZone = TimeZone.of("Europe/Oslo"),
 ) {
     private val logger = KotlinLogging.logger {}
 
@@ -59,8 +61,8 @@ class ControllableUnitLookup(
                 ).bind()
                 logger.debug { "Found ${controllableUnits.size} controllable units on accounting point $accountingPointBusinessId" }
 
-                val validFrom = controllableUnits.mapNotNull { it.startDate }.minByOrNull { it }?.asNorwegianMidnightInstant()
-                    ?: Instant.todayNorwegianMidnight()
+                val validFrom = controllableUnits.mapNotNull { it.startDate }.minByOrNull { it }?.asLocalMidnightInstant(timezone)
+                    ?: Instant.todayLocalMidnight(timezone)
                 logger.debug { "Using $validFrom as start date for accounting point sync" }
 
                 if (accountingPointAdapterSyncEnabled) {

--- a/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
@@ -20,11 +20,11 @@ import no.elhub.flex.model.error.AppError
 import no.elhub.flex.model.error.BadRequestError
 import no.elhub.flex.model.error.InternalServerError
 import no.elhub.flex.util.TraceIdUtil.Companion.traceIdOrUnknown
-import no.elhub.flex.util.asLocalStartOfDayInstant
-import no.elhub.flex.util.atLocalStartOfToday
+import no.elhub.flex.util.asNorwegianMidnightInstant
 import no.elhub.flex.util.body
 import no.elhub.flex.util.logger
 import no.elhub.flex.util.respondJson
+import no.elhub.flex.util.todayNorwegianMidnight
 import org.koin.core.annotation.Property
 import org.koin.core.annotation.Single
 import kotlin.time.Instant
@@ -59,8 +59,8 @@ class ControllableUnitLookup(
                 ).bind()
                 logger.debug { "Found ${controllableUnits.size} controllable units on accounting point $accountingPointBusinessId" }
 
-                val validFrom = controllableUnits.mapNotNull { it.startDate }.minByOrNull { it }?.asLocalStartOfDayInstant()
-                    ?: Instant.atLocalStartOfToday()
+                val validFrom = controllableUnits.mapNotNull { it.startDate }.minByOrNull { it }?.asNorwegianMidnightInstant()
+                    ?: Instant.todayNorwegianMidnight()
                 logger.debug { "Using $validFrom as start date for accounting point sync" }
 
                 if (accountingPointAdapterSyncEnabled) {

--- a/kbackend/src/main/kotlin/no/elhub/flex/util/InstantExtensions.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/util/InstantExtensions.kt
@@ -8,10 +8,8 @@ import kotlin.time.Clock
 import kotlin.time.Instant
 import java.time.Instant as JavaInstant
 
-fun Instant.Companion.todayNorwegianMidnight(): Instant {
-    val tz = TimeZone.of("Europe/Oslo")
-    return Clock.System.todayIn(tz).atStartOfDayIn(tz)
-}
+fun Instant.Companion.todayLocalMidnight(timezone: TimeZone): Instant =
+    Clock.System.todayIn(timezone).atStartOfDayIn(timezone)
 
 fun Instant.toSqlTimestamp(): Timestamp =
     Timestamp.from(JavaInstant.ofEpochSecond(epochSeconds, nanosecondsOfSecond.toLong()))

--- a/kbackend/src/main/kotlin/no/elhub/flex/util/InstantExtensions.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/util/InstantExtensions.kt
@@ -8,8 +8,8 @@ import kotlin.time.Clock
 import kotlin.time.Instant
 import java.time.Instant as JavaInstant
 
-fun Instant.Companion.atLocalStartOfToday(): Instant {
-    val tz = TimeZone.currentSystemDefault()
+fun Instant.Companion.todayNorwegianMidnight(): Instant {
+    val tz = TimeZone.of("Europe/Oslo")
     return Clock.System.todayIn(tz).atStartOfDayIn(tz)
 }
 

--- a/kbackend/src/main/kotlin/no/elhub/flex/util/LocalDateExtensions.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/util/LocalDateExtensions.kt
@@ -5,4 +5,4 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlin.time.Instant
 
-fun LocalDate.asLocalStartOfDayInstant(): Instant = this.atStartOfDayIn(TimeZone.currentSystemDefault())
+fun LocalDate.asNorwegianMidnightInstant(): Instant = this.atStartOfDayIn(TimeZone.of("Europe/Oslo"))

--- a/kbackend/src/main/kotlin/no/elhub/flex/util/LocalDateExtensions.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/util/LocalDateExtensions.kt
@@ -5,4 +5,4 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlin.time.Instant
 
-fun LocalDate.asNorwegianMidnightInstant(): Instant = this.atStartOfDayIn(TimeZone.of("Europe/Oslo"))
+fun LocalDate.asLocalMidnightInstant(timezone: TimeZone): Instant = this.atStartOfDayIn(timezone)

--- a/kbackend/src/main/resources/application.yaml
+++ b/kbackend/src/main/resources/application.yaml
@@ -14,6 +14,7 @@ ktor:
 
 flex:
   jwt-secret: ${FLEX_JWT_SECRET}
+  timezone: ${FLEX_TIMEZONE:Europe/Oslo}
 
 accounting-point-adapter:
   base-url: ${ACCOUNTING_POINT_ADAPTER_BASE_URL}

--- a/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTest.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTest.kt
@@ -532,7 +532,7 @@ class ControllableUnitLookupTest :
                         businessId = controllableUnitBusinessId,
                         name = "My CU",
                         technicalResources = emptyList(),
-                        startDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+                        startDate = Clock.System.todayIn(TimeZone.of("Europe/Oslo")),
                     ),
                 ).right()
 

--- a/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTimezoneTest.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTimezoneTest.kt
@@ -1,0 +1,226 @@
+package no.elhub.flex.controllableunit
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.application.install
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.TestApplication
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import no.elhub.flex.PostgresTestContainer
+import no.elhub.flex.accountingpoint.AccountingPointServiceImpl
+import no.elhub.flex.accountingpoint.db.AccountingPointRepositoryImpl
+import no.elhub.flex.config.Tracing
+import no.elhub.flex.config.configureSerialization
+import no.elhub.flex.controllableunit.db.ControllableUnitRepositoryImpl
+import no.elhub.flex.integration.accountingpointadapter.AccountingPointAdapterHttpService
+import no.elhub.flex.integration.accountingpointadapter.AccountingPointAdapterWireMockServer
+import no.elhub.flex.routes.controllableunit.ControllableUnitLookup
+import no.elhub.flex.util.todayNorwegianMidnight
+import no.elhub.flex.util.uniqueGsrn
+import java.util.UUID
+import kotlin.time.Instant
+
+/**
+ * Integration tests verifying that the validFrom timestamps sent and received to/from the
+ * accounting point adapter are always midnight aligned in the Norwegian timezone.
+ *
+ * When an AP has at least one CU, validFrom must be midnight in Norway for its start date.
+ * When it does not have a CU, validFrom must be midnight in Norway today as a fallback.
+ *
+ * In both cases the test asserts that the lookup call succeeds and that the DB accepted the change.
+ */
+class ControllableUnitLookupTimezoneTest : FunSpec({
+
+    extensions(AccountingPointAdapterWireMockServer)
+
+    @Suppress("UnusedPrivateProperty")
+    val db = PostgresTestContainer // ensure FlexTransaction is initialised
+
+    val osloTz = TimeZone.of("Europe/Oslo")
+
+    lateinit var lookup: ControllableUnitLookup
+
+    beforeSpec {
+        val adapterService = AccountingPointAdapterHttpService(
+            baseUrl = AccountingPointAdapterWireMockServer.baseUrl(),
+            apiKey = "test-api-key",
+        )
+        lookup = ControllableUnitLookup(
+            repo = ControllableUnitRepositoryImpl(),
+            accountingPointService = AccountingPointServiceImpl(AccountingPointRepositoryImpl(), adapterService),
+            // keep enabled so that we check that checks in the DB pass
+            accountingPointAdapterSyncEnabled = true,
+        )
+    }
+
+    beforeTest {
+        AccountingPointAdapterWireMockServer.resetAll()
+        PostgresTestContainer.withConnection { conn ->
+            conn.autoCommit = false
+            conn.createStatement().use { stmt ->
+                stmt.execute("SELECT flex.set_entity_party_identity(0, 0, 0)")
+                stmt.execute("TRUNCATE flex.accounting_point CASCADE")
+            }
+            conn.commit()
+        }
+    }
+
+    // minimal app just calling the raw handler
+    // (we avoid auth and other stuff we don't need to have in the test)
+    fun testApp() = TestApplication {
+        application {
+            install(Tracing.plugin)
+            configureSerialization()
+            routing {
+                post("/controllable_unit/lookup") { lookup.handle(call) }
+            }
+        }
+    }
+
+    /** Inserts an accounting point (and optionally a CU behind it) into the database. */
+    fun seedAccountingPoint(gsrn: String, cuStartDate: LocalDate? = null): Unit =
+        PostgresTestContainer.withConnection { conn ->
+            conn.autoCommit = false
+            conn.createStatement().use { it.execute("SELECT flex.set_entity_party_identity(0, 0, 0)") }
+
+            conn.prepareStatement("INSERT INTO flex.accounting_point (business_id) VALUES (?)").use { stmt ->
+                stmt.setString(1, gsrn)
+                stmt.execute()
+            }
+
+            if (cuStartDate != null) {
+                val apID = conn.prepareStatement("SELECT id FROM flex.accounting_point WHERE business_id = ?")
+                    .use { stmt ->
+                        stmt.setString(1, gsrn)
+                        stmt.executeQuery().use { rs ->
+                            rs.next()
+                            rs.getLong(1)
+                        }
+                    }
+
+                conn.prepareStatement(
+                    """
+                    INSERT INTO flex.controllable_unit
+                        (business_id, name, start_date, regulation_direction, maximum_active_power, accounting_point_id)
+                    VALUES (?::uuid, ?, ?::date, 'up', 100.0, ?)
+                    """.trimIndent(),
+                ).use { stmt ->
+                    stmt.setString(1, UUID.randomUUID().toString())
+                    stmt.setString(2, "Test CU")
+                    stmt.setString(3, cuStartDate.toString())
+                    stmt.setLong(4, apID)
+                    stmt.execute()
+                }
+            }
+
+            conn.commit()
+        }
+
+    /**
+     * Stubs the adapter so that, when looking up the accounting point identified by [gsrn] with end user identified by
+     * [endUserID], it responds with an end user contract whose starting date is [validFrom].
+     */
+    fun stubAdapter(gsrn: String, endUserID: String, validFrom: Instant) {
+        AccountingPointAdapterWireMockServer.stubFor(
+            get(urlPathEqualTo("/accounting_point/$gsrn"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(HttpStatusCode.OK.value)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                            """
+                            {
+                                "gsrn": "$gsrn",
+                                "end_user": [
+                                    {
+                                        "business_id": "$endUserID",
+                                        "entity_type": "organisation",
+                                        "valid_from": "$validFrom"
+                                    }
+                                ],
+                                "energy_supplier": [],
+                                "metering_grid_area": []
+                            }
+                            """.trimIndent(),
+                        ),
+                ),
+        )
+    }
+
+    /**
+     * Queries the start date of one end user contract on a given AP. We only insert one in the tests so we do not have
+     * to filter more carefully: this is just to check that contracts were inserted normally.
+     */
+    fun query1EndUserValidFrom(apGsrn: String): Instant? =
+        PostgresTestContainer.withConnection { conn ->
+            conn.prepareStatement(
+                """
+                SELECT lower(apeu.valid_time_range)
+                FROM flex.accounting_point_end_user AS apeu
+                    INNER JOIN flex.accounting_point AS ap ON ap.id = apeu.accounting_point_id
+                WHERE ap.business_id = ?
+                """.trimIndent(),
+            ).use { stmt ->
+                stmt.setString(1, apGsrn)
+                stmt.executeQuery().use { rs ->
+                    if (rs.next()) {
+                        rs.getTimestamp(1)?.toInstant()
+                            ?.let { Instant.fromEpochSeconds(it.epochSecond, it.nano) }
+                    } else {
+                        null
+                    }
+                }
+            }
+        }
+
+    context("validFrom is midnight in the Norwegian timezone (Europe/Oslo)") {
+
+        test("AP has a CU") {
+            val endUserOrg = "123456001"
+            val gsrn = uniqueGsrn()
+            val cuStartDate = LocalDate(2024, 1, 15)
+            val expectedValidFrom = cuStartDate.atStartOfDayIn(osloTz) // 2024-01-14T23:00:00Z
+
+            seedAccountingPoint(gsrn, cuStartDate)
+            stubAdapter(gsrn, endUserOrg, expectedValidFrom)
+
+            testApp().client.post("/controllable_unit/lookup") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"end_user":"$endUserOrg","accounting_point":"$gsrn"}""")
+            }.status shouldBe HttpStatusCode.OK
+
+            // HTTP OK means the DB has done the upsert as intended, but we will still check the exact valid_from that
+            // was used to ensure Norwegian midnight was inserted
+            query1EndUserValidFrom(gsrn) shouldBe expectedValidFrom
+        }
+
+        test("AP has no CU") {
+            val endUserOrg = "123456002"
+            val gsrn = uniqueGsrn()
+            val expectedValidFrom = Instant.todayNorwegianMidnight() // should be the default used when no CU
+
+            seedAccountingPoint(gsrn, cuStartDate = null)
+            stubAdapter(gsrn, endUserOrg, expectedValidFrom)
+
+            testApp().client.post("/controllable_unit/lookup") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"end_user":"$endUserOrg","accounting_point":"$gsrn"}""")
+            }.status shouldBe HttpStatusCode.OK
+
+            // the DB must have accepted the correct upsert here as well
+            query1EndUserValidFrom(gsrn) shouldBe expectedValidFrom
+        }
+    }
+})

--- a/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTimezoneTest.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTimezoneTest.kt
@@ -27,7 +27,7 @@ import no.elhub.flex.controllableunit.db.ControllableUnitRepositoryImpl
 import no.elhub.flex.integration.accountingpointadapter.AccountingPointAdapterHttpService
 import no.elhub.flex.integration.accountingpointadapter.AccountingPointAdapterWireMockServer
 import no.elhub.flex.routes.controllableunit.ControllableUnitLookup
-import no.elhub.flex.util.todayNorwegianMidnight
+import no.elhub.flex.util.todayLocalMidnight
 import no.elhub.flex.util.uniqueGsrn
 import java.util.UUID
 import kotlin.time.Instant
@@ -62,6 +62,7 @@ class ControllableUnitLookupTimezoneTest : FunSpec({
             accountingPointService = AccountingPointServiceImpl(AccountingPointRepositoryImpl(), adapterService),
             // keep enabled so that we check that checks in the DB pass
             accountingPointAdapterSyncEnabled = true,
+            timezone = osloTz,
         )
     }
 
@@ -209,7 +210,7 @@ class ControllableUnitLookupTimezoneTest : FunSpec({
         test("AP has no CU") {
             val endUserOrg = "123456002"
             val gsrn = uniqueGsrn()
-            val expectedValidFrom = Instant.todayNorwegianMidnight() // should be the default used when no CU
+            val expectedValidFrom = Instant.todayLocalMidnight(osloTz) // should be the default used when no CU
 
             seedAccountingPoint(gsrn, cuStartDate = null)
             stubAdapter(gsrn, endUserOrg, expectedValidFrom)

--- a/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/db/ControllableUnitRepositoryTest.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/db/ControllableUnitRepositoryTest.kt
@@ -42,7 +42,7 @@ class ControllableUnitRepositoryTest : FunSpec({
                         id = 0,
                         businessId = uniqueUuid(),
                         name = "CU Beta",
-                        startDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+                        startDate = Clock.System.todayIn(TimeZone.of("Europe/Oslo")),
                         technicalResources = listOf(
                             TechnicalResource(id = 0, name = "TR One"),
                             TechnicalResource(id = 0, name = "TR Two"),
@@ -52,7 +52,7 @@ class ControllableUnitRepositoryTest : FunSpec({
             )
             seedControllableUnits(
                 apBusinessId = uniqueGsrn(),
-                cus = listOf(ControllableUnit(id = 0, businessId = uniqueUuid(), name = "Noise CU", startDate = Clock.System.todayIn(TimeZone.currentSystemDefault()), technicalResources = emptyList())),
+                cus = listOf(ControllableUnit(id = 0, businessId = uniqueUuid(), name = "Noise CU", startDate = Clock.System.todayIn(TimeZone.of("Europe/Oslo")), technicalResources = emptyList())),
             )
 
             // when
@@ -73,13 +73,13 @@ class ControllableUnitRepositoryTest : FunSpec({
             val expected = seedControllableUnits(
                 apBusinessId = apBusinessId,
                 cus = listOf(
-                    ControllableUnit(id = 0, businessId = uniqueUuid(), name = "CU One", startDate = Clock.System.todayIn(TimeZone.currentSystemDefault()), technicalResources = emptyList()),
-                    ControllableUnit(id = 0, businessId = uniqueUuid(), name = "CU Two", startDate = Clock.System.todayIn(TimeZone.currentSystemDefault()), technicalResources = emptyList()),
+                    ControllableUnit(id = 0, businessId = uniqueUuid(), name = "CU One", startDate = Clock.System.todayIn(TimeZone.of("Europe/Oslo")), technicalResources = emptyList()),
+                    ControllableUnit(id = 0, businessId = uniqueUuid(), name = "CU Two", startDate = Clock.System.todayIn(TimeZone.of("Europe/Oslo")), technicalResources = emptyList()),
                 ),
             )
             seedControllableUnits(
                 apBusinessId = uniqueGsrn(),
-                cus = listOf(ControllableUnit(id = 0, businessId = uniqueUuid(), name = "Noise CU", startDate = Clock.System.todayIn(TimeZone.currentSystemDefault()), technicalResources = emptyList())),
+                cus = listOf(ControllableUnit(id = 0, businessId = uniqueUuid(), name = "Noise CU", startDate = Clock.System.todayIn(TimeZone.of("Europe/Oslo")), technicalResources = emptyList())),
             )
 
             // when


### PR DESCRIPTION
This PR fixes a bug that we had in CU lookup, where we were taking the _system midnight_ as the lower bound of the time window when asking the adapter for data, instead of the _Norwegian midnight_.

The bug has been silent because of the previous logic we had when filtering the timeline in the adapter, where any record _overlapping_ with the time window was kept. Then, unless a record was starting exactly on the asked start date (the wrong one -- so it never happened), the earliest record was kept with its start date even though it is earlier than the (wrong) limit we send. So the AP sync process worked and did not complain. With the new filtering, all records' start dates get replaced with the (wrong) `validFrom` if they happen to be earlier, so the DB refuses to upsert (the bug is made visible).

Fixed by explicitly using Norwegian timezone everywhere. Added an extra test as well.