### PR TITLE
feat: email entity business IDs must be lowercase (FLEX-1280)

### DIFF
--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -551,6 +551,14 @@ func (auth *API) GetCallbackHandler(ctx *gin.Context) { //nolint:funlen,cyclop
 
 	slog.DebugContext(ctx, "callback", "token", idToken, "id", id)
 
+	if idType == "email" && id != strings.ToLower(id) {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, oauthErrorMessage{
+			Error:            oauthErrorInvalidClient,
+			ErrorDescription: "email address must be lowercase",
+		})
+		return
+	}
+
 	tx, err := auth.db.Begin(ctx)
 	if err != nil {
 		ctx.AbortWithStatusJSON(http.StatusInternalServerError, newErrorMessage(http.StatusInternalServerError, "could not begin tx in callback handler", err))

--- a/backend/data/data.go
+++ b/backend/data/data.go
@@ -488,6 +488,10 @@ func (data *api) entityLookupHandler(
 			err == nil,
 			"email address is not valid",
 		)
+		entityLookupValidator.Check(
+			entityLookupRequestBody.BusinessID == strings.ToLower(entityLookupRequestBody.BusinessID),
+			"email address must be lowercase",
+		)
 	case "org":
 		entityLookupValidator.Check(
 			regexOrganisationBusinessID.MatchString(entityLookupRequestBody.BusinessID),

--- a/db/flex/business_id_type.sql
+++ b/db/flex/business_id_type.sql
@@ -61,7 +61,10 @@ BEGIN
         );
     ELSIF business_id_type = 'email' THEN
         -- Email validation: check if business_id is a valid email address
-        RETURN (business_id ~ '^[^@\s]+@[^@\s]+\.[^@\s]+$');
+        RETURN (
+            business_id ~ '^[^@\s]+@[^@\s]+\.[^@\s]+$'
+            AND business_id = lower(business_id)
+        );
     ELSIF business_id_type = 'pid' THEN
         -- PID validation: check if business_id is a valid personal identification number
         RETURN (business_id ~ '^[0-9]{11}$');

--- a/db/flex/entity_migrations.sql
+++ b/db/flex/entity_migrations.sql
@@ -9,10 +9,3 @@ ADD CONSTRAINT check_entity_type_business_id_type CHECK (
     (type = 'person' AND business_id_type IN ('pid', 'email'))
     OR (type = 'organisation' AND business_id_type = 'org')
 );
-
--- changeset flex:entity-business-id-email-lowercase runOnChange:false endDelimiter:;
---preconditions onFail:MARK_RAN
---precondition-sql-check expectedResult:t SELECT EXISTS (SELECT 1 FROM flex.entity WHERE business_id_type = 'email' AND business_id != lower(business_id))
-UPDATE flex.entity
-SET business_id = lower(business_id)
-WHERE business_id_type = 'email' AND business_id != lower(business_id);

--- a/db/flex/entity_migrations.sql
+++ b/db/flex/entity_migrations.sql
@@ -9,3 +9,10 @@ ADD CONSTRAINT check_entity_type_business_id_type CHECK (
     (type = 'person' AND business_id_type IN ('pid', 'email'))
     OR (type = 'organisation' AND business_id_type = 'org')
 );
+
+-- changeset flex:entity-business-id-email-lowercase runOnChange:false endDelimiter:;
+--preconditions onFail:MARK_RAN
+--precondition-sql-check expectedResult:t SELECT EXISTS (SELECT 1 FROM flex.entity WHERE business_id_type = 'email' AND business_id != lower(business_id))
+UPDATE flex.entity
+SET business_id = lower(business_id)
+WHERE business_id_type = 'email' AND business_id != lower(business_id);

--- a/docs/resources/entity.md
+++ b/docs/resources/entity.md
@@ -43,7 +43,9 @@ to their organisation, and possibly create entities for their colleagues.
 
 ## Validation Rules
 
-No validation rules.
+| Policy key | Policy                                                               | Status |
+|------------|----------------------------------------------------------------------|--------|
+| ENT-VAL001 | Email addresses used as `business_id` on entities must be lowercase. | DONE   |
 
 ## Notifications
 
@@ -97,9 +99,9 @@ No policies.
 
 #### Organisation
 
-| Policy key | Policy                                                                                                                                    | Status |
-|------------|-------------------------------------------------------------------------------------------------------------------------------------------|--------|
-| ENT-ORG001 | Read all entities belonging to parties owned by the organisation.                                                                         | DONE   |
+| Policy key | Policy                                                            | Status |
+|------------|-------------------------------------------------------------------|--------|
+| ENT-ORG001 | Read all entities belonging to parties owned by the organisation. | DONE   |
 
 #### System Operator
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2142,9 +2142,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2162,9 +2159,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2182,9 +2176,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2202,9 +2193,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2222,9 +2210,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2242,9 +2227,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [

--- a/frontend/src/party/membership/AddPartyMemberViaEntityLookupModal.tsx
+++ b/frontend/src/party/membership/AddPartyMemberViaEntityLookupModal.tsx
@@ -170,12 +170,19 @@ export const AddPartyMemberViaEntityLookupModal = ({
       <Modal.Content className="flex flex-col gap-4 min-w-lg">
         <FormItem>
           <FormItemLabel htmlFor="lookup-business-id">Email</FormItemLabel>
-          <TextField
-            id="lookup-business-id"
-            {...register("business_id")}
-            disabled={isPending}
-            placeholder="Enter the entity's email address"
-            aria-invalid={!!errors.business_id}
+          <Controller
+            name="business_id"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                id="lookup-business-id"
+                {...field}
+                onChange={(e) => field.onChange(e.target.value.toLowerCase())}
+                disabled={isPending}
+                placeholder="Enter the entity's email address"
+                aria-invalid={!!errors.business_id}
+              />
+            )}
           />
           {errors.business_id && (
             <Alert variant="error">{errors.business_id.message}</Alert>

--- a/test/api_client_tests/test_entity.py
+++ b/test/api_client_tests/test_entity.py
@@ -225,6 +225,7 @@ def test_entity_fiso(sts):
         "@missingusername.com",
         "username@.com",
         "username@com",
+        "Valid.But.Upper.Case@example.com",
     ]:
         e = create_entity.sync(
             client=client_fiso,

--- a/test/api_client_tests/test_entity_lookup.py
+++ b/test/api_client_tests/test_entity_lookup.py
@@ -93,6 +93,20 @@ def test_entity_lookup_params(sts):
     assert isinstance(e, ErrorMessage)
     assert e.code == "HTTP400"
 
+    # uppercase email
+    e = call_entity_lookup.sync(
+        client=client_fiso,
+        body=EntityLookupRequest(
+            business_id="User@Example.COM",
+            business_id_type=EntityLookupRequestBusinessIdType.EMAIL,
+            name="TEST-ENTITY-LOOKUP",
+            type_=EntityLookupRequestType.PERSON,
+        ),
+    )
+    assert isinstance(e, ErrorMessage)
+    assert e.code == "HTTP400"
+    assert e.message == "email address must be lowercase"
+
     # empty name
     e = call_entity_lookup.sync(
         client=client_fiso,


### PR DESCRIPTION
Documented in the entity resource.

The DB change secures that no entity can be created with a non-lowercase email, so it is theoretically enough to catch all possible errors. The other changes are there to increase the quality of error handling (getting HTTP 400 with a good error message instead of a cryptic HTTP 500, for instance) or preventing the user from going into this error from the start (frontend forcing lowercase email on entity lookup).

The callback endpoint could somehow not be tested with Authelia using lowercase automagically even when configured in a different way.

> [!CAUTION]
> After merge, needs manual cleanup of entities with non-lowercase emails in the deployed environments.