### PR TITLE
fix: suppress empty .update events (FLEX-1307)

### DIFF
--- a/db/flex/event.sql
+++ b/db/flex/event.sql
@@ -79,6 +79,12 @@ BEGIN
         AND pre.value IS DISTINCT FROM post.value
         -- excluding audit fields because otherwise they will show up everywhere
         AND pre.key NOT IN ('record_time_range', 'recorded_by');
+
+        IF l_event_data IS NULL THEN
+            -- if no fields changed (except audit fields), we can skip creating an event
+            RETURN NULL;
+        END IF;
+
     END IF;
 
     l_operation := lower(TG_OP);


### PR DESCRIPTION
Relates to #940 . This will protect us from similar issues where we have redundant updates on resources.

The caveat here is that it will make it less apparent that redundant updates are happening, but I'd argue it is more important to hide it from the app/users..