### PR TITLE
feat(db): SPPA and SPGPA product type lists cannot be empty (FLEX-1076)

### DIFF
--- a/db/flex/service_provider_product_application_migrations.sql
+++ b/db/flex/service_provider_product_application_migrations.sql
@@ -1,6 +1,36 @@
 --liquibase formatted sql
 -- Manually managed file
 
+-- changeset flex:service-provider-product-application-product-type-ids-not-empty-function runOnChange:true endDelimiter:--
+-- trigger to check that product_type_ids is not empty
+CREATE OR REPLACE FUNCTION
+service_provider_product_application_product_type_ids_not_empty()
+RETURNS trigger
+SECURITY INVOKER
+LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    IF array_length(NEW.product_type_ids, 1) IS NULL THEN
+        RAISE sqlstate 'PT400' using
+            message = 'product_type_ids must not be empty';
+        RETURN null;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+-- changeset flex:service-provider-product-application-product-type-ids-not-empty-trigger runOnChange:true endDelimiter:--
+-- SPPA-VAL004
+CREATE OR REPLACE TRIGGER
+service_provider_product_application_product_type_ids_not_empty
+BEFORE INSERT OR UPDATE ON service_provider_product_application
+FOR EACH ROW
+EXECUTE FUNCTION
+service_provider_product_application_product_type_ids_not_empty();
+
+
 -- changeset flex:service-provider-product-application-status-qualified-function runOnChange:true endDelimiter:--
 -- trigger to first set the last qualified timestamp if not done by the user
 CREATE OR REPLACE FUNCTION

--- a/db/flex/service_providing_group_product_application_migrations.sql
+++ b/db/flex/service_providing_group_product_application_migrations.sql
@@ -134,3 +134,32 @@ ADD CONSTRAINT spg_product_application_ramping_description_check CHECK (
     ramping_description IS NOT NULL
     OR NOT (1 = any(product_type_ids))
 );
+
+-- changeset flex:service-providing-group-product-application-product-type-ids-not-empty-function runOnChange:true endDelimiter:--
+-- trigger to check that product_type_ids is not empty
+CREATE OR REPLACE FUNCTION
+service_providing_group_product_application_product_type_ids_not_empty()
+RETURNS trigger
+SECURITY INVOKER
+LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    IF array_length(NEW.product_type_ids, 1) IS NULL THEN
+        RAISE sqlstate 'PT400' using
+            message = 'product_type_ids must not be empty';
+        RETURN null;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+-- changeset flex:service-providing-group-product-application-product-type-ids-not-empty-trigger runOnChange:true endDelimiter:--
+-- SPGPA-VAL009
+CREATE OR REPLACE TRIGGER
+service_providing_group_product_application_product_type_ids_not_empty
+BEFORE INSERT OR UPDATE ON service_providing_group_product_application
+FOR EACH ROW
+EXECUTE FUNCTION
+service_providing_group_product_application_product_type_ids_not_empty();

--- a/docs/resources/service_provider_product_application.md
+++ b/docs/resources/service_provider_product_application.md
@@ -45,6 +45,7 @@ application is updated as the process and lifecycle of the application progresse
 | SPPA-VAL001         | Inserted `product_type_ids` must be active product types asked by the SO.                                        | DONE   |
 | SPPA-VAL002         | If `status` is set to `qualified`, then `qualified_at` must already be specified in the resource or the request. | DONE   |
 | SPPA-VAL003         | If `status` is set to `not_qualified`, then `qualified_at` must be unset in the resource or by the request.      | DONE   |
+| SPPA-VAL004         | `product_type_ids` must not be empty.                                                                            | DONE   |
 
 ## Notifications
 

--- a/docs/resources/service_providing_group_product_application.md
+++ b/docs/resources/service_providing_group_product_application.md
@@ -65,6 +65,7 @@ change from `requested` will trigger this check as well.
 | SPGPA-VAL006        | If `status` is set to `rejected`, then both `prequalified_at` and `verified_at` must be unset in the resource or by the request. | DONE   |
 | SPGPA-VAL007        | If `product_type_ids` contains Manual Congestion, then `ramping_capability` must be set                                          | DONE   |
 | SPGPA-VAL008        | If `product_type_ids` contains Manual Congestion, then `ramping_description` must be set                                         | DONE   |
+| SPGPA-VAL009        | `product_type_ids` must not be empty.                                                                                            | DONE   |
 
 ## Notifications
 

