### PR TITLE
fix: use projection SRID over text (FLEX-1132)

### DIFF
--- a/db/staging/substation_staging.sql
+++ b/db/staging/substation_staging.sql
@@ -103,13 +103,13 @@ CREATE OR REPLACE VIEW staging.substation_cluster_v AS (
                 ST_CONVEXHULL(
                     ST_COLLECT(
                         ST_TRANSFORM(
-                            ST_MAKEPOINT(sub.lon, sub.lat), 'EPSG:4326', 'EPSG:3857'
+                            ST_SETSRID(ST_MAKEPOINT(sub.lon, sub.lat), 4326), 3857
                         )
                     )
                 ),
                 50
             ),
-            'EPSG:3857', 'EPSG:4326'
+            4326
         ) AS area
     FROM staging.substation_cluster AS sc
         INNER JOIN staging.substation AS sub


### PR DESCRIPTION
Got the following error on non-local database. Seems to be a bit of a difference in PostGIS versjon or setup. Replacing with SRID to avoid the parsing.

> ERROR:  could not parse proj string 'EPSG:4326'

https://postgis.net/docs/ST_Transform.html