### PR TITLE
fix: correct notification generation on CU lookup by accounting point ID (FLEX-1265)

### DIFF
--- a/backend/event/models.sql
+++ b/backend/event/models.sql
@@ -335,7 +335,7 @@ WHERE cueu.controllable_unit_id = @cu_id
 
 -- name: GetControllableUnitLookupNotificationRecipientsAP :many
 SELECT apeu.end_user_id
-FROM api.accounting_point_end_user AS apeu
+FROM notification.accounting_point_end_user AS apeu
 WHERE apeu.accounting_point_id = @ap_id
     AND apeu.valid_time_range @> @recorded_at::timestamptz;
 

--- a/backend/event/models/models.custom.go
+++ b/backend/event/models/models.custom.go
@@ -30,7 +30,7 @@ func (q *Queries) GetNotificationRecipients( //nolint:cyclop,funlen
 			return q.GetControllableUnitLookupNotificationRecipientsCU(ctx, *subjectID, recordedAt)
 		}
 		// general AP lookup, identify recipients from AP ID
-		return q.GetControllableUnitLookupNotificationRecipientsAP(ctx, recordedAt, sourceID)
+		return q.GetControllableUnitLookupNotificationRecipientsAP(ctx, sourceID, recordedAt)
 	case "no.elhub.flex.controllable_unit.create":
 		return q.GetControllableUnitCreateNotificationRecipients(ctx, recordedAt, resourceID)
 	case "no.elhub.flex.controllable_unit.update":

--- a/backend/event/models/models.go
+++ b/backend/event/models/models.go
@@ -733,6 +733,12 @@ type ApiTechnicalResourceHistory struct {
 	ReplacedAt            pgtype.Timestamptz
 }
 
+type NotificationAccountingPointEndUser struct {
+	AccountingPointID int
+	EndUserID         int
+	ValidTimeRange    pgtype.Range[pgtype.Timestamptz]
+}
+
 type NotificationAccountingPointSystemOperator struct {
 	AccountingPointID int
 	SystemOperatorID  int

--- a/backend/event/models/models.sql.go
+++ b/backend/event/models/models.sql.go
@@ -91,16 +91,14 @@ func (q *Queries) GetControllableUnitCreateNotificationRecipients(ctx context.Co
 }
 
 const getControllableUnitLookupNotificationRecipientsAP = `-- name: GetControllableUnitLookupNotificationRecipientsAP :many
-SELECT cueu.end_user_id
-FROM api.controllable_unit AS cu
-    INNER JOIN notification.controllable_unit_end_user AS cueu
-        ON cu.id = cueu.controllable_unit_id
-            AND cueu.valid_time_range @> $1::timestamptz
-WHERE cu.accounting_point_id = $2
+SELECT apeu.end_user_id
+FROM notification.accounting_point_end_user AS apeu
+WHERE apeu.accounting_point_id = $1
+    AND apeu.valid_time_range @> $2::timestamptz
 `
 
-func (q *Queries) GetControllableUnitLookupNotificationRecipientsAP(ctx context.Context, recordedAt pgtype.Timestamptz, apID int) ([]int, error) {
-	rows, err := q.db.Query(ctx, getControllableUnitLookupNotificationRecipientsAP, recordedAt, apID)
+func (q *Queries) GetControllableUnitLookupNotificationRecipientsAP(ctx context.Context, apID int, recordedAt pgtype.Timestamptz) ([]int, error) {
+	rows, err := q.db.Query(ctx, getControllableUnitLookupNotificationRecipientsAP, apID, recordedAt)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/event/schemas/notification.sql
+++ b/backend/event/schemas/notification.sql
@@ -2,6 +2,12 @@
 
 CREATE SCHEMA notification;
 
+CREATE TABLE notification.accounting_point_end_user (
+    accounting_point_id bigint NOT NULL,
+    end_user_id bigint NOT NULL,
+    valid_time_range tstzrange NOT NULL
+);
+
 CREATE TABLE notification.controllable_unit_end_user (
     controllable_unit_id bigint NOT NULL,
     end_user_id bigint NOT NULL,

--- a/db/notification/accounting_point_end_user.sql
+++ b/db/notification/accounting_point_end_user.sql
@@ -1,0 +1,16 @@
+--liquibase formatted sql
+-- Manually managed file
+
+-- changeset flex:notification-accounting-point-end-user endDelimiter:-- runOnChange:true
+CREATE OR REPLACE VIEW notification.accounting_point_end_user
+WITH (security_invoker = true) AS (
+    SELECT
+        accounting_point_id,
+        end_user_id,
+        valid_time_range
+    FROM flex.accounting_point_end_user
+);
+
+-- changeset flex:notification-accounting-point-end-user-grant endDelimiter:; runOnChange:true
+GRANT SELECT ON TABLE notification.accounting_point_end_user
+TO flex_internal_event_notification;


### PR DESCRIPTION
First, sqlc had not been run for the updated query on the AP case.
Second, the query was invalid (`api` views have `valid_from`/`valid_to` instead of `valid_time_range`).
Third, the `api` view for AP-EU implements RLS in the view. As the notification role lies outside the RLS logic, it could not read anything.

We probably tested that the right events were created, and notifications for CU lookup based on CU business ID, but the AP case got forgotten after hotfixing the query before merging.

Here we define a `notification` view for AP-EU as we have done for a few other resources.

Properly tested this time, both event and notification generation.

> [!NOTE]
> After merging this, we should set `processed = false` in the deployed environments on lookup events when there exists no related notification, just to make sure end users have been notified.