--- a/test/api_client_tests/test_service_provider_product_application.py
+++ b/test/api_client_tests/test_service_provider_product_application.py
@@ -350,6 +350,61 @@ def test_sppa_so(sts):
     assert isinstance(u, ErrorMessage)
 
 
+# SPPA-VAL004
+def test_sppa_product_type_ids_not_empty(sts):
+    client_fiso = sts.get_client(TestEntity.TEST, "FISO")
+
+    client_sp = sts.fresh_client(TestEntity.TEST, "SP")
+    sp_id = sts.get_userinfo(client_sp)["party_id"]
+
+    client_so = sts.fresh_client(TestEntity.TEST, "SO")
+    so_id = sts.get_userinfo(client_so)["party_id"]
+
+    pts = list_product_type.sync(client=client_fiso)
+    assert isinstance(pts, list)
+
+    sopt = create_system_operator_product_type.sync(
+        client=client_fiso,
+        body=SystemOperatorProductTypeCreateRequest(
+            system_operator_id=so_id,
+            product_type_id=cast(int, pts[0].id),
+        ),
+    )
+    assert isinstance(sopt, SystemOperatorProductTypeResponse)
+
+    # insert with empty product_type_ids must fail
+    sppa = create_service_provider_product_application.sync(
+        client=client_sp,
+        body=ServiceProviderProductApplicationCreateRequest(
+            service_provider_id=sp_id,
+            system_operator_id=so_id,
+            product_type_ids=[],
+        ),
+    )
+    assert isinstance(sppa, ErrorMessage)
+
+    # but with a product type it's ok
+    sppa = create_service_provider_product_application.sync(
+        client=client_sp,
+        body=ServiceProviderProductApplicationCreateRequest(
+            service_provider_id=sp_id,
+            system_operator_id=so_id,
+            product_type_ids=[cast(int, pts[0].id)],
+        ),
+    )
+    assert isinstance(sppa, ServiceProviderProductApplicationResponse)
+
+    # update with empty product_type_ids must also fail
+    u = update_service_provider_product_application.sync(
+        client=client_fiso,
+        id=cast(int, sppa.id),
+        body=ServiceProviderProductApplicationUpdateRequest(
+            product_type_ids=[],
+        ),
+    )
+    assert isinstance(u, ErrorMessage)
+
+
 def test_sppa_common(sts):
     for role in sts.COMMON_ROLES:
         client = sts.get_client(TestEntity.TEST, role)

--- a/test/api_client_tests/test_spg_product_application.py
+++ b/test/api_client_tests/test_spg_product_application.py
@@ -595,6 +595,50 @@ def test_spgpa_fiso_sp_so(data):
         assert not (isinstance(d, ErrorMessage))
 
 
+# SPGPA-VAL009
+def test_spgpa_product_type_ids_not_empty(data):
+    (sts, spg_ids, _, client_sp, _, so_ids, pt_ids) = data
+
+    client_fiso = sts.get_client(TestEntity.TEST, "FISO")
+    so_id = so_ids[0]
+
+    # insert with empty product_type_ids must fail
+    e = create_service_providing_group_product_application.sync(
+        client=client_sp,
+        body=ServiceProvidingGroupProductApplicationCreateRequest(
+            service_providing_group_id=spg_ids[0],
+            procuring_system_operator_id=so_id,
+            product_type_ids=[],
+            maximum_active_power_up=3.5,
+            maximum_active_power_down=3.5,
+        ),
+    )
+    assert isinstance(e, ErrorMessage)
+
+    # but with a product type it's ok
+    spgpa = create_service_providing_group_product_application.sync(
+        client=client_sp,
+        body=ServiceProvidingGroupProductApplicationCreateRequest(
+            service_providing_group_id=spg_ids[0],
+            procuring_system_operator_id=so_id,
+            product_type_ids=[pt_ids[0]],
+            maximum_active_power_up=3.5,
+            maximum_active_power_down=3.5,
+        ),
+    )
+    assert isinstance(spgpa, ServiceProvidingGroupProductApplicationResponse)
+
+    # update with empty product_type_ids must also fail
+    u = update_service_providing_group_product_application.sync(
+        client=client_fiso,
+        id=cast(int, spgpa.id),
+        body=ServiceProvidingGroupProductApplicationUpdateRequest(
+            product_type_ids=[],
+        ),
+    )
+    assert isinstance(u, ErrorMessage)
+
+
 def test_spgpa_common(data):
     (sts, _, _, _, _, _, _) = data
 


### PR DESCRIPTION
This PR adds one trigger on `INSERT`/`UPDATE` per concerned resource. We just check the array is not empty, otherwise we reject the request.