### PR TITLE
fix(frontend): use react-router-dom for useLocation (FLEX-1322)

### DIFF
--- a/frontend/src/hooks/useLocationState.ts
+++ b/frontend/src/hooks/useLocationState.ts
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router";
+import { useLocation } from "react-router-dom";
 
 const useLocationState = <T>(): T | undefined => {
   const { state } = useLocation();


### PR DESCRIPTION
This PR changes the library we import the `useLocation` hook from. Apparently, `react-router` operates at a lower level, which caused some anomalies. We use `react-router-dom` instead and it fixed the issue: the hook now detects it is used in a proper "`Router` component". BTW we already use `react-router-dom` a lot of places in the app so it looks consistent.

NB: seems to fix both [FLEX-1322](https://elhub.atlassian.net/browse/FLEX-1322) and [FLEX-1318](https://elhub.atlassian.net/browse/FLEX-1318)

[FLEX-1322]: https://elhub.atlassian.net/browse/FLEX-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FLEX-1318]: https://elhub.atlassian.net/browse/FLEX-1318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