### PR TITLE
fix: accept PID starting with 0 (FLEX-1262)

### DIFF
--- a/db/flex/business_id_type.sql
+++ b/db/flex/business_id_type.sql
@@ -64,7 +64,7 @@ BEGIN
         RETURN (business_id ~ '^[a-zA-Z0-9._%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$');
     ELSIF business_id_type = 'pid' THEN
         -- PID validation: check if business_id is a valid personal identification number
-        RETURN (business_id ~ '^[1-9][0-9]{10}$');
+        RETURN (business_id ~ '^[0-9]{11}$');
     ELSIF business_id_type = 'org' THEN
         -- Validate organisation number
         RETURN (business_id ~ '^[1-9][0-9]{8}$');

--- a/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepository.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepository.kt
@@ -442,7 +442,7 @@ private fun Connection.createTimestampArray(instants: List<Instant>): Array =
 
 private fun resolveOrCreateEntity(conn: Connection, endUserBusinessId: String): Long {
     val (entityType, businessIdType) = when {
-        endUserBusinessId.matches(Regex("^[1-9][0-9]{10}$")) -> "person" to "pid"
+        endUserBusinessId.matches(Regex("^[0-9]{11}$")) -> "person" to "pid"
         endUserBusinessId.matches(Regex("^[1-9][0-9]{8}$")) -> "organisation" to "org"
         else -> error("Cannot determine entity type for end user business ID")
     }

--- a/kbackend/src/test/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepositoryTest.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/accountingpoint/db/AccountingPointRepositoryTest.kt
@@ -688,11 +688,11 @@ class AccountingPointRepositoryTest : FunSpec({
     }
 })
 
-private val pidCounter = AtomicLong(10_000_000_000L)
+private val pidCounter = AtomicLong(0L)
 private val orgCounter = AtomicLong(100_000_000L)
 private val glnCounter = AtomicLong(10_000_000L)
 
-private fun uniquePid(): String = pidCounter.getAndIncrement().toString()
+private fun uniquePid(): String = pidCounter.getAndIncrement().toString().padStart(6, '0') + "12345"
 
 private fun uniqueOrgNumber(): String {
     val next = orgCounter.getAndIncrement()

--- a/test/api_client_tests/test_entity.py
+++ b/test/api_client_tests/test_entity.py
@@ -60,7 +60,7 @@ def random_org():
 
 
 def random_pid():
-    return "4" + random_number(10)
+    return "0" + random_number(10)
 
 
 # RLS: ENT-FISO001


### PR DESCRIPTION
This PR fixes a bug in the validation of PID both in the database and in the backend. For some reason, we were always expecting `[1-9]` for the first digit.

My guess is that at some point we parsed a PID from an integer in one of the tests or something like that, and the DB was not happy when it started with a `0` (the end string was shorter). Then we changed it, and the regex was copied here and there afterwards. The initial regex probably dates back to a time where I did not have a clue how a PID is formatted, and since this did not cause a problem in the unrealistic test data, this got under the radar.

Fun that we survived that long without changing this.

Some entities are created in the tests, on both Python and Kotlin sides, so just making PIDs starting with a zero in those tests is enough to make sure this case is now supported (the non-zero case being our whole test suite basically).