### PR TITLE
feat: reintroduce controllable unit lookup events (FLEX-1265)

### DIFF
--- a/backend/event/models.sql
+++ b/backend/event/models.sql
@@ -334,12 +334,10 @@ WHERE cueu.controllable_unit_id = @cu_id
     AND cueu.valid_time_range @> @recorded_at::timestamptz;
 
 -- name: GetControllableUnitLookupNotificationRecipientsAP :many
-SELECT cueu.end_user_id
-FROM api.controllable_unit AS cu
-    INNER JOIN notification.controllable_unit_end_user AS cueu
-        ON cu.id = cueu.controllable_unit_id
-            AND cueu.valid_time_range @> @recorded_at::timestamptz
-WHERE cu.accounting_point_id = @ap_id;
+SELECT apeu.end_user_id
+FROM api.accounting_point_end_user AS apeu
+WHERE apeu.accounting_point_id = @ap_id
+    AND apeu.valid_time_range @> @recorded_at::timestamptz;
 
 -- name: GetServiceProvidingGroupGridSuspensionNotificationRecipients :many
 -- SP

--- a/backend/event/models.sql
+++ b/backend/event/models.sql
@@ -327,11 +327,19 @@ INSERT INTO api.notification (event_id, party_id)
 SELECT @event_id, unnest(@party_ids::bigint[])
 ON CONFLICT DO NOTHING;
 
--- name: GetControllableUnitLookupNotificationRecipients :many
+-- name: GetControllableUnitLookupNotificationRecipientsCU :many
 SELECT cueu.end_user_id
 FROM notification.controllable_unit_end_user AS cueu
-WHERE cueu.controllable_unit_id = @resource_id
+WHERE cueu.controllable_unit_id = @cu_id
     AND cueu.valid_time_range @> @recorded_at::timestamptz;
+
+-- name: GetControllableUnitLookupNotificationRecipientsAP :many
+SELECT cueu.end_user_id
+FROM api.controllable_unit AS cu
+    INNER JOIN notification.controllable_unit_end_user AS cueu
+        ON cu.id = cueu.controllable_unit_id
+            AND cueu.valid_time_range @> @recorded_at::timestamptz
+WHERE cu.accounting_point_id = @ap_id;
 
 -- name: GetServiceProvidingGroupGridSuspensionNotificationRecipients :many
 -- SP

