### PR TITLE
fix: remove isAutoCommit=false from HikariCP to prevent idle-in-transaction connections (FLEX-1269)

### DIFF
--- a/kbackend/src/main/kotlin/no/elhub/flex/config/Database.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/config/Database.kt
@@ -22,7 +22,6 @@ fun Application.configureDatabase(): HikariDataSource {
         maximumPoolSize =
             environment.config.propertyOrNull("ktor.database.hikari.maximumPoolSize")?.getString()?.toInt() ?: 10
         schema = "api"
-        isAutoCommit = false
         transactionIsolation = "TRANSACTION_READ_COMMITTED"
         validate()
     }


### PR DESCRIPTION
With `autoCommit=false`, Hikari will keep connections idle in transaction after initializing the pool with `SET SESSION search_path TO api`.

This caused a lot of warnings in the logs because we have a 30s max idle in transaction setting in the database:
```
[trace_id=, span_id=] [HikariPool-1:housekeeper] WARN  com.zaxxer.hikari.pool.PoolBase -- HikariPool-1 - Failed to validate connection org.postgresql.jdbc.PgConnection@7daabeec (This connection has been closed.). Possibly consider using a shorter maxLifetime value.
```
Exposed disables auto commit in the TransactionManager, so no need for the additional setting on the connection pool.