### PR TITLE
feat: set boundary parameter manually in attachment upload multipart form (FLEX-1323)

### DIFF
--- a/frontend/src/components/attachments/registry.ts
+++ b/frontend/src/components/attachments/registry.ts
@@ -6,6 +6,40 @@ import {
 } from "../../generated-client";
 import { throwOnError } from "../../util";
 
+const enc = new TextEncoder();
+
+// create raw multipart form body
+// used to be able to set the boundary, which is not possible with FormData
+// (the WAF seems not to like the default boundary)
+async function buildMultipartBlob(
+  id: number,
+  file: File,
+  boundary: string,
+): Promise<Blob> {
+  const dash = "--";
+  const crlf = "\r\n";
+  const fileBytes = await file.arrayBuffer();
+
+  const parts: BlobPart[] = [
+    enc.encode(
+      `${dash}${boundary}${crlf}` +
+        `Content-Disposition: form-data; name="service_providing_group_product_application_id"${crlf}` +
+        `${crlf}` +
+        `${id}${crlf}`,
+    ),
+    enc.encode(
+      `${dash}${boundary}${crlf}` +
+        `Content-Disposition: form-data; name="file"; filename="${file.name}"${crlf}` +
+        (file.type ? `Content-Type: ${file.type}${crlf}` : "") +
+        `${crlf}`,
+    ),
+    fileBytes,
+    enc.encode(`${crlf}${dash}${boundary}${dash}${crlf}`),
+  ];
+
+  return new Blob(parts);
+}
+
 // generic fetch functions for a given attachment resource
 export type AttachmentClient = {
   list: (parentId: number) => Promise<AttachmentItem[]>;
@@ -32,13 +66,28 @@ export const attachmentRegistry = {
           service_providing_group_product_application_id: `eq.${parentId}`,
         },
       }).then(throwOnError),
-    upload: (parentId: number, file: File) =>
-      createServiceProvidingGroupProductApplicationAttachment({
-        body: {
-          service_providing_group_product_application_id: parentId,
-          file,
+    upload: async (parentId: number, file: File) => {
+      // generate a boundary that will be accepted by the WAF
+      const chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+      const random = Array.from(
+        { length: 24 },
+        () => chars[Math.floor(Math.random() * chars.length)],
+      ).join("");
+      const boundary = "------------------------" + random;
+
+      // create the body
+      const blob = await buildMultipartBlob(parentId, file, boundary);
+
+      // call the generated API client overriding the body and boundary
+      return createServiceProvidingGroupProductApplicationAttachment({
+        body: {} as never,
+        bodySerializer: () => blob,
+        headers: {
+          "Content-Type": `multipart/form-data; boundary=${boundary}`,
         },
-      }).then(throwOnError),
+      }).then(throwOnError);
+    },
     delete: (attachmentId: number) =>
       deleteServiceProvidingGroupProductApplicationAttachment({
         path: { id: attachmentId },

--- a/frontend/src/components/attachments/registry.ts
+++ b/frontend/src/components/attachments/registry.ts
@@ -19,6 +19,11 @@ async function buildMultipartBlob(
   const dash = "--";
   const crlf = "\r\n";
   const fileBytes = await file.arrayBuffer();
+  const safeFilename = file.name
+    .replace(/[\r\n]/g, "")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
+  const safeContentType = file.type.replace(/[\r\n]/g, "");
 
   const parts: BlobPart[] = [
     enc.encode(
@@ -29,8 +34,8 @@ async function buildMultipartBlob(
     ),
     enc.encode(
       `${dash}${boundary}${crlf}` +
-        `Content-Disposition: form-data; name="file"; filename="${file.name}"${crlf}` +
-        (file.type ? `Content-Type: ${file.type}${crlf}` : "") +
+        `Content-Disposition: form-data; name="file"; filename="${safeFilename}"${crlf}` +
+        (safeContentType ? `Content-Type: ${safeContentType}${crlf}` : "") +
         `${crlf}`,
     ),
     fileBytes,


### PR DESCRIPTION
This PR tries to avoid that our attachment upload requests get wrongly caught by the firewall in the test environment. Indeed, we got errors that did not reach our backend and there is no visible routing error in the deployed cluster, so we assume it comes from the firewall.

After investigating, our hypothesis is that the WAF does not like the `boundary` parameter generated by the browser. It starts with `----` and then random letter/digit characters. Trying with `curl` instead seems to always work, and the generated `boundary` there has way more dashes. We suspect that some mechanism preventing injection attacks does not like the 4 dashes, but with 24 dashes it lets us through.

The proposed fix (even though a better long-term solution would be to actually make the firewall rules more precise and remove those false positives) is to override the way the generated API client writes the attachment upload requests, so that instead of getting a generated `boundary`, we decide what is used there.