### PR TITLE
feat: New print page for SPG PA with simpler layout (FLEX-968)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -640,9 +640,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -836,29 +836,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/hey-api"
-            }
-        },
-        "node_modules/@hey-api/json-schema-ref-parser/node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/nodeca"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@hey-api/openapi-ts": {
@@ -4250,9 +4227,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.16",
+            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6188,9 +6165,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -7017,6 +6994,29 @@
             "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "license": "MIT"
+        },
+        "node_modules/js-yaml": {
+            "version": "4.3.0",
+            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
         },
         "node_modules/jsesc": {
             "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,5 +64,8 @@
         "typescript": "6.0.3",
         "typescript-eslint": "8.63.0",
         "vite": "8.1.4"
+    },
+    "overrides": {
+        "js-yaml": "4.3.0"
     }
 }

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -6,7 +6,7 @@ import { Link } from "../ui";
 
 export const Header = () => {
   return (
-    <DSHeader className="w-full p-0">
+    <DSHeader className="w-full p-0 print:hidden">
       <div className="flex h-12 items-center justify-between bg-semantic-background-action-primary px-7">
         <Link
           className="flex items-center gap-2 h-10"

--- a/frontend/src/resources/serviceProvidingGroupResources.tsx
+++ b/frontend/src/resources/serviceProvidingGroupResources.tsx
@@ -24,6 +24,7 @@ import { ServiceProvidingGroupGridPrequalificationList } from "../service_provid
 import { ServiceProvidingGroupProductApplicationInput } from "../service_providing_group/product_application/ServiceProvidingGroupProductApplicationInput";
 import { ServiceProvidingGroupProductApplicationShow } from "../service_providing_group/product_application/ServiceProvidingGroupProductApplicationShow";
 import { ServiceProvidingGroupProductApplicationHistoryList } from "../service_providing_group/product_application/ServiceProvidingGroupProductApplicationHistoryList";
+import { ServiceProvidingGroupProductApplicationPrint } from "../service_providing_group/product_application/print/ServiceProvidingGroupProductApplicationPrint";
 import { ServiceProvidingGroupProductSuspensionInput } from "../service_providing_group/product_suspension/ServiceProvidingGroupProductSuspensionInput";
 import { ServiceProvidingGroupProductSuspensionShow } from "../service_providing_group/product_suspension/ServiceProvidingGroupProductSuspensionShow";
 import { ServiceProvidingGroupProductSuspensionHistoryList } from "../service_providing_group/product_suspension/ServiceProvidingGroupProductSuspensionHistoryList";
@@ -174,6 +175,14 @@ export const createServiceProvidingGroupResources = (
           element={
             <ResourceContextProvider value="service_providing_group_product_application">
               <ServiceProvidingGroupProductApplicationShow />
+            </ResourceContextProvider>
+          }
+        />
+        <Route
+          path=":service_providing_group_id/product_application/:id/print"
+          element={
+            <ResourceContextProvider value="service_providing_group_product_application">
+              <ServiceProvidingGroupProductApplicationPrint />
             </ResourceContextProvider>
           }
         />
@@ -460,6 +469,10 @@ export const createServiceProvidingGroupResources = (
               <ServiceProvidingGroupProductApplicationShow />
             </ResourceContextProvider>
           }
+        />
+        <Route
+          path=":id/print"
+          element={<ServiceProvidingGroupProductApplicationPrint />}
         />
       </Resource>,
     );

--- a/frontend/src/service_providing_group/product_application/print/ServiceProvidingGroupProductApplicationPrint.tsx
+++ b/frontend/src/service_providing_group/product_application/print/ServiceProvidingGroupProductApplicationPrint.tsx
@@ -1,0 +1,119 @@
+import { useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { Heading } from "../../../components/ui";
+import { useSpgpaRecord } from "../show/useSpgpaShowViewModel";
+import {
+  useServiceProvidingGroup,
+  useSpgShowViewModel,
+} from "../../show/useSpgShowViewModel";
+import { useTranslateEnum } from "../../../intl/intl";
+import { useParty } from "../../../hooks/party";
+import { useProductTypes } from "../../../product_type/useProductTypes";
+import { useSpgpaComments } from "../show/useSpgpaComments";
+import { displayProductType } from "../../../product_type/components";
+import { SpgpaPrintSummary } from "./SpgpaPrintSummary";
+import { SpgpaPrintSpgInfo } from "./SpgpaPrintSpgInfo";
+import { SpgpaPrintComments } from "./SpgpaPrintComments";
+
+export const ServiceProvidingGroupProductApplicationPrint = () => {
+  const spgpaId = Number(useParams<{ id: string }>().id);
+  const translateEnum = useTranslateEnum();
+
+  // --- Fetch all data upfront ---
+  const spgpaQuery = useSpgpaRecord(spgpaId);
+  const spgpa = spgpaQuery.data;
+
+  const spgQuery = useServiceProvidingGroup(spgpa?.service_providing_group_id);
+  const spg = spgQuery.data;
+
+  const spgViewModelQuery = useSpgShowViewModel(
+    spgpa?.service_providing_group_id,
+  );
+  const spgViewModel = spgViewModelQuery.data;
+
+  const psoQuery = useParty(spgpa?.procuring_system_operator_id);
+
+  const productTypesQuery = useProductTypes();
+  const productTypeNames = productTypesQuery.data
+    ?.filter((pt) => spgpa?.product_type_ids.includes(pt.id))
+    .map((pt) => displayProductType(pt))
+    .join(", ");
+
+  const commentsQuery = useSpgpaComments(spgpaId);
+
+  // All queries must be settled before printing
+  const allLoaded =
+    !spgpaQuery.isPending &&
+    !spgQuery.isPending &&
+    !spgViewModelQuery.isPending &&
+    !psoQuery.isPending &&
+    !productTypesQuery.isPending &&
+    !commentsQuery.commentsQuery.isPending;
+
+  useEffect(() => {
+    if (allLoaded) {
+      window.print();
+    }
+  }, [allLoaded]);
+
+  // --- Error handling ---
+  if (spgpaQuery.error) throw spgpaQuery.error;
+  if (spgQuery.error) throw spgQuery.error;
+  if (spgViewModelQuery.error) throw spgViewModelQuery.error;
+  if (psoQuery.error) throw psoQuery.error;
+  if (commentsQuery.commentsQuery.error)
+    throw commentsQuery.commentsQuery.error;
+
+  if (!allLoaded) {
+    return (
+      <div className="flex items-center justify-center h-screen text-gray-500">
+        Preparing print view…
+      </div>
+    );
+  }
+
+  if (!spgpa || !spg || !spgViewModel) return null;
+
+  const statusLabel = translateEnum(
+    `service_providing_group_product_application.status.${spgpa.status}`,
+  );
+
+  return (
+    <div className="max-w-4xl mx-auto p-8 flex flex-col gap-8">
+      {/* Page header */}
+      <div className="flex flex-col gap-2 border-b pb-4">
+        <Heading size="xlarge">
+          Product Application #{spgpa.id} for {spg.name}
+        </Heading>
+        <div className="flex items-center gap-2 text-sm text-gray-600">
+          <span className="font-semibold">Status:</span>
+          <span>{statusLabel}</span>
+        </div>
+      </div>
+
+      {/* Application details */}
+      <section className="flex flex-col gap-2">
+        <Heading size="large">Application details</Heading>
+        <SpgpaPrintSummary
+          spgpa={spgpa}
+          spgName={spg.name}
+          spgId={spg.id}
+          psoName={psoQuery.data?.name}
+          productTypeNames={productTypeNames}
+        />
+      </section>
+
+      {/* SPG info */}
+      <section className="flex flex-col gap-2">
+        <Heading size="large">Service providing group info</Heading>
+        <SpgpaPrintSpgInfo spg={spg} spgViewModel={spgViewModel} />
+      </section>
+
+      {/* Comments */}
+      <section className="flex flex-col gap-2">
+        <Heading size="large">Comments</Heading>
+        <SpgpaPrintComments comments={commentsQuery.commentsQuery.data ?? []} />
+      </section>
+    </div>
+  );
+};

--- a/frontend/src/service_providing_group/product_application/print/SpgpaPrintComments.tsx
+++ b/frontend/src/service_providing_group/product_application/print/SpgpaPrintComments.tsx
@@ -1,0 +1,40 @@
+import { Comment } from "../../../components/comments/types";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+type Props = {
+  comments: Comment[];
+};
+
+export const SpgpaPrintComments = ({ comments }: Props) => {
+  const visibleComments = comments.filter(
+    (c) => c.visibility === "any_involved_party",
+  );
+
+  if (visibleComments.length === 0) {
+    return <p className="text-sm text-gray-400 py-4">No comments.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {visibleComments.map((comment) => (
+        <div key={comment.id} className="flex flex-col border-b pb-4">
+          <span className="text-xs text-gray-400 mb-1">
+            {formatDate(comment.created_at)}
+          </span>
+          <div className="text-base text-gray-700 whitespace-pre-wrap">
+            {comment.content}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/service_providing_group/product_application/print/SpgpaPrintCuSummary.tsx
+++ b/frontend/src/service_providing_group/product_application/print/SpgpaPrintCuSummary.tsx
@@ -1,0 +1,67 @@
+import { Heading } from "../../../components/ui";
+import { LabelValue } from "../../../components/LabelValue";
+import type { ServiceProvidingGroupSummary } from "../../../generated-client";
+import type { SpgShowViewModel } from "../../show/useSpgShowViewModel";
+
+type Props = {
+  spgViewModel: SpgShowViewModel;
+  summary: ServiceProvidingGroupSummary;
+};
+
+export const SpgpaPrintCuSummary = ({ spgViewModel, summary }: Props) => {
+  const cu = summary.controllable_unit;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Heading size="large">Controllable units summary</Heading>
+      <p>
+        This service providing group contains <b>{cu.count ?? 0}</b>{" "}
+        controllable units. Here are the aggregates computed across all of them,
+        taking into account all technical resources they contain:
+      </p>
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <LabelValue
+          label="Aggregated rated power"
+          value={cu.maximum_active_power?.sum ?? 0}
+          unit="kW"
+        />
+        <LabelValue
+          label="Average rated power"
+          value={
+            cu.maximum_active_power?.average
+              ? Math.round(cu.maximum_active_power.average * 100) / 100
+              : 0
+          }
+          unit="kW"
+        />
+        <LabelValue
+          label="Minimum rated power"
+          value={cu.maximum_active_power?.min ?? 0}
+          unit="kW"
+        />
+        <LabelValue
+          label="Maximum rated power"
+          value={cu.maximum_active_power?.max ?? 0}
+          unit="kW"
+        />
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <LabelValue
+          label="Aggregated flexible power"
+          value={spgViewModel.totalCapacityKw}
+          unit="kW"
+        />
+        <LabelValue
+          label="Aggregated flexible power (down)"
+          value={spgViewModel.consumptionCapacityKw}
+          unit="kW"
+        />
+        <LabelValue
+          label="Aggregated flexible power (up)"
+          value={spgViewModel.productionCapacityKw}
+          unit="kW"
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/service_providing_group/product_application/print/SpgpaPrintSpgInfo.tsx
+++ b/frontend/src/service_providing_group/product_application/print/SpgpaPrintSpgInfo.tsx
@@ -1,0 +1,160 @@
+import { Heading } from "../../../components/ui";
+import { LabelValue } from "../../../components/LabelValue";
+import { useTranslateEnum } from "../../../intl/intl";
+import { ServiceProvidingGroup } from "../../../generated-client";
+import type { SpgShowViewModel } from "../../show/useSpgShowViewModel";
+import { SpgpaPrintCuSummary } from "./SpgpaPrintCuSummary";
+import { Column, SimpleTable } from "../../../components/SimpleTable";
+import type { Technology } from "../../../generated-client";
+
+type TechnologyRow = {
+  id: string;
+  technology: string;
+  count: number;
+  sum: number;
+  average: number;
+  min: number | undefined;
+  max: number | undefined;
+};
+
+const formatKw = (value: number | undefined) =>
+  value !== undefined ? `${Math.round(value * 100) / 100} kW` : "-";
+
+type Props = {
+  spg: ServiceProvidingGroup;
+  spgViewModel: SpgShowViewModel;
+};
+
+export const SpgpaPrintSpgInfo = ({ spg, spgViewModel }: Props) => {
+  const translateEnum = useTranslateEnum();
+
+  const statusLabel = translateEnum(
+    `service_providing_group.status.${spg.status}`,
+  );
+
+  const technologyColumns: Column<TechnologyRow>[] = [
+    { key: "technology", header: "Technology" },
+    {
+      key: "count",
+      header: "Number of technical resources",
+      render: (v) => <div className="text-right">{String(v)}</div>,
+    },
+    {
+      key: "sum",
+      header: "Aggregated rated power",
+      render: (v) => <div className="text-right">{formatKw(v as number)}</div>,
+    },
+    {
+      key: "average",
+      header: "Average rated power",
+      render: (v) => <div className="text-right">{formatKw(v as number)}</div>,
+    },
+    {
+      key: "min",
+      header: "Minimum rated power",
+      render: (v) => (
+        <div className="text-right">{formatKw(v as number | undefined)}</div>
+      ),
+    },
+    {
+      key: "max",
+      header: "Maximum rated power",
+      render: (v) => (
+        <div className="text-right">{formatKw(v as number | undefined)}</div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4">
+        <LabelValue label="Name" value={spg.name} />
+        <LabelValue label="Bidding zone" value={spg.bidding_zone} />
+        <LabelValue label="Status" value={statusLabel} />
+      </div>
+
+      {spg.summary && (
+        <>
+          <SpgpaPrintCuSummary
+            spgViewModel={spgViewModel}
+            summary={spg.summary}
+          />
+
+          <div className="flex flex-col gap-4">
+            <Heading size="large">Technical resource summary</Heading>
+            <p>
+              This service providing group contains{" "}
+              <b>{spg.summary.technical_resource.count ?? 0}</b> technical
+              resources. Here are the <b>rated power</b> aggregates computed
+              across all of them:
+            </p>
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+              <LabelValue
+                label="Aggregated rated power"
+                value={
+                  spg.summary.technical_resource.maximum_active_power?.sum ?? 0
+                }
+                unit="kW"
+              />
+              <LabelValue
+                label="Average rated power"
+                value={
+                  spg.summary.technical_resource.maximum_active_power?.average
+                    ? Math.round(
+                        spg.summary.technical_resource.maximum_active_power
+                          .average * 100,
+                      ) / 100
+                    : 0
+                }
+                unit="kW"
+              />
+              <LabelValue
+                label="Minimum rated power"
+                value={
+                  spg.summary.technical_resource.maximum_active_power?.min ?? 0
+                }
+                unit="kW"
+              />
+              <LabelValue
+                label="Maximum rated power"
+                value={
+                  spg.summary.technical_resource.maximum_active_power?.max ?? 0
+                }
+                unit="kW"
+              />
+            </div>
+
+            {/* Breakdown by technology table */}
+            {(() => {
+              const byTechnology =
+                spg.summary.technical_resource.by_technology ?? {};
+              const technologyRows: TechnologyRow[] = Object.entries(
+                byTechnology,
+              ).map(([tech, stats]) => ({
+                id: tech,
+                technology: translateEnum(`technology.${tech as Technology}`),
+                count: stats?.count ?? 0,
+                sum: stats?.maximum_active_power?.sum ?? 0,
+                average: stats?.maximum_active_power?.average ?? 0,
+                min: stats?.maximum_active_power?.min,
+                max: stats?.maximum_active_power?.max,
+              }));
+
+              return technologyRows.length > 0 ? (
+                <div className="flex flex-col gap-2">
+                  <Heading size="small">Breakdown by technology</Heading>
+                  <SimpleTable
+                    size="small"
+                    data={technologyRows}
+                    columns={technologyColumns}
+                    className="w-full"
+                  />
+                </div>
+              ) : null;
+            })()}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/service_providing_group/product_application/print/SpgpaPrintSummary.tsx
+++ b/frontend/src/service_providing_group/product_application/print/SpgpaPrintSummary.tsx
@@ -1,0 +1,90 @@
+import { LabelValue } from "../../../components/LabelValue";
+import { ServiceProvidingGroupProductApplication } from "../../../generated-client";
+import { useTranslateEnum } from "../../../intl/intl";
+
+type Props = {
+  spgpa: ServiceProvidingGroupProductApplication;
+  spgName: string | undefined;
+  spgId: number | undefined;
+  psoName: string | undefined;
+  productTypeNames: string | undefined;
+};
+
+export const SpgpaPrintSummary = ({
+  spgpa,
+  spgName,
+  spgId,
+  psoName,
+  productTypeNames,
+}: Props) => {
+  const translateEnum = useTranslateEnum();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <LabelValue
+        size="small"
+        label="Service providing group"
+        value={`${spgName} (#${spgId})`}
+      />
+
+      <LabelValue size="small" label="System Operator / PSO" value={psoName} />
+
+      <LabelValue size="small" label="Product types" value={productTypeNames} />
+
+      <LabelValue
+        size="small"
+        label="Max active power (up)"
+        value={spgpa.maximum_active_power_up}
+        unit="kW"
+      />
+
+      <LabelValue
+        size="small"
+        label="Max active power (down)"
+        value={spgpa.maximum_active_power_down}
+        unit="kW"
+      />
+
+      {spgpa.ramping_capability && (
+        <LabelValue
+          size="small"
+          labelKey="service_providing_group_product_application.ramping_capability"
+          value={translateEnum(
+            `service_providing_group_product_application.ramping_capability.${spgpa.ramping_capability}`,
+          )}
+        />
+      )}
+
+      {spgpa.ramping_description && (
+        <LabelValue
+          size="small"
+          labelKey="service_providing_group_product_application.ramping_description"
+          value={
+            <span className="whitespace-pre-wrap">
+              {spgpa.ramping_description}
+            </span>
+          }
+        />
+      )}
+
+      <LabelValue
+        size="small"
+        label="Prequalified at"
+        value={spgpa.prequalified_at}
+      />
+      <LabelValue size="small" label="Verified at" value={spgpa.verified_at} />
+
+      {spgpa.additional_information && (
+        <LabelValue
+          size="small"
+          label="Additional information"
+          value={
+            <span className="whitespace-pre-wrap">
+              {spgpa.additional_information}
+            </span>
+          }
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend/src/service_providing_group/product_application/show/SpgpaShowSummary.tsx
+++ b/frontend/src/service_providing_group/product_application/show/SpgpaShowSummary.tsx
@@ -1,7 +1,7 @@
 import { Button, Link, Panel } from "../../../components/ui";
 import { LabelValue } from "../../../components/LabelValue";
 import { Link as RouterLink } from "react-router-dom";
-import { IconPencil } from "@elhub/ds-icons";
+import { IconPencil, IconExternal } from "@elhub/ds-icons";
 import { usePermissions } from "ra-core";
 import type { Permissions } from "../../../auth/permissions";
 import {
@@ -152,6 +152,16 @@ export const SpgpaShowSummary = ({ spgpa, spg }: Props) => {
       <div className="flex gap-4 mt-2">
         <NestedResourceHistoryButton child="product_application" />
         <EventButton filterOnSubject recordId={String(spgpa.id)} />
+        <Button
+          as={RouterLink}
+          to={`/service_providing_group_product_application/${spgpa.id}/print`}
+          target="_blank"
+          rel="noopener noreferrer"
+          variant="invisible"
+          icon={IconExternal}
+        >
+          Print
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
I decided to duplicate quite a bit instead of applying logic/args for visual appearance  on existing components.

Clicking "print" on SPG PA page immediately opens a print dialog:
<img width="846" height="1170" alt="image" src="https://github.com/user-attachments/assets/57cae4a9-7941-44b1-be34-cbb2e49deade" />