--- a/backend/event/models/models.custom.go
+++ b/backend/event/models/models.custom.go
@@ -10,16 +10,31 @@ import (
 func (q *Queries) GetNotificationRecipients( //nolint:cyclop,funlen
 	ctx context.Context,
 	eventType string,
-	resourceID int,
+	sourceID int,
+	subjectID *int,
 	recordedAt pgtype.Timestamptz,
 ) ([]int, error) {
+	// in many cases, only one ID is used to determine recipients
+	// (subject_id if present, otherwise source_id)
+	// TODO: consider removing this merging logic and stating explicitly which of
+	// these IDs we use in each of the queries below
+	resourceID := sourceID
+	if subjectID != nil {
+		resourceID = *subjectID
+	}
+
 	switch eventType {
+	case "no.elhub.flex.controllable_unit.lookup":
+		if subjectID != nil {
+			// CU-specific lookup, identify recipients from CU ID
+			return q.GetControllableUnitLookupNotificationRecipientsCU(ctx, *subjectID, recordedAt)
+		}
+		// general AP lookup, identify recipients from AP ID
+		return q.GetControllableUnitLookupNotificationRecipientsAP(ctx, recordedAt, sourceID)
 	case "no.elhub.flex.controllable_unit.create":
 		return q.GetControllableUnitCreateNotificationRecipients(ctx, recordedAt, resourceID)
 	case "no.elhub.flex.controllable_unit.update":
 		return q.GetControllableUnitUpdateNotificationRecipients(ctx, resourceID, recordedAt)
-	case "no.elhub.flex.controllable_unit.lookup":
-		return q.GetControllableUnitLookupNotificationRecipients(ctx, resourceID, recordedAt)
 	case "no.elhub.flex.controllable_unit_suspension.create",
 		"no.elhub.flex.controllable_unit_suspension.update",
 		"no.elhub.flex.controllable_unit_suspension.delete":

--- a/backend/event/models/models.sql.go
+++ b/backend/event/models/models.sql.go
@@ -90,15 +90,44 @@ func (q *Queries) GetControllableUnitCreateNotificationRecipients(ctx context.Co
 	return items, nil
 }
 
-const getControllableUnitLookupNotificationRecipients = `-- name: GetControllableUnitLookupNotificationRecipients :many
+const getControllableUnitLookupNotificationRecipientsAP = `-- name: GetControllableUnitLookupNotificationRecipientsAP :many
+SELECT cueu.end_user_id
+FROM api.controllable_unit AS cu
+    INNER JOIN notification.controllable_unit_end_user AS cueu
+        ON cu.id = cueu.controllable_unit_id
+            AND cueu.valid_time_range @> $1::timestamptz
+WHERE cu.accounting_point_id = $2
+`
+
+func (q *Queries) GetControllableUnitLookupNotificationRecipientsAP(ctx context.Context, recordedAt pgtype.Timestamptz, apID int) ([]int, error) {
+	rows, err := q.db.Query(ctx, getControllableUnitLookupNotificationRecipientsAP, recordedAt, apID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int
+	for rows.Next() {
+		var end_user_id int
+		if err := rows.Scan(&end_user_id); err != nil {
+			return nil, err
+		}
+		items = append(items, end_user_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getControllableUnitLookupNotificationRecipientsCU = `-- name: GetControllableUnitLookupNotificationRecipientsCU :many
 SELECT cueu.end_user_id
 FROM notification.controllable_unit_end_user AS cueu
 WHERE cueu.controllable_unit_id = $1
     AND cueu.valid_time_range @> $2::timestamptz
 `
 
-func (q *Queries) GetControllableUnitLookupNotificationRecipients(ctx context.Context, resourceID int, recordedAt pgtype.Timestamptz) ([]int, error) {
-	rows, err := q.db.Query(ctx, getControllableUnitLookupNotificationRecipients, resourceID, recordedAt)
+func (q *Queries) GetControllableUnitLookupNotificationRecipientsCU(ctx context.Context, cuID int, recordedAt pgtype.Timestamptz) ([]int, error) {
+	rows, err := q.db.Query(ctx, getControllableUnitLookupNotificationRecipientsCU, cuID, recordedAt)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/event/worker.go
+++ b/backend/event/worker.go
@@ -115,12 +115,6 @@ func (eventWorker *Worker) processBatch(ctx context.Context) (bool, error) {
 			ctx, "handling event", "type", event.Type, "id", event.ID,
 		)
 
-		// Determine resource ID (use subject_id if present, otherwise source_id)
-		resourceID := event.SourceID
-		if event.SubjectID != nil {
-			resourceID = *event.SubjectID
-		}
-
 		// TODO (improvement): go through the auth API instead of the models
 		eventPartyID, err := authModels.PartyOfIdentity(ctx, tx, event.RecordedBy)
 		if err != nil {
@@ -131,7 +125,8 @@ func (eventWorker *Worker) processBatch(ctx context.Context) (bool, error) {
 		notificationRecipients, err := queries.GetNotificationRecipients(
 			ctx,
 			event.Type,
-			resourceID,
+			event.SourceID,
+			event.SubjectID,
 			event.RecordedAt,
 		)
 		if err != nil {

--- a/db/flex/event_migrations.sql
+++ b/db/flex/event_migrations.sql
@@ -7,3 +7,30 @@
 CREATE INDEX event_processed_false_idx
 ON flex.event (processed, id)
 WHERE processed = false;
+
+-- changeset flex:event-lookup-source-accounting-point runOnChange:false endDelimiter:;
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:true SELECT EXISTS (SELECT 1 FROM flex.event WHERE type = 'no.elhub.flex.controllable_unit.lookup' AND source_resource = 'controllable_unit')
+WITH
+    lookup_event_data AS (
+        SELECT
+            e.id AS event_id,
+            cu.accounting_point_id AS ap_id,
+            cu.id AS cu_id
+        FROM flex.event AS e
+            INNER JOIN flex.controllable_unit AS cu
+                ON e.source_id = cu.id
+        WHERE
+            e.type = 'no.elhub.flex.controllable_unit.lookup'
+            AND e.source_resource = 'controllable_unit'
+    )
+
+UPDATE flex.event AS e
+SET
+    -- transform past lookup events with the old format into CU-specific lookups
+    source_resource = 'accounting_point',
+    source_id = lookup_event_data.ap_id,
+    subject_resource = 'controllable_unit',
+    subject_id = lookup_event_data.cu_id
+FROM lookup_event_data
+WHERE e.id = lookup_event_data.event_id;

--- a/db/flex/event_migrations.sql
+++ b/db/flex/event_migrations.sql
@@ -10,7 +10,7 @@ WHERE processed = false;
 
 -- changeset flex:event-lookup-source-accounting-point runOnChange:false endDelimiter:;
 --preconditions onFail:MARK_RAN
---precondition-sql-check expectedResult:true SELECT EXISTS (SELECT 1 FROM flex.event WHERE type = 'no.elhub.flex.controllable_unit.lookup' AND source_resource = 'controllable_unit')
+--precondition-sql-check expectedResult:t SELECT EXISTS (SELECT 1 FROM flex.event WHERE type = 'no.elhub.flex.controllable_unit.lookup' AND source_resource = 'controllable_unit')
 WITH
     lookup_event_data AS (
         SELECT

--- a/db/flex/event_rls.sql
+++ b/db/flex/event_rls.sql
@@ -48,6 +48,14 @@ $$;
 ALTER TABLE IF EXISTS event ENABLE ROW LEVEL SECURITY;
 
 -- internal
+GRANT INSERT, SELECT ON event TO flex_internal_data;
+DROP POLICY IF EXISTS "EVENT_INTERNAL_DATA" ON event;
+CREATE POLICY "EVENT_INTERNAL_DATA" ON event
+FOR ALL
+TO flex_internal_data
+USING (true)
+WITH CHECK (true);
+
 GRANT SELECT ON event TO flex_internal_event_notification;
 DROP POLICY IF EXISTS "EVENT_INTERNAL_EVENT_NOTIFICATION_SELECT" ON event;
 CREATE POLICY "EVENT_INTERNAL_EVENT_NOTIFICATION_SELECT" ON event
@@ -77,6 +85,37 @@ USING (
         SELECT 1
         FROM flex.controllable_unit_end_user AS cueu
         WHERE cueu.controllable_unit_id = event.source_id -- noqa
+            AND cueu.end_user_id = (SELECT flex.current_party())
+            AND cueu.valid_time_range @> lower(event.record_time_range) -- noqa
+    )
+);
+
+DROP POLICY IF EXISTS "EVENT_EU001_LOOKUP" ON event;
+CREATE POLICY "EVENT_EU001_LOOKUP" ON event
+FOR SELECT
+TO flex_end_user
+USING (
+    source_resource = 'accounting_point'
+    AND type ~ 'no.elhub.flex.controllable_unit.lookup'
+    AND EXISTS (
+        SELECT 1
+        FROM (
+            SELECT
+                id AS cu_id,
+                accounting_point_id,
+                record_time_range
+            FROM flex.controllable_unit
+            UNION ALL
+            SELECT
+                id AS cu_id,
+                accounting_point_id,
+                record_time_range
+            FROM flex.controllable_unit_history
+        ) AS cu_timeline
+            INNER JOIN flex.controllable_unit_end_user AS cueu
+                ON cu_timeline.cu_id = cueu.controllable_unit_id
+        WHERE cu_timeline.accounting_point_id = event.source_id -- noqa
+            AND cu_timeline.record_time_range @> lower(event.record_time_range) -- noqa
             AND cueu.end_user_id = (SELECT flex.current_party())
             AND cueu.valid_time_range @> lower(event.record_time_range) -- noqa
     )

--- a/kbackend/src/main/kotlin/no/elhub/flex/event/db/EventRepository.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/event/db/EventRepository.kt
@@ -20,14 +20,15 @@ import org.koin.core.annotation.Single
  */
 interface EventRepository {
 
-    /**
-     * Creates one `no.elhub.flex.controllable_unit.lookup` event per entry in [controllableUnitIds], giving information
-     * about [requestingPartyId] in the event data. */
+    /** Inserts an event in the database. */
     context(principal: FlexPrincipal)
-    suspend fun insertLookupEvent(
-        accountingPointBusinessId: String,
-        controllableUnitBusinessId: String?,
-        requestingPartyId: Int
+    suspend fun insertEvent(
+        type: String,
+        source: String,
+        sourceId: Long,
+        subjectResource: String?,
+        subjectId: Long?,
+        data: String?,
     ): Either<RepositoryError, Unit>
 }
 
@@ -37,59 +38,40 @@ private val logger = KotlinLogging.logger {}
 class EventRepositoryImpl : EventRepository {
 
     context(principal: FlexPrincipal)
-    override suspend fun insertLookupEvent(
-        accountingPointBusinessId: String,
-        controllableUnitBusinessId: String?,
-        requestingPartyId: Int,
+    override suspend fun insertEvent(
+        type: String,
+        source: String,
+        sourceId: Long,
+        subjectResource: String?,
+        subjectId: Long?,
+        data: String?,
     ): Either<RepositoryError, Unit> = flexTransaction { conn ->
         runCatching {
-            if (controllableUnitBusinessId != null) {
-                // lookup was done on specific CU: add it as subject of the event
-                conn.prepareNamed(
-                    """
-                INSERT INTO flex.event (type, source_resource, source_id, subject_resource, subject_id, data)
-                SELECT
-                    public.text2ltree('no.elhub.flex.controllable_unit.lookup'),
-                    'accounting_point',
-                    (SELECT id FROM flex.accounting_point WHERE business_id::text = :apBusinessId),
-                    'controllable_unit',
-                    (SELECT id FROM flex.controllable_unit WHERE business_id::text = :cuBusinessId),
-                    jsonb_build_object(
-                        'requesting_party_name',
-                        (SELECT name FROM flex.party WHERE id = :partyId)
-                    )
-                """,
-                    mapOf(
-                        "apBusinessId" to accountingPointBusinessId,
-                        "cuBusinessId" to controllableUnitBusinessId,
-                        "partyId" to requestingPartyId
-                    ),
-                ).use { it.execute() }
-            } else {
-                // general lookup on the AP: no subject
-                conn.prepareNamed(
-                    """
-                INSERT INTO flex.event (type, source_resource, source_id, data)
-                SELECT
-                    public.text2ltree('no.elhub.flex.controllable_unit.lookup'),
-                    'accounting_point',
-                    (SELECT id FROM flex.accounting_point WHERE business_id::text = :apBusinessId),
-                    jsonb_build_object(
-                        'requesting_party_name',
-                        (SELECT name FROM flex.party WHERE id = :partyId)
-                    )
-                """,
-                    mapOf(
-                        "apBusinessId" to accountingPointBusinessId,
-                        "partyId" to requestingPartyId
-                    ),
-                ).use { it.execute() }
-            }
+            conn.prepareNamed(
+                """
+            INSERT INTO flex.event (type, source_resource, source_id, subject_resource, subject_id, data)
+            SELECT
+                public.text2ltree(:type),
+                :source,
+                :sourceId,
+                :subjectResource,
+                :subjectId,
+                :data::jsonb
+            """,
+                mapOf(
+                    "type" to type,
+                    "source" to source,
+                    "sourceId" to sourceId,
+                    "subjectResource" to subjectResource,
+                    "subjectId" to subjectId,
+                    "data" to data,
+                ),
+            ).use { it.execute() }
         }.fold(
             onSuccess = { Unit.right() },
             onFailure = { e ->
-                logger.error { "insertLookupEvent failed: ${e.message}" }
-                DatabaseError("failed to insert lookup events: ${e.message}").left()
+                logger.error { "insertEvent failed: ${e.message}" }
+                DatabaseError("failed to insert event: ${e.message}").left()
             },
         )
     }

--- a/kbackend/src/main/kotlin/no/elhub/flex/event/db/EventRepository.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/event/db/EventRepository.kt
@@ -1,0 +1,97 @@
+package no.elhub.flex.event.db
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.elhub.flex.auth.FlexPrincipal
+import no.elhub.flex.db.FlexTransaction.flexTransaction
+import no.elhub.flex.db.prepareNamed
+import no.elhub.flex.model.domain.ControllableUnit
+import no.elhub.flex.model.domain.db.DatabaseError
+import no.elhub.flex.model.domain.db.RepositoryError
+import org.koin.core.annotation.Single
+
+/**
+ * Repository for events.
+ *
+ * All functions receive the caller's [FlexPrincipal] via context parameter so
+ * implementations can apply the per-request RLS preamble without it being
+ * threaded explicitly through every call site.
+ */
+interface EventRepository {
+
+    /**
+     * Creates one `no.elhub.flex.controllable_unit.lookup` event per entry in [controllableUnitIds], giving information
+     * about [requestingPartyId] in the event data. */
+    context(principal: FlexPrincipal)
+    suspend fun insertLookupEvent(
+        accountingPointBusinessId: String,
+        controllableUnitBusinessId: String?,
+        requestingPartyId: Int
+    ): Either<RepositoryError, Unit>
+}
+
+private val logger = KotlinLogging.logger {}
+
+@Single(createdAtStart = true)
+class EventRepositoryImpl : EventRepository {
+
+    context(principal: FlexPrincipal)
+    override suspend fun insertLookupEvent(
+        accountingPointBusinessId: String,
+        controllableUnitBusinessId: String?,
+        requestingPartyId: Int,
+    ): Either<RepositoryError, Unit> = flexTransaction { conn ->
+        runCatching {
+            if (controllableUnitBusinessId != null) {
+                // lookup was done on specific CU: add it as subject of the event
+                conn.prepareNamed(
+                    """
+                INSERT INTO flex.event (type, source_resource, source_id, subject_resource, subject_id, data)
+                SELECT
+                    public.text2ltree('no.elhub.flex.controllable_unit.lookup'),
+                    'accounting_point',
+                    (SELECT id FROM flex.accounting_point WHERE business_id::text = :apBusinessId),
+                    'controllable_unit',
+                    (SELECT id FROM flex.controllable_unit WHERE business_id::text = :cuBusinessId),
+                    jsonb_build_object(
+                        'requesting_party_name',
+                        (SELECT name FROM flex.party WHERE id = :partyId)
+                    )
+                """,
+                    mapOf(
+                        "apBusinessId" to accountingPointBusinessId,
+                        "cuBusinessId" to controllableUnitBusinessId,
+                        "partyId" to requestingPartyId
+                    ),
+                ).use { it.execute() }
+            } else {
+                // general lookup on the AP: no subject
+                conn.prepareNamed(
+                    """
+                INSERT INTO flex.event (type, source_resource, source_id, data)
+                SELECT
+                    public.text2ltree('no.elhub.flex.controllable_unit.lookup'),
+                    'accounting_point',
+                    (SELECT id FROM flex.accounting_point WHERE business_id::text = :apBusinessId),
+                    jsonb_build_object(
+                        'requesting_party_name',
+                        (SELECT name FROM flex.party WHERE id = :partyId)
+                    )
+                """,
+                    mapOf(
+                        "apBusinessId" to accountingPointBusinessId,
+                        "partyId" to requestingPartyId
+                    ),
+                ).use { it.execute() }
+            }
+        }.fold(
+            onSuccess = { Unit.right() },
+            onFailure = { e ->
+                logger.error { "insertLookupEvent failed: ${e.message}" }
+                DatabaseError("failed to insert lookup events: ${e.message}").left()
+            },
+        )
+    }
+}

--- a/kbackend/src/main/kotlin/no/elhub/flex/event/db/EventRepository.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/event/db/EventRepository.kt
@@ -7,7 +7,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import no.elhub.flex.auth.FlexPrincipal
 import no.elhub.flex.db.FlexTransaction.flexTransaction
 import no.elhub.flex.db.prepareNamed
-import no.elhub.flex.model.domain.ControllableUnit
 import no.elhub.flex.model.domain.db.DatabaseError
 import no.elhub.flex.model.domain.db.RepositoryError
 import org.koin.core.annotation.Single

--- a/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
@@ -6,8 +6,10 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.routing.RoutingCall
 import kotlinx.datetime.TimeZone
 import no.elhub.flex.accountingpoint.AccountingPointService
+import no.elhub.flex.auth.AccessTokenKey
 import no.elhub.flex.auth.FlexPrincipal
 import no.elhub.flex.controllableunit.db.ControllableUnitRepository
+import no.elhub.flex.event.db.EventRepository
 import no.elhub.flex.model.domain.ControllableUnit
 import no.elhub.flex.model.domain.GSRN
 import no.elhub.flex.model.dto.generated.models.ControllableUnitLookupRequest
@@ -35,12 +37,14 @@ private val CONTROLLABLE_UNIT_BUSINESS_ID_REGEX =
 class ControllableUnitLookup(
     private val repo: ControllableUnitRepository,
     private val accountingPointService: AccountingPointService,
+    private val eventRepo: EventRepository,
     @Property("accounting-point-adapter.sync-enabled") private val accountingPointAdapterSyncEnabled: Boolean = true,
     @Property("flex.timezone") private val timezone: TimeZone = TimeZone.of("Europe/Oslo"),
 ) {
     private val logger = KotlinLogging.logger {}
 
     suspend fun handle(call: RoutingCall) {
+        val requestingPartyId = call.attributes[AccessTokenKey].partyId
         with(FlexPrincipal.internalData()) {
             either {
                 val request = call.body<ControllableUnitLookupRequest>().bind()
@@ -74,6 +78,12 @@ class ControllableUnitLookup(
                 ).bind()
                 val accountingPoint = accountingPointService.getAccountingPointByBusinessId(accountingPointBusinessId).bind()
 
+                insertEvent(
+                    accountingPointBusinessId,
+                    request.controllableUnitBusinessId.takeIf { it.isNotEmpty() },
+                    requestingPartyId
+                ).bind()
+
                 ControllableUnitLookupResponse(
                     accountingPoint = ControllableUnitLookupResponseAccountingPoint(
                         id = accountingPoint.id,
@@ -94,6 +104,18 @@ class ControllableUnitLookup(
         repo.lookupControllableUnits(controllableUnitBusinessId, accountingPointBusinessId)
             .mapLeft { e ->
                 logger.error { "Failed to lookup controllable units: ${e.message}" }
+                InternalServerError(traceIdOrUnknown())
+            }
+
+    context(principal: FlexPrincipal)
+    private suspend fun insertEvent(
+        accountingPointBusinessId: String,
+        controllableUnitBusinessId: String?,
+        requestingPartyId: Int,
+    ): Either<AppError, Unit> =
+        eventRepo.insertLookupEvent(accountingPointBusinessId, controllableUnitBusinessId, requestingPartyId)
+            .mapLeft { e ->
+                logger.error { "Failed to insert lookup event: ${e.message}" }
                 InternalServerError(traceIdOrUnknown())
             }
 }

--- a/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
@@ -78,9 +78,9 @@ class ControllableUnitLookup(
                 ).bind()
                 val accountingPoint = accountingPointService.getAccountingPointByBusinessId(accountingPointBusinessId).bind()
 
-                insertEvent(
-                    accountingPointBusinessId,
-                    request.controllableUnitBusinessId.takeIf { it.isNotEmpty() },
+                insertLookupEvent(
+                    accountingPoint.id,
+                    if (request.controllableUnitBusinessId.isNotEmpty()) controllableUnits.firstOrNull()?.id else null,
                     requestingPartyId
                 ).bind()
 
@@ -108,12 +108,19 @@ class ControllableUnitLookup(
             }
 
     context(principal: FlexPrincipal)
-    private suspend fun insertEvent(
-        accountingPointBusinessId: String,
-        controllableUnitBusinessId: String?,
+    private suspend fun insertLookupEvent(
+        accountingPointId: Long,
+        controllableUnitId: Long?,
         requestingPartyId: Int,
     ): Either<AppError, Unit> =
-        eventRepo.insertLookupEvent(accountingPointBusinessId, controllableUnitBusinessId, requestingPartyId)
+        eventRepo.insertEvent(
+            "no.elhub.flex.controllable_unit.lookup",
+            "accounting_point",
+            accountingPointId,
+            controllableUnitId?.let { "controllable_unit" },
+            controllableUnitId,
+            "{\"requesting_party_id\": $requestingPartyId}"
+        )
             .mapLeft { e ->
                 logger.error { "Failed to insert lookup event: ${e.message}" }
                 InternalServerError(traceIdOrUnknown())

--- a/kbackend/src/test/kotlin/no/elhub/flex/TestApplication.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/TestApplication.kt
@@ -14,6 +14,7 @@ import no.elhub.flex.config.configureMonitoring
 import no.elhub.flex.config.configureRouting
 import no.elhub.flex.config.configureSerialization
 import no.elhub.flex.controllableunit.db.ControllableUnitRepository
+import no.elhub.flex.event.db.EventRepository
 import no.elhub.flex.model.domain.db.DatabaseError
 import no.elhub.flex.model.error.DataFetchError
 import no.elhub.flex.routes.controllableunit.ControllableUnitLookup
@@ -35,6 +36,9 @@ fun defaultTestApplication(): TestApplication {
         coEvery { with(any<FlexPrincipal>()) { repo.lookupControllableUnits(any(), any()) } } returns
             DatabaseError("stub").left()
     }
+    val mockEventRepo = mockk<EventRepository>().also { repo ->
+        coEvery { with(any<FlexPrincipal>()) { repo.insertLookupEvent(any(), any(), any()) } } returns Unit.right()
+    }
 
     return TestApplication {
         application {
@@ -47,7 +51,8 @@ fun defaultTestApplication(): TestApplication {
                     module {
                         single<AccountingPointService> { mockAccountingPointService }
                         single<ControllableUnitRepository> { mockRepo }
-                        single { ControllableUnitLookup(get(), get()) }
+                        single<EventRepository> { mockEventRepo }
+                        single { ControllableUnitLookup(get(), get(), get()) }
                     },
                 )
             }

--- a/kbackend/src/test/kotlin/no/elhub/flex/TestApplication.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/TestApplication.kt
@@ -37,7 +37,7 @@ fun defaultTestApplication(): TestApplication {
             DatabaseError("stub").left()
     }
     val mockEventRepo = mockk<EventRepository>().also { repo ->
-        coEvery { with(any<FlexPrincipal>()) { repo.insertLookupEvent(any(), any(), any()) } } returns Unit.right()
+        coEvery { with(any<FlexPrincipal>()) { repo.insertEvent(any(), any(), any(), any(), any(), any()) } } returns Unit.right()
     }
 
     return TestApplication {

--- a/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTest.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTest.kt
@@ -2,8 +2,6 @@ package no.elhub.flex.controllableunit
 
 import arrow.core.left
 import arrow.core.right
-import com.auth0.jwt.JWT
-import com.auth0.jwt.algorithms.Algorithm
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.header
@@ -15,6 +13,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.server.application.install
 import io.ktor.server.testing.TestApplication
+import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -27,26 +26,36 @@ import no.elhub.flex.config.Tracing
 import no.elhub.flex.config.configureLogging
 import no.elhub.flex.config.configureSerialization
 import no.elhub.flex.controllableunit.db.ControllableUnitRepository
+import no.elhub.flex.event.db.EventRepository
 import no.elhub.flex.model.domain.AccountingPoint
 import no.elhub.flex.model.domain.ControllableUnit
 import no.elhub.flex.model.error.InternalServerError
 import no.elhub.flex.model.error.ResourceNotFoundError
 import no.elhub.flex.routes.controllableunit.ControllableUnitLookup
 import no.elhub.flex.routes.controllableunit.controllableUnitRoutes
+import no.elhub.flex.util.TEST_JWT_SECRET
+import no.elhub.flex.util.makeJwt
 import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
-import java.util.Date
 import kotlin.time.Clock
 
 class ControllableUnitLookupTest :
     FunSpec({
         val mockRepo = mockk<ControllableUnitRepository>()
         val mockAccountingPointService = mockk<AccountingPointService>()
+        val mockEventRepo = mockk<EventRepository>()
+
+        beforeTest {
+            clearAllMocks(answers = false)
+            coEvery {
+                with(any<FlexPrincipal>()) { mockEventRepo.insertLookupEvent(any(), any(), any()) }
+            } returns Unit.right()
+        }
 
         context("POST /controllable_unit/lookup") {
 
             test("missing Authorization header returns HTTP 401") {
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     setBody("""{"end_user":"123456789","accounting_point":"133700000000000053"}""")
@@ -78,7 +87,7 @@ class ControllableUnitLookupTest :
                     with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
                 } returns emptyList<ControllableUnit>().right()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Cookie", "__Host-flex_session=${makeJwt()}")
@@ -111,7 +120,7 @@ class ControllableUnitLookupTest :
                     with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
                 } returns emptyList<ControllableUnit>().right()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -123,7 +132,7 @@ class ControllableUnitLookupTest :
             }
 
             test("disallowed role returns HTTP 403") {
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt(role = "flex_organisation")}")
@@ -134,7 +143,7 @@ class ControllableUnitLookupTest :
             }
 
             test("insufficient scope returns HTTP 403") {
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt(scope = "read:data")}")
@@ -167,7 +176,7 @@ class ControllableUnitLookupTest :
                     with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
                 } returns emptyList<ControllableUnit>().right()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt(scope = "manage:data")}")
@@ -178,7 +187,7 @@ class ControllableUnitLookupTest :
             }
 
             test("missing end_user returns HTTP 400") {
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -189,7 +198,7 @@ class ControllableUnitLookupTest :
             }
 
             test("ill-formed end_user returns HTTP 400") {
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -200,7 +209,7 @@ class ControllableUnitLookupTest :
             }
 
             test("PID (11-digit fødselsnummer) is rejected as end_user") {
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -211,7 +220,7 @@ class ControllableUnitLookupTest :
             }
 
             test("both AP and CU business IDs returns HTTP 400") {
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -248,7 +257,7 @@ class ControllableUnitLookupTest :
                     with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
                 } returns emptyList<ControllableUnit>().right()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -259,7 +268,7 @@ class ControllableUnitLookupTest :
             }
 
             test("missing both AP and CU business IDs returns HTTP 400") {
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -270,7 +279,7 @@ class ControllableUnitLookupTest :
             }
 
             test("invalid GSRN accounting point returns HTTP 400") {
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -287,7 +296,7 @@ class ControllableUnitLookupTest :
                     with(any<FlexPrincipal>()) { mockAccountingPointService.getCurrentAccountingPoint(controllableUnitBusinessId) }
                 } returns ResourceNotFoundError("controllable unit does not exist").left()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -315,7 +324,7 @@ class ControllableUnitLookupTest :
                     with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
                 } returns emptyList<ControllableUnit>().right()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -345,7 +354,7 @@ class ControllableUnitLookupTest :
                     with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
                 } returns emptyList<ControllableUnit>().right()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -376,7 +385,7 @@ class ControllableUnitLookupTest :
                         with(any<FlexPrincipal>()) { syncDisabledRepo.lookupControllableUnits(any(), any()) }
                     } returns emptyList<ControllableUnit>().right()
 
-                    val app = testApp(syncDisabledRepo, syncDisabledAccountingPointService, syncEnabled = false)
+                    val app = testApp(syncDisabledRepo, syncDisabledAccountingPointService, mockEventRepo, syncEnabled = false)
                     val response = app.client.post("/controllable_unit/lookup") {
                         contentType(ContentType.Application.Json)
                         header("Authorization", "Bearer ${makeJwt()}")
@@ -408,7 +417,7 @@ class ControllableUnitLookupTest :
                         with(any<FlexPrincipal>()) { syncDisabledRepo.lookupControllableUnits(any(), any()) }
                     } returns emptyList<ControllableUnit>().right()
 
-                    val app = testApp(syncDisabledRepo, syncDisabledAccountingPointService, syncEnabled = false)
+                    val app = testApp(syncDisabledRepo, syncDisabledAccountingPointService, mockEventRepo, syncEnabled = false)
                     val response = app.client.post("/controllable_unit/lookup") {
                         contentType(ContentType.Application.Json)
                         header("Authorization", "Bearer ${makeJwt()}")
@@ -443,7 +452,7 @@ class ControllableUnitLookupTest :
                     with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
                 } returns emptyList<ControllableUnit>().right()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -477,7 +486,7 @@ class ControllableUnitLookupTest :
                     with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
                 } returns emptyList<ControllableUnit>().right()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -494,7 +503,7 @@ class ControllableUnitLookupTest :
                     with(any<FlexPrincipal>()) { mockAccountingPointService.getCurrentAccountingPoint(controllableUnitBusinessId) }
                 } returns ResourceNotFoundError("Current AP not found").left()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -536,7 +545,7 @@ class ControllableUnitLookupTest :
                     ),
                 ).right()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -557,7 +566,7 @@ class ControllableUnitLookupTest :
                     mockAccountingPointService.synchronizeAccountingPoint(any(), any())
                 } returns InternalServerError("traceId").left()
 
-                val app = testApp(mockRepo, mockAccountingPointService)
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
                 val response = app.client.post("/controllable_unit/lookup") {
                     contentType(ContentType.Application.Json)
                     header("Authorization", "Bearer ${makeJwt()}")
@@ -566,35 +575,130 @@ class ControllableUnitLookupTest :
                 response.status shouldBe HttpStatusCode.InternalServerError
                 app.stop()
             }
+
+            test("AP lookup: one event is inserted with AP business ID and no CU business ID") {
+                val endUserBusinessId = "123456789"
+                val accountingPointBusinessId = "133700000000000053"
+                coEvery {
+                    with(any<FlexPrincipal>()) { mockAccountingPointService.getCurrentAccountingPoint(any()) }
+                } returns AccountingPoint(id = 1, businessId = accountingPointBusinessId).right()
+                coEvery {
+                    mockAccountingPointService.synchronizeAccountingPoint(any(), any())
+                } returns Unit.right()
+                coEvery {
+                    with(any<FlexPrincipal>()) {
+                        mockAccountingPointService.checkEndUserMatchesAccountingPoint(endUserBusinessId, accountingPointBusinessId)
+                    }
+                } returns 7L.right()
+                coEvery {
+                    with(any<FlexPrincipal>()) {
+                        mockAccountingPointService.getAccountingPointByBusinessId(accountingPointBusinessId)
+                    }
+                } returns AccountingPoint(id = 1, businessId = accountingPointBusinessId).right()
+                coEvery {
+                    with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
+                } returns listOf(
+                    ControllableUnit(id = 10L, businessId = "550e8400-e29b-41d4-a716-446655440000", name = "CU 1", technicalResources = emptyList(), startDate = null),
+                    ControllableUnit(id = 20L, businessId = "660e8400-e29b-41d4-a716-446655440001", name = "CU 2", technicalResources = emptyList(), startDate = null),
+                ).right()
+
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
+                app.client.post("/controllable_unit/lookup") {
+                    contentType(ContentType.Application.Json)
+                    header("Authorization", "Bearer ${makeJwt()}")
+                    setBody("""{"end_user":"$endUserBusinessId","accounting_point":"$accountingPointBusinessId"}""")
+                }
+                coVerify(exactly = 1) {
+                    with(any<FlexPrincipal>()) { mockEventRepo.insertLookupEvent(accountingPointBusinessId, null, 1) }
+                }
+                app.stop()
+            }
+
+            test("AP lookup with no CUs found: event is still inserted with AP business ID") {
+                val endUserBusinessId = "123456789"
+                val accountingPointBusinessId = "133700000000000053"
+                coEvery {
+                    with(any<FlexPrincipal>()) { mockAccountingPointService.getCurrentAccountingPoint(any()) }
+                } returns AccountingPoint(id = 1, businessId = accountingPointBusinessId).right()
+                coEvery {
+                    mockAccountingPointService.synchronizeAccountingPoint(any(), any())
+                } returns Unit.right()
+                coEvery {
+                    with(any<FlexPrincipal>()) {
+                        mockAccountingPointService.checkEndUserMatchesAccountingPoint(endUserBusinessId, accountingPointBusinessId)
+                    }
+                } returns 7L.right()
+                coEvery {
+                    with(any<FlexPrincipal>()) {
+                        mockAccountingPointService.getAccountingPointByBusinessId(accountingPointBusinessId)
+                    }
+                } returns AccountingPoint(id = 1, businessId = accountingPointBusinessId).right()
+                coEvery {
+                    with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
+                } returns emptyList<ControllableUnit>().right()
+
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
+                app.client.post("/controllable_unit/lookup") {
+                    contentType(ContentType.Application.Json)
+                    header("Authorization", "Bearer ${makeJwt()}")
+                    setBody("""{"end_user":"$endUserBusinessId","accounting_point":"$accountingPointBusinessId"}""")
+                }
+                coVerify(exactly = 1) {
+                    with(any<FlexPrincipal>()) { mockEventRepo.insertLookupEvent(accountingPointBusinessId, null, 1) }
+                }
+                app.stop()
+            }
+
+            test("CU-specific lookup: event is inserted with AP and CU business IDs") {
+                val endUserBusinessId = "123456789"
+                val controllableUnitBusinessId = "550e8400-e29b-41d4-a716-446655440000"
+                val accountingPointBusinessId = "133700000000000053"
+                coEvery {
+                    with(any<FlexPrincipal>()) { mockAccountingPointService.getCurrentAccountingPoint(controllableUnitBusinessId) }
+                } returns AccountingPoint(id = 1, businessId = accountingPointBusinessId).right()
+                coEvery {
+                    mockAccountingPointService.synchronizeAccountingPoint(any(), any())
+                } returns Unit.right()
+                coEvery {
+                    with(any<FlexPrincipal>()) {
+                        mockAccountingPointService.checkEndUserMatchesAccountingPoint(endUserBusinessId, accountingPointBusinessId)
+                    }
+                } returns 7L.right()
+                coEvery {
+                    with(any<FlexPrincipal>()) {
+                        mockAccountingPointService.getAccountingPointByBusinessId(accountingPointBusinessId)
+                    }
+                } returns AccountingPoint(id = 1, businessId = accountingPointBusinessId).right()
+                coEvery {
+                    with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
+                } returns listOf(
+                    ControllableUnit(id = 10L, businessId = controllableUnitBusinessId, name = "CU 1", technicalResources = emptyList(), startDate = null),
+                ).right()
+
+                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
+                app.client.post("/controllable_unit/lookup") {
+                    contentType(ContentType.Application.Json)
+                    header("Authorization", "Bearer ${makeJwt()}")
+                    setBody("""{"end_user":"$endUserBusinessId","controllable_unit":"$controllableUnitBusinessId"}""")
+                }
+                coVerify(exactly = 1) {
+                    with(any<FlexPrincipal>()) { mockEventRepo.insertLookupEvent(accountingPointBusinessId, controllableUnitBusinessId, 1) }
+                }
+                app.stop()
+            }
         }
     })
-
-private const val TEST_SECRET = "test-secret-key-at-least-256-bits-long-for-hs256"
-
-@Suppress("MagicNumber")
-private fun makeJwt(
-    role: String = "flex_service_provider",
-    eid: String = "12345678901",
-    scope: String = "use:data:controllable_unit:lookup",
-): String =
-    JWT.create()
-        .withClaim("entity_id", 1)
-        .withClaim("eid", eid)
-        .withClaim("party_id", 1)
-        .withClaim("role", role)
-        .withClaim("scope", scope)
-        .withExpiresAt(Date(System.currentTimeMillis() + 60_000))
-        .sign(Algorithm.HMAC256(TEST_SECRET))
 
 private fun testApp(
     repo: ControllableUnitRepository,
     accountingPointService: AccountingPointService,
+    eventRepo: EventRepository,
     syncEnabled: Boolean = true,
 ): TestApplication =
     TestApplication {
         application {
             install(Tracing.plugin)
-            install(FlexAuthentication) { jwtSecret = TEST_SECRET }
+            install(FlexAuthentication) { jwtSecret = TEST_JWT_SECRET }
             configureSerialization()
             configureLogging()
             install(Koin) {
@@ -602,7 +706,8 @@ private fun testApp(
                     module {
                         single<ControllableUnitRepository> { repo }
                         single<AccountingPointService> { accountingPointService }
-                        single { ControllableUnitLookup(get(), get(), syncEnabled) }
+                        single<EventRepository> { eventRepo }
+                        single { ControllableUnitLookup(get(), get(), get(), syncEnabled) }
                     },
                 )
             }

--- a/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTest.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTest.kt
@@ -48,7 +48,7 @@ class ControllableUnitLookupTest :
         beforeTest {
             clearAllMocks(answers = false)
             coEvery {
-                with(any<FlexPrincipal>()) { mockEventRepo.insertLookupEvent(any(), any(), any()) }
+                with(any<FlexPrincipal>()) { mockEventRepo.insertEvent(any(), any(), any(), any(), any(), any()) }
             } returns Unit.right()
         }
 
@@ -609,7 +609,16 @@ class ControllableUnitLookupTest :
                     setBody("""{"end_user":"$endUserBusinessId","accounting_point":"$accountingPointBusinessId"}""")
                 }
                 coVerify(exactly = 1) {
-                    with(any<FlexPrincipal>()) { mockEventRepo.insertLookupEvent(accountingPointBusinessId, null, 1) }
+                    with(any<FlexPrincipal>()) {
+                        mockEventRepo.insertEvent(
+                            "no.elhub.flex.controllable_unit.lookup",
+                            "accounting_point",
+                            1,
+                            null,
+                            null,
+                            "{\"requesting_party_id\": 1}"
+                        )
+                    }
                 }
                 app.stop()
             }
@@ -644,7 +653,16 @@ class ControllableUnitLookupTest :
                     setBody("""{"end_user":"$endUserBusinessId","accounting_point":"$accountingPointBusinessId"}""")
                 }
                 coVerify(exactly = 1) {
-                    with(any<FlexPrincipal>()) { mockEventRepo.insertLookupEvent(accountingPointBusinessId, null, 1) }
+                    with(any<FlexPrincipal>()) {
+                        mockEventRepo.insertEvent(
+                            "no.elhub.flex.controllable_unit.lookup",
+                            "accounting_point",
+                            1,
+                            null,
+                            null,
+                            "{\"requesting_party_id\": 1}"
+                        )
+                    }
                 }
                 app.stop()
             }
@@ -682,7 +700,16 @@ class ControllableUnitLookupTest :
                     setBody("""{"end_user":"$endUserBusinessId","controllable_unit":"$controllableUnitBusinessId"}""")
                 }
                 coVerify(exactly = 1) {
-                    with(any<FlexPrincipal>()) { mockEventRepo.insertLookupEvent(accountingPointBusinessId, controllableUnitBusinessId, 1) }
+                    with(any<FlexPrincipal>()) {
+                        mockEventRepo.insertEvent(
+                            "no.elhub.flex.controllable_unit.lookup",
+                            "accounting_point",
+                            1,
+                            "controllable_unit",
+                            10,
+                            "{\"requesting_party_id\": 1}"
+                        )
+                    }
                 }
                 app.stop()
             }

--- a/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTimezoneTest.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTimezoneTest.kt
@@ -6,6 +6,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -22,13 +23,17 @@ import no.elhub.flex.PostgresTestContainer
 import no.elhub.flex.accountingpoint.AccountingPointServiceImpl
 import no.elhub.flex.accountingpoint.db.AccountingPointMeteringGridAreaRepositoryImpl
 import no.elhub.flex.accountingpoint.db.AccountingPointRepositoryImpl
+import no.elhub.flex.auth.FlexAuthentication
 import no.elhub.flex.config.Tracing
 import no.elhub.flex.config.configureSerialization
 import no.elhub.flex.controllableunit.db.ControllableUnitRepositoryImpl
+import no.elhub.flex.event.db.EventRepositoryImpl
 import no.elhub.flex.integration.accountingpointadapter.AccountingPointAdapterHttpService
 import no.elhub.flex.integration.accountingpointadapter.AccountingPointAdapterWireMockServer
 import no.elhub.flex.meteringgridarea.db.MeteringGridAreaRepositoryImpl
 import no.elhub.flex.routes.controllableunit.ControllableUnitLookup
+import no.elhub.flex.util.TEST_JWT_SECRET
+import no.elhub.flex.util.makeJwt
 import no.elhub.flex.util.todayLocalMidnight
 import no.elhub.flex.util.uniqueEicY
 import no.elhub.flex.util.uniqueGsrn
@@ -69,6 +74,7 @@ class ControllableUnitLookupTimezoneTest : FunSpec({
                 AccountingPointMeteringGridAreaRepositoryImpl(),
                 adapterService,
             ),
+            eventRepo = EventRepositoryImpl(),
             // keep enabled so that we check that checks in the DB pass
             accountingPointAdapterSyncEnabled = true,
             timezone = osloTz,
@@ -96,10 +102,10 @@ class ControllableUnitLookupTimezoneTest : FunSpec({
     }
 
     // minimal app just calling the raw handler
-    // (we avoid auth and other stuff we don't need to have in the test)
     fun testApp() = TestApplication {
         application {
             install(Tracing.plugin)
+            install(FlexAuthentication) { jwtSecret = TEST_JWT_SECRET }
             configureSerialization()
             routing {
                 post("/controllable_unit/lookup") { lookup.handle(call) }
@@ -221,6 +227,7 @@ class ControllableUnitLookupTimezoneTest : FunSpec({
 
             testApp().client.post("/controllable_unit/lookup") {
                 contentType(ContentType.Application.Json)
+                header("Authorization", "Bearer ${makeJwt()}")
                 setBody("""{"end_user":"$endUserOrg","accounting_point":"$gsrn"}""")
             }.status shouldBe HttpStatusCode.OK
 
@@ -239,6 +246,7 @@ class ControllableUnitLookupTimezoneTest : FunSpec({
 
             testApp().client.post("/controllable_unit/lookup") {
                 contentType(ContentType.Application.Json)
+                header("Authorization", "Bearer ${makeJwt()}")
                 setBody("""{"end_user":"$endUserOrg","accounting_point":"$gsrn"}""")
             }.status shouldBe HttpStatusCode.OK
 

--- a/kbackend/src/test/kotlin/no/elhub/flex/util/JwtTestUtil.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/util/JwtTestUtil.kt
@@ -1,0 +1,22 @@
+package no.elhub.flex.util
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import java.util.Date
+
+const val TEST_JWT_SECRET = "test-secret-key-at-least-256-bits-long-for-hs256"
+
+@Suppress("MagicNumber")
+fun makeJwt(
+    role: String = "flex_service_provider",
+    eid: String = "12345678901",
+    scope: String = "use:data:controllable_unit:lookup",
+): String =
+    JWT.create()
+        .withClaim("entity_id", 1)
+        .withClaim("eid", eid)
+        .withClaim("party_id", 1)
+        .withClaim("role", role)
+        .withClaim("scope", scope)
+        .withExpiresAt(Date(System.currentTimeMillis() + 60_000))
+        .sign(Algorithm.HMAC256(TEST_JWT_SECRET))


### PR DESCRIPTION
This PR reintroduces the insertion of events at the end of the CU lookup handler, which probably got removed when switching to the Kotlin backend.

The new events, however, use another logic than the one previously used: they use the _accounting point_ as the `source` instead of the controllable unit, which means only one event is generated per lookup. When it is a lookup by controllable unit business ID, we store this information in the `subject` field, and when it is a lookup by accounting point business ID, the `subject` is empty. All the previous logic generating notification should be preserved, it just needs to go through the AP ID instead of the CU ID in some cases.

Pre-existing events with the AP in `source` are updated to match the new format, even though they all probably have already been processed.