### PR TITLE
fix: run failing test first

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "psycopg[binary,pool]",
   "pyjwt",
   "pytest",
+  "pytest-ordering",
   "python-dotenv",
   "ruff",
   "schemathesis",

--- a/test/api_client_tests/test_accounting_point_balance_responsible_party.py
+++ b/test/api_client_tests/test_accounting_point_balance_responsible_party.py
@@ -56,6 +56,8 @@ def test_apbrp_so(sts):
 
 
 # RLS: APBRP-SP001
+# This test must run first since it depends on the test data being in a certain state
+@pytest.mark.first
 def test_apbrp_sp(sts):
     client_sp = sts.get_client(TestEntity.TEST, "SP")
 

--- a/uv.lock
+++ b/uv.lock
@@ -383,6 +383,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pyjwt" },
     { name = "pytest" },
+    { name = "pytest-ordering" },
     { name = "python-dotenv" },
     { name = "ruff" },
     { name = "schemathesis" },
@@ -406,6 +407,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary", "pool"] },
     { name = "pyjwt" },
     { name = "pytest" },
+    { name = "pytest-ordering" },
     { name = "python-dotenv" },
     { name = "ruff" },
     { name = "schemathesis" },
@@ -1216,6 +1218,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-ordering"
+version = "0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/ba/65091c36e6e18da479d22d860586e3ba3a4237cc92a66e3ddd945e4fe761/pytest-ordering-0.6.tar.gz", hash = "sha256:561ad653626bb171da78e682f6d39ac33bb13b3e272d406cd555adb6b006bda6", size = 2629, upload-time = "2018-11-14T00:55:26.004Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/98/adc368fe369465f291ab24e18b9900473786ed1afdf861ba90467eb0767e/pytest_ordering-0.6-py3-none-any.whl", hash = "sha256:3f314a178dbeb6777509548727dc69edf22d6d9a2867bf2d310ab85c403380b6", size = 4643, upload-time = "2018-10-25T16:25:18.445Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Tests where collected in a different order on my new setup, resulting in a failing test. Specifying it to run first fixes that.