### PR TITLE
chore: cleanup of logs (FLEX-1332)

### DIFF
--- a/backend/flex.go
+++ b/backend/flex.go
@@ -424,8 +424,6 @@ func Run(ctx context.Context, lookupenv func(string) (string, bool)) error { //n
 
 	// middlewares with logging
 
-	router.Use(gin.Logger())
-
 	slogginConfig := sloggin.Config{ //nolint:exhaustruct
 		// We are providing our own trace.SlogHandler, so we don't need to log trace IDs here.
 		WithSpanID:        false,

--- a/kbackend/gradle/libs.versions.toml
+++ b/kbackend/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ ktor = [
 ]
 logging = [
   "ktor-server-call-logging",
+  "logging-logstash-encoder",
   "logging-oshai-kotlin-logging",
   "logging-logback",
 ]
@@ -82,6 +83,7 @@ ktor-server-swagger = { group = "io.ktor", name = "ktor-server-swagger", version
 ktor-server-status-pages = { group = "io.ktor", name = "ktor-server-status-pages", version.ref = "ktor" }
 krontab = { group = "dev.inmo", name = "krontab", version.ref = "krontab" }
 logging-logback = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }
+logging-logstash-encoder = { group = "net.logstash.logback", name = "logstash-logback-encoder", version.ref = "logstash-logback-encoder" }
 logging-slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 logging-oshai-kotlin-logging = { group = "io.github.oshai", name = "kotlin-logging-jvm", version.ref = "kotlin-logging" }
 monitoring-cohort-hikari = { group = "com.sksamuel.cohort", name = "cohort-hikari", version.ref = "cohort" }
@@ -137,6 +139,7 @@ mockk = "1.14.11"
 mybatis = "3.5.19"
 postgresql = "42.7.13"
 logback = "1.5.38"
+logstash-logback-encoder = "9.0"
 slf4j = "2.0.18"
 snakeyaml = "2.6"
 testcontainers = "2.0.5"

--- a/kbackend/src/main/kotlin/no/elhub/flex/config/Logging.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/config/Logging.kt
@@ -11,7 +11,7 @@ import org.slf4j.event.Level
 fun Application.configureLogging() {
     install(CallLogging) {
         level = Level.INFO
-        filter { call -> call.request.path() != "/healthz" }
+        filter { call -> call.request.path() !in listOf("/healthz", "/metrics") }
 
         mdc("trace_id") { call -> call.attributes.getOrNull(TraceKey)?.traceID }
         mdc("span_id") { call -> call.attributes.getOrNull(TraceKey)?.spanID }

--- a/kbackend/src/main/kotlin/no/elhub/flex/config/Logging.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/config/Logging.kt
@@ -7,7 +7,7 @@ import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 import org.slf4j.event.Level
 
-/** Configures the call logging plugin with standard Elhub format and trace information. */
+/** Configures the call logging plugin with MDC properties for structured JSON logging */
 fun Application.configureLogging() {
     install(CallLogging) {
         level = Level.INFO
@@ -15,19 +15,10 @@ fun Application.configureLogging() {
 
         mdc("trace_id") { call -> call.attributes.getOrNull(TraceKey)?.traceID }
         mdc("span_id") { call -> call.attributes.getOrNull(TraceKey)?.spanID }
-
-        format { call ->
-            val status =
-                call.response
-                    .status()
-                    ?.value
-                    .toString()
-            val method = call.request.httpMethod.value
-            val uri = call.request.path()
-            val userAgent = call.request.headers["User-Agent"].orEmpty()
-            val traceInfo = call.attributes.get(TraceKey)
-            val log = "status=$status method=$method uri=$uri userAgent=$userAgent trace_id=${traceInfo.traceID} span_id=${traceInfo.spanID}"
-            log + (traceInfo.parentSpanID?.let { " parent_span_id=$it" } ?: "")
-        }
+        mdc("parent_span_id") { call -> call.attributes.getOrNull(TraceKey)?.parentSpanID }
+        mdc("http.method") { call -> call.request.httpMethod.value }
+        mdc("http.uri") { call -> call.request.path() }
+        mdc("http.status") { call -> call.response.status()?.value?.toString() }
+        mdc("http.userAgent") { call -> call.request.headers["User-Agent"] }
     }
 }

--- a/kbackend/src/main/kotlin/no/elhub/flex/config/Logging.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/config/Logging.kt
@@ -7,11 +7,13 @@ import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 import org.slf4j.event.Level
 
-/** Configures the call logging plugin with MDC properties for structured JSON logging */
+private val silentPaths = setOf("/healthz", "/metrics")
+
+/** Configures the call logging plugin with standard Elhub format and trace information. */
 fun Application.configureLogging() {
     install(CallLogging) {
         level = Level.INFO
-        filter { call -> call.request.path() !in listOf("/healthz", "/metrics") }
+        filter { call -> call.request.path() !in silentPaths }
 
         mdc("trace_id") { call -> call.attributes.getOrNull(TraceKey)?.traceID }
         mdc("span_id") { call -> call.attributes.getOrNull(TraceKey)?.spanID }

--- a/kbackend/src/main/resources/logback.xml
+++ b/kbackend/src/main/resources/logback.xml
@@ -1,9 +1,7 @@
 <configuration>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [trace_id=%X{trace_id}, span_id=%X{span_id}] [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
-    </encoder>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
   </appender>
 
   <logger name="no.elhub.flex" level="debug" />


### PR DESCRIPTION
 - Removed GIN logger from Go backend as it does not include log level and is a duplicate of what sloggin already logs
 - Removed logging of calls to /metrics in kbackend
 - Added logstash encoder for structured json logs in kbackend