### PR TITLE
chore: remove null-examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   ## Commits
   #
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
@@ -41,7 +41,7 @@ repos:
   ## Basics
   #
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: "(test/flex/.*)|(docs/.*)"
@@ -89,13 +89,13 @@ repos:
   ## YAML
   #
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
         args: []
         exclude: ^(local/scripts/templates/.*)|(mkdocs.yml)$
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.37.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         exclude: ^local/scripts/templates/.*$
@@ -108,7 +108,7 @@ repos:
       - id: check-json5
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: pretty-format-json
         args: ['--indent', '4', '--autofix', '--no-sort-keys', '--no-ensure-ascii']
@@ -116,7 +116,7 @@ repos:
   ## Markdown
   #
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.21.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint-cli2
         language_version: lts
@@ -125,7 +125,7 @@ repos:
   ## SQL
   #
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 3.4.0
+    rev: 4.2.2
     hooks:
       - id: sqlfluff-fix
         exclude: ^(backend/event/.*)|(backend/data/.*)|(.*j2\.sql)$
@@ -169,11 +169,11 @@ repos:
   ## Bash / Shell
   #
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: shellcheck
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.11.0-1
+    rev: v3.13.1-1
     hooks:
       - id: shfmt
   #
@@ -200,7 +200,7 @@ repos:
     hooks:
       - id: prettier
         additional_dependencies:
-          - prettier@3.4.2
+          - prettier@3.9.4
         name: prettier
         entry: prettier --write --ignore-unknown --print-width 80
         language: node
@@ -286,7 +286,7 @@ repos:
   ## Python
   #
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.11.8"
+    rev: "v0.15.20"
     hooks:
       - id: ruff-format
         exclude: "test/flex/.*"
@@ -295,7 +295,7 @@ repos:
         # test/flex is excluded because it is a generated directory
         exclude: "test/flex/.*"
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.400
+    rev: v1.1.411
     hooks:
       - id: pyright
         # test/flex is excluded because it is a generated directory
@@ -310,7 +310,7 @@ repos:
       - id: taplo-format
         exclude: "test/flex/.*"
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-toml
         exclude: "test/flex/.*"
@@ -336,7 +336,7 @@ repos:
   ## Secret linting
   #
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.2
+    rev: v8.30.0
     hooks:
       - id: gitleaks
         name: gitleaks

--- a/backend/auth/static/openapi.json
+++ b/backend/auth/static/openapi.json
@@ -87,16 +87,14 @@
                             "string",
                             "null"
                         ],
-                        "description": "Detailed information about the error.",
-                        "example": null
+                        "description": "Detailed information about the error."
                     },
                     "hint": {
                         "type": [
                             "string",
                             "null"
                         ],
-                        "description": "A hint to help resolve the error.",
-                        "example": null
+                        "description": "A hint to help resolve the error."
                     },
                     "message": {
                         "type": "string",

--- a/backend/data/static/openapi.json
+++ b/backend/data/static/openapi.json
@@ -217,16 +217,14 @@
                             "string",
                             "null"
                         ],
-                        "description": "Detailed information about the error.",
-                        "example": null
+                        "description": "Detailed information about the error."
                     },
                     "hint": {
                         "type": [
                             "string",
                             "null"
                         ],
-                        "description": "A hint to help resolve the error.",
-                        "example": null
+                        "description": "A hint to help resolve the error."
                     },
                     "message": {
                         "type": "string",
@@ -1145,8 +1143,7 @@
                         "description": "Free text field for extra information about the controllable unit if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 }
             },
@@ -1196,8 +1193,7 @@
                         "description": "Free text field for extra information about the controllable unit if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -1275,8 +1271,7 @@
                         "description": "Free text field for extra information about the controllable unit if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -2152,8 +2147,7 @@
                         "description": "Free text field for extra information about the service providing group if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 }
             },
@@ -2186,8 +2180,7 @@
                         "description": "Free text field for extra information about the service providing group if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -2232,8 +2225,7 @@
                         "description": "Free text field for extra information about the service providing group if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -2374,8 +2366,7 @@
                         "description": "The date until which the relation between the controllable unit and the service providing group is valid. Midnight aligned on Norwegian timezone.",
                         "format": "date-time",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 }
             },
@@ -2406,8 +2397,7 @@
                         "description": "The date until which the relation between the controllable unit and the service providing group is valid. Midnight aligned on Norwegian timezone.",
                         "format": "date-time",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -2450,8 +2440,7 @@
                         "description": "The date until which the relation between the controllable unit and the service providing group is valid. Midnight aligned on Norwegian timezone.",
                         "format": "date-time",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -3850,8 +3839,7 @@
                         "description": "Free text field for extra information about the technical resource if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 }
             },
@@ -3943,8 +3931,7 @@
                         "description": "Free text field for extra information about the technical resource if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -4062,8 +4049,7 @@
                         "description": "Free text field for extra information about the technical resource if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -4159,8 +4145,7 @@
                         "format": "text",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "notification": {
                         "description": "Embedded notification",
@@ -4496,8 +4481,7 @@
                         "format": "date-time",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "accounting_point": {
                         "description": "Embedded accounting_point",
@@ -4558,8 +4542,7 @@
                         "format": "date-time",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "accounting_point": {
                         "description": "Embedded accounting_point",
@@ -4611,8 +4594,7 @@
                         "format": "date-time",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "accounting_point": {
                         "description": "Embedded accounting_point",
@@ -4676,8 +4658,7 @@
                         "format": "date-time",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "accounting_point": {
                         "description": "Embedded accounting_point",
@@ -4800,8 +4781,7 @@
                         "format": "date-time",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "accounting_point": {
                         "description": "Embedded accounting_point",
@@ -4870,8 +4850,7 @@
                         "description": "Free text field for extra information about the grid location if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "quality": {
                         "$ref": "#/components/schemas/accounting_point_grid_location_quality"
@@ -4920,8 +4899,7 @@
                         "description": "Free text field for extra information about the grid location if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "quality": {
                         "$ref": "#/components/schemas/accounting_point_grid_location_quality"
@@ -4985,8 +4963,7 @@
                         "description": "Free text field for extra information about the grid location if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "source": {
                         "$ref": "#/components/schemas/accounting_point_grid_location_source",
@@ -5868,8 +5845,7 @@
                         "format": "text",
                         "type": "string",
                         "maxLength": 512,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "prequalified_at": {
                         "description": "When the product application was last prequalified.",
@@ -5962,8 +5938,7 @@
                         "format": "text",
                         "type": "string",
                         "maxLength": 512,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "prequalified_at": {
                         "description": "When the product application was last prequalified.",
@@ -6070,8 +6045,7 @@
                         "format": "text",
                         "type": "string",
                         "maxLength": 512,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "prequalified_at": {
                         "description": "When the product application was last prequalified.",
@@ -6746,8 +6720,7 @@
                         "description": "Free text field for extra information about the controllable unit if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -7089,8 +7062,7 @@
                         "description": "Free text field for extra information about the service providing group if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -7171,8 +7143,7 @@
                         "description": "The date until which the relation between the controllable unit and the service providing group is valid. Midnight aligned on Norwegian timezone.",
                         "format": "date-time",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -7824,8 +7795,7 @@
                         "description": "Free text field for extra information about the technical resource if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -7923,8 +7893,7 @@
                         "description": "Free text field for extra information about the grid location if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "source": {
                         "$ref": "#/components/schemas/accounting_point_grid_location_source",
@@ -8472,8 +8441,7 @@
                         "format": "text",
                         "type": "string",
                         "maxLength": 512,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "prequalified_at": {
                         "description": "When the product application was last prequalified.",

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -29,7 +29,6 @@ export default defineConfig([
     },
     rules: reactHooks.configs.recommended.rules,
   },
-  prettier,
   {
     languageOptions: {
       globals: {
@@ -68,4 +67,5 @@ export default defineConfig([
       ],
     },
   },
+  prettier,
 ]);

--- a/frontend/src/accounting_point/grid_location/AccountingPointGridLocationInput.tsx
+++ b/frontend/src/accounting_point/grid_location/AccountingPointGridLocationInput.tsx
@@ -73,7 +73,7 @@ const GridLocationFormFields = ({
         selectedSubstation.business_id !== currentBusinessId;
       if (isNewSubstation) setValue("nominal_voltage", null);
     }
-  }, [selectedSubstation, setValue]);
+  }, [selectedSubstation, currentBusinessId, setValue]);
 
   const nominalVoltage = watch("nominal_voltage");
 

--- a/frontend/src/auth/permissions.ts
+++ b/frontend/src/auth/permissions.ts
@@ -608,11 +608,7 @@ export type PermissionTarget =
   | "technical_resource_history.technology";
 
 export type PermissionOperation =
-  | "create"
-  | "delete"
-  | "lookup"
-  | "read"
-  | "update";
+  "create" | "delete" | "lookup" | "read" | "update";
 
 export type Permissions = {
   allow: (target: PermissionTarget, operation: PermissionOperation) => boolean;

--- a/frontend/src/controllable_unit/show/useControllableUnitViewModel.ts
+++ b/frontend/src/controllable_unit/show/useControllableUnitViewModel.ts
@@ -33,8 +33,7 @@ export type ControllableUnitShowViewModel = {
   suspensions: ControllableUnitSuspension[] | undefined;
   balanceResponsibleParty: Party | undefined;
   accountingPointBalanceResponsibleParty:
-    | AccountingPointBalanceResponsibleParty
-    | undefined;
+    AccountingPointBalanceResponsibleParty | undefined;
   biddingZone: string | undefined;
   meteringGridArea: MeteringGridArea | undefined;
   energySupplier: Party | undefined;

--- a/frontend/src/generated-client/client/client.gen.ts
+++ b/frontend/src/generated-client/client/client.gen.ts
@@ -67,8 +67,7 @@ export const createClient = (config: Config = {}): Client => {
 
     if (opts.body !== undefined && opts.bodySerializer) {
       opts.serializedBody = opts.bodySerializer(opts.body) as
-        | string
-        | undefined;
+        string | undefined;
     }
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
@@ -263,9 +262,7 @@ export const createClient = (config: Config = {}): Client => {
           return request;
         },
         serializedBody: getValidRequestBody(opts) as
-          | BodyInit
-          | null
-          | undefined,
+          BodyInit | null | undefined,
         url,
       });
     };

--- a/frontend/src/generated-client/client/types.gen.ts
+++ b/frontend/src/generated-client/client/types.gen.ts
@@ -42,13 +42,7 @@ export interface Config<T extends ClientOptions = ClientOptions>
    * @default 'auto'
    */
   parseAs?:
-    | "arrayBuffer"
-    | "auto"
-    | "blob"
-    | "formData"
-    | "json"
-    | "stream"
-    | "text";
+    "arrayBuffer" | "auto" | "blob" | "formData" | "json" | "stream" | "text";
   /**
    * Should we return only data or multiple fields (data, error, response, etc.)?
    *
@@ -128,11 +122,8 @@ export type RequestResult<
     >
   : Promise<
       TResponseStyle extends "data"
-        ?
-            | (TData extends Record<string, unknown>
-                ? TData[keyof TData]
-                : TData)
-            | undefined
+        ? | (TData extends Record<string, unknown> ? TData[keyof TData] : TData)
+          | undefined
         : (
             | {
                 data: TData extends Record<string, unknown>

--- a/frontend/src/generated-client/core/params.gen.ts
+++ b/frontend/src/generated-client/core/params.gen.ts
@@ -88,16 +88,15 @@ function buildKeyMap(fields: FieldsConfig, map?: KeyMap): KeyMap {
 }
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
 }
 
-type ParamsSlotMap = Record<Slot, unknown>;
-
-function stripEmptySlots(params: ParamsSlotMap): void {
+function stripEmptySlots(params: Params): void {
   for (const [slot, value] of Object.entries(params)) {
+    if (slot === "body") continue;
     if (
       value &&
       typeof value === "object" &&
@@ -113,14 +112,22 @@ export function buildClientParams(
   args: ReadonlyArray<unknown>,
   fields: FieldsConfig,
 ): Params {
-  const params: ParamsSlotMap = {
-    body: Object.create(null),
+  const params: Params = {
     headers: Object.create(null),
     path: Object.create(null),
     query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);
+
+  function writeSlot(slot: Slot, key: string, value: unknown): void {
+    let record = params[slot] as Record<string, unknown> | undefined;
+    if (record === undefined) {
+      record = Object.create(null) as Record<string, unknown>;
+      params[slot] = record;
+    }
+    record[key] = value;
+  }
 
   let config: FieldsConfig[number] | undefined;
 
@@ -138,7 +145,7 @@ export function buildClientParams(
         const field = map.get(config.key)!;
         const name = field.map || config.key;
         if (field.in) {
-          (params[field.in] as Record<string, unknown>)[name] = arg;
+          writeSlot(field.in, name, arg);
         }
       } else {
         params.body = arg;
@@ -150,7 +157,7 @@ export function buildClientParams(
         if (field) {
           if (field.in) {
             const name = field.map || key;
-            (params[field.in] as Record<string, unknown>)[name] = value;
+            writeSlot(field.in, name, value);
           } else {
             params[field.map] = value;
           }
@@ -161,13 +168,11 @@ export function buildClientParams(
 
           if (extra) {
             const [prefix, slot] = extra;
-            (params[slot] as Record<string, unknown>)[
-              key.slice(prefix.length)
-            ] = value;
+            writeSlot(slot, key.slice(prefix.length), value);
           } else if ("allowExtra" in config && config.allowExtra) {
             for (const [slot, allowed] of Object.entries(config.allowExtra)) {
               if (allowed) {
-                (params[slot as Slot] as Record<string, unknown>)[key] = value;
+                writeSlot(slot as Slot, key, value);
                 break;
               }
             }
@@ -179,5 +184,5 @@ export function buildClientParams(
 
   stripEmptySlots(params);
 
-  return params as Params;
+  return params;
 }

--- a/frontend/src/generated-client/core/queryKeySerializer.gen.ts
+++ b/frontend/src/generated-client/core/queryKeySerializer.gen.ts
@@ -4,12 +4,7 @@
  * JSON-friendly union that mirrors what Pinia Colada can hash.
  */
 export type JsonValue =
-  | null
-  | string
-  | number
-  | boolean
-  | JsonValue[]
-  | { [key: string]: JsonValue };
+  null | string | number | boolean | JsonValue[] | { [key: string]: JsonValue };
 
 /**
  * Replacer that converts non-JSON values (bigint, Date, etc.) to safe substitutes.

--- a/frontend/src/generated-client/core/types.gen.ts
+++ b/frontend/src/generated-client/core/types.gen.ts
@@ -118,7 +118,9 @@ type IsExactlyNeverOrNeverUndefined<T> = [T] extends [never]
     : false;
 
 export type OmitNever<T extends Record<string, unknown>> = {
-  [K in keyof T as IsExactlyNeverOrNeverUndefined<T[K]> extends true
-    ? never
-    : K]: T[K];
+  [
+    K in keyof T as IsExactlyNeverOrNeverUndefined<T[K]> extends true
+      ? never
+      : K
+  ]: T[K];
 };

--- a/frontend/src/generated-client/types.gen.ts
+++ b/frontend/src/generated-client/types.gen.ts
@@ -309,10 +309,7 @@ export type EmptyObject = {
  * The status of the controllable unit.
  */
 export type ControllableUnitStatus =
-  | "new"
-  | "active"
-  | "inactive"
-  | "terminated";
+  "new" | "active" | "inactive" | "terminated";
 
 /**
  * The regulation direction of the controllable unit. `up` means it can be used to increase production or decrease consumption, while `down` means to decrease production or increase consumption.
@@ -323,34 +320,25 @@ export type ControllableUnitRegulationDirection = "up" | "down" | "both";
  * The reason for the suspension.
  */
 export type ControllableUnitSuspensionReason =
-  | "compromises_safe_operation"
-  | "other";
+  "compromises_safe_operation" | "other";
 
 /**
  * The level of visibility of the comment.
  */
 export type ControllableUnitSuspensionCommentVisibility =
-  | "same_party"
-  | "any_involved_party";
+  "same_party" | "any_involved_party";
 
 /**
  * The bidding zone that restricts which CUs that can be added to the group. Also known as scheduling area or price area for TSO.
  */
 export type ServiceProvidingGroupBiddingZone =
-  | "NO1"
-  | "NO2"
-  | "NO3"
-  | "NO4"
-  | "NO5";
+  "NO1" | "NO2" | "NO3" | "NO4" | "NO5";
 
 /**
  * The status of the group.
  */
 export type ServiceProvidingGroupStatus =
-  | "new"
-  | "active"
-  | "inactive"
-  | "terminated";
+  "new" | "active" | "inactive" | "terminated";
 
 /**
  * The status of the grid prequalification for this service providing group.
@@ -366,23 +354,19 @@ export type ServiceProvidingGroupGridPrequalificationStatus =
  * The level of visibility of the comment.
  */
 export type ServiceProvidingGroupGridPrequalificationCommentVisibility =
-  | "same_party"
-  | "any_involved_party";
+  "same_party" | "any_involved_party";
 
 /**
  * The reason for the suspension.
  */
 export type ServiceProvidingGroupGridSuspensionReason =
-  | "breach_of_conditions"
-  | "significant_group_change"
-  | "other";
+  "breach_of_conditions" | "significant_group_change" | "other";
 
 /**
  * The level of visibility of the comment.
  */
 export type ServiceProvidingGroupGridSuspensionCommentVisibility =
-  | "same_party"
-  | "any_involved_party";
+  "same_party" | "any_involved_party";
 
 /**
  * The type of the business identifier.
@@ -431,11 +415,7 @@ export type PartyType =
  * The status of the party.
  */
 export type PartyStatus =
-  | "new"
-  | "active"
-  | "inactive"
-  | "suspended"
-  | "terminated";
+  "new" | "active" | "inactive" | "suspended" | "terminated";
 
 /**
  * The type of business identifier used for the device.
@@ -446,18 +426,13 @@ export type TechnicalResourceBusinessIdType = "serial_number" | "mac" | "other";
  * The direction of the effect on the balance that the BRP takes responsibility for.
  */
 export type AccountingPointBalanceResponsiblePartyEnergyDirection =
-  | "consumption"
-  | "production";
+  "consumption" | "production";
 
 /**
  * The bidding zone of the accounting point.
  */
 export type AccountingPointBiddingZoneBiddingZone =
-  | "NO1"
-  | "NO2"
-  | "NO3"
-  | "NO4"
-  | "NO5";
+  "NO1" | "NO2" | "NO3" | "NO4" | "NO5";
 
 /**
  * The type of the business identifier.
@@ -478,10 +453,7 @@ export type AccountingPointGridLocationObjectType = "substation";
  * How the grid location was determined. When a system operator creates or updates a grid location, this field is set automatically: `cso` if the SO is the connecting system operator, `so` otherwise.
  */
 export type AccountingPointGridLocationSource =
-  | "cso"
-  | "so"
-  | "grid_model"
-  | "system";
+  "cso" | "so" | "grid_model" | "system";
 
 /**
  * The quality of the grid location registration.
@@ -507,8 +479,7 @@ export type ServiceProviderProductApplicationStatus =
  * The level of visibility of the comment.
  */
 export type ServiceProviderProductApplicationCommentVisibility =
-  | "same_party"
-  | "any_involved_party";
+  "same_party" | "any_involved_party";
 
 /**
  * The reason for the suspension.
@@ -525,8 +496,7 @@ export type ServiceProviderProductSuspensionReason =
  * The level of visibility of the comment.
  */
 export type ServiceProviderProductSuspensionCommentVisibility =
-  | "same_party"
-  | "any_involved_party";
+  "same_party" | "any_involved_party";
 
 /**
  * The status of the application.
@@ -543,30 +513,25 @@ export type ServiceProvidingGroupProductApplicationStatus =
  * The ramping capability of the service providing group for this product application.
  */
 export type ServiceProvidingGroupProductApplicationRampingCapability =
-  | "always"
-  | "partial"
-  | "never";
+  "always" | "partial" | "never";
 
 /**
  * The level of visibility of the comment.
  */
 export type ServiceProvidingGroupProductApplicationCommentVisibility =
-  | "same_party"
-  | "any_involved_party";
+  "same_party" | "any_involved_party";
 
 /**
  * The reason for the suspension.
  */
 export type ServiceProvidingGroupProductSuspensionReason =
-  | "failed_verification"
-  | "other";
+  "failed_verification" | "other";
 
 /**
  * The level of visibility of the comment.
  */
 export type ServiceProvidingGroupProductSuspensionCommentVisibility =
-  | "same_party"
-  | "any_involved_party";
+  "same_party" | "any_involved_party";
 
 /**
  * The status of the notice.

--- a/frontend/src/generated-client/zod.gen.ts
+++ b/frontend/src/generated-client/zod.gen.ts
@@ -1813,18 +1813,10 @@ export const zNoticeDataPartyOutdated = z.object({
 });
 
 export const zNoticeData = z.discriminatedUnion("kind", [
-  zNoticeDataValidTimeOutsideContract.extend({
-    kind: z.literal("notice.data.valid_time.outside_contract"),
-  }),
-  zNoticeDataPartyMissing.extend({
-    kind: z.literal("notice.data.party.missing"),
-  }),
-  zNoticeDataPartyOutdated.extend({
-    kind: z.literal("notice.data.party.outdated"),
-  }),
-  zNoticeDataProductTypeNotQualified.extend({
-    kind: z.literal("notice.data.product_type.not_qualified"),
-  }),
+  zNoticeDataValidTimeOutsideContract,
+  zNoticeDataPartyMissing,
+  zNoticeDataPartyOutdated,
+  zNoticeDataProductTypeNotQualified,
 ]);
 
 /**
@@ -2591,18 +2583,10 @@ export const zNoticeDataPartyOutdatedWritable = z.object({
 });
 
 export const zNoticeDataWritable = z.discriminatedUnion("kind", [
-  zNoticeDataValidTimeOutsideContract.extend({
-    kind: z.literal("notice.data.valid_time.outside_contract"),
-  }),
-  zNoticeDataPartyMissingWritable.extend({
-    kind: z.literal("notice.data.party.missing"),
-  }),
-  zNoticeDataPartyOutdatedWritable.extend({
-    kind: z.literal("notice.data.party.outdated"),
-  }),
-  zNoticeDataProductTypeNotQualified.extend({
-    kind: z.literal("notice.data.product_type.not_qualified"),
-  }),
+  zNoticeDataValidTimeOutsideContract,
+  zNoticeDataPartyMissingWritable,
+  zNoticeDataPartyOutdatedWritable,
+  zNoticeDataProductTypeNotQualified,
 ]);
 
 /**

--- a/openapi/openapi-api-base.yml
+++ b/openapi/openapi-api-base.yml
@@ -55,11 +55,9 @@ components:
         details:
           type: [string, "null"]
           description: Detailed information about the error.
-          example: null
         hint:
           type: [string, "null"]
           description: A hint to help resolve the error.
-          example: null
         message:
           type: string
           description: The error message.

--- a/openapi/openapi-api-no-default.json
+++ b/openapi/openapi-api-no-default.json
@@ -203,16 +203,14 @@
                             "string",
                             "null"
                         ],
-                        "description": "Detailed information about the error.",
-                        "example": null
+                        "description": "Detailed information about the error."
                     },
                     "hint": {
                         "type": [
                             "string",
                             "null"
                         ],
-                        "description": "A hint to help resolve the error.",
-                        "example": null
+                        "description": "A hint to help resolve the error."
                     },
                     "message": {
                         "type": "string",
@@ -1114,8 +1112,7 @@
                         "description": "Free text field for extra information about the controllable unit if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 }
             },
@@ -1164,8 +1161,7 @@
                         "description": "Free text field for extra information about the controllable unit if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -1242,8 +1238,7 @@
                         "description": "Free text field for extra information about the controllable unit if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -2115,8 +2110,7 @@
                         "description": "Free text field for extra information about the service providing group if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 }
             },
@@ -2148,8 +2142,7 @@
                         "description": "Free text field for extra information about the service providing group if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -2193,8 +2186,7 @@
                         "description": "Free text field for extra information about the service providing group if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -2335,8 +2327,7 @@
                         "description": "The date until which the relation between the controllable unit and the service providing group is valid. Midnight aligned on Norwegian timezone.",
                         "format": "date-time",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 }
             },
@@ -2367,8 +2358,7 @@
                         "description": "The date until which the relation between the controllable unit and the service providing group is valid. Midnight aligned on Norwegian timezone.",
                         "format": "date-time",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -2411,8 +2401,7 @@
                         "description": "The date until which the relation between the controllable unit and the service providing group is valid. Midnight aligned on Norwegian timezone.",
                         "format": "date-time",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -3797,8 +3786,7 @@
                         "description": "Free text field for extra information about the technical resource if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 }
             },
@@ -3890,8 +3878,7 @@
                         "description": "Free text field for extra information about the technical resource if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -4009,8 +3996,7 @@
                         "description": "Free text field for extra information about the technical resource if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -4106,8 +4092,7 @@
                         "format": "text",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "notification": {
                         "description": "Embedded notification",
@@ -4443,8 +4428,7 @@
                         "format": "date-time",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "accounting_point": {
                         "description": "Embedded accounting_point",
@@ -4505,8 +4489,7 @@
                         "format": "date-time",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "accounting_point": {
                         "description": "Embedded accounting_point",
@@ -4558,8 +4541,7 @@
                         "format": "date-time",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "accounting_point": {
                         "description": "Embedded accounting_point",
@@ -4623,8 +4605,7 @@
                         "format": "date-time",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "accounting_point": {
                         "description": "Embedded accounting_point",
@@ -4747,8 +4728,7 @@
                         "format": "date-time",
                         "type": "string",
                         "readOnly": true,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "accounting_point": {
                         "description": "Embedded accounting_point",
@@ -4817,8 +4797,7 @@
                         "description": "Free text field for extra information about the grid location if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "quality": {
                         "$ref": "#/components/schemas/accounting_point_grid_location_quality"
@@ -4867,8 +4846,7 @@
                         "description": "Free text field for extra information about the grid location if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "quality": {
                         "$ref": "#/components/schemas/accounting_point_grid_location_quality"
@@ -4932,8 +4910,7 @@
                         "description": "Free text field for extra information about the grid location if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "source": {
                         "$ref": "#/components/schemas/accounting_point_grid_location_source",
@@ -5802,8 +5779,7 @@
                         "format": "text",
                         "type": "string",
                         "maxLength": 512,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "prequalified_at": {
                         "description": "When the product application was last prequalified.",
@@ -5895,8 +5871,7 @@
                         "format": "text",
                         "type": "string",
                         "maxLength": 512,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "prequalified_at": {
                         "description": "When the product application was last prequalified.",
@@ -6002,8 +5977,7 @@
                         "format": "text",
                         "type": "string",
                         "maxLength": 512,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "prequalified_at": {
                         "description": "When the product application was last prequalified.",
@@ -6670,8 +6644,7 @@
                         "description": "Free text field for extra information about the controllable unit if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -7011,8 +6984,7 @@
                         "description": "Free text field for extra information about the service providing group if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -7093,8 +7065,7 @@
                         "description": "The date until which the relation between the controllable unit and the service providing group is valid. Midnight aligned on Norwegian timezone.",
                         "format": "date-time",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -7741,8 +7712,7 @@
                         "description": "Free text field for extra information about the technical resource if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "recorded_at": {
                         "description": "When the resource was recorded (created or updated) in the system.",
@@ -7840,8 +7810,7 @@
                         "description": "Free text field for extra information about the grid location if needed.",
                         "format": "text",
                         "type": "string",
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "source": {
                         "$ref": "#/components/schemas/accounting_point_grid_location_source",
@@ -8384,8 +8353,7 @@
                         "format": "text",
                         "type": "string",
                         "maxLength": 512,
-                        "nullable": true,
-                        "example": null
+                        "nullable": true
                     },
                     "prequalified_at": {
                         "description": "When the product application was last prequalified.",

--- a/openapi/openapi-auth.yml
+++ b/openapi/openapi-auth.yml
@@ -68,11 +68,9 @@ components:
         details:
           type: [string, 'null']
           description: Detailed information about the error.
-          example: null
         hint:
           type: [string, 'null']
           description: A hint to help resolve the error.
-          example: null
         message:
           type: string
           description: The error message.

--- a/openapi/resources.yml
+++ b/openapi/resources.yml
@@ -181,7 +181,6 @@ resources:
         format: text
         type: string
         nullable: true
-        example:
         x-intl:
           en: Additional information
           nb: Tilleggsinformasjon
@@ -809,7 +808,6 @@ resources:
         format: text
         type: string
         nullable: true
-        example:
         x-intl:
           en: Additional information
           nb: Tilleggsinformasjon
@@ -902,7 +900,6 @@ resources:
         type: string
         x-filter: true
         nullable: true
-        example:
         x-intl:
           en: Valid to
           nb: Gyldig til
@@ -2006,7 +2003,6 @@ resources:
         format: text
         type: string
         nullable: true
-        example:
         x-intl:
           en: Additional information
           nb: Tilleggsinformasjon
@@ -2105,7 +2101,6 @@ resources:
         type: string
         readOnly: true
         nullable: true
-        example:
         x-intl:
           en: Data
           nb: Data
@@ -2349,7 +2344,6 @@ resources:
         readOnly: true
         x-filter: true
         nullable: true
-        example:
         x-intl:
           en: Valid to
           nb: Gyldig til
@@ -2444,7 +2438,6 @@ resources:
         readOnly: true
         nullable: true
         x-filter: true
-        example:
         x-intl:
           en: Valid to
           nb: Gyldig til
@@ -2517,7 +2510,6 @@ resources:
         type: string
         readOnly: true
         nullable: true
-        example:
         x-filter: true
         x-intl:
           en: Valid to
@@ -2593,7 +2585,6 @@ resources:
         readOnly: true
         x-filter: true
         nullable: true
-        example:
         x-intl:
           en: Valid to
           nb: Gyldig til
@@ -2761,7 +2752,6 @@ resources:
         type: string
         readOnly: true
         nullable: true
-        example:
         x-filter: true
         x-intl:
           en: Valid to
@@ -3331,7 +3321,6 @@ resources:
         format: text
         type: string
         nullable: true
-        example:
         x-intl:
           en: Additional information
           nb: Tilleggsinformasjon
@@ -3963,7 +3952,6 @@ resources:
         type: string
         maxLength: 512
         nullable: true
-        example:
         x-intl:
           en: Additional information
           nb: Tilleggsinformasjon


### PR DESCRIPTION
On my fresh dev setup I noticed two things:

1. openapi generation failed on the null example values similar to this: https://github.com/stoplightio/spectral/issues/1981
2. eslint and prettier was in conflict on some formatting stuff in pre-commit

I'm guessing that both of these are due to my setup being with slightly newer versions of the tools. This does not fix that underlying issue, but makes things "work on my machine" ...