### PR TITLE
fix(frontend): avoid duplicate keys in DataGrid by using index as key (FLEX-1335)

### DIFF
--- a/frontend/src/components/EDS-ra/list/Datagrid.tsx
+++ b/frontend/src/components/EDS-ra/list/Datagrid.tsx
@@ -120,10 +120,7 @@ export const DataTable = <T extends RaRecord>({
             const childSource = children?.props?.source;
 
             return (
-              <Table.ColumnHeader
-                key={source ?? childSource ?? index}
-                scope="col"
-              >
+              <Table.ColumnHeader key={index} scope="col">
                 <span className="flex items-center gap-1">
                   <FieldTitle
                     source={childSource ?? source}
@@ -157,30 +154,22 @@ export const DataTable = <T extends RaRecord>({
                   </RecordContextProvider>
                 }
               >
-                {columns.map((child, index) => {
-                  const key =
-                    (child.props as { source?: string }).source ?? index;
-                  return (
-                    <Table.DataCell key={key}>
-                      {cloneElement(child)}
-                    </Table.DataCell>
-                  );
-                })}
+                {columns.map((child, index) => (
+                  <Table.DataCell key={index}>
+                    {cloneElement(child)}
+                  </Table.DataCell>
+                ))}
               </Table.ExpandableRow>
             ) : (
               <Table.Row
                 style={hasRowClick ? { cursor: "pointer" } : undefined}
                 onClick={(e) => handleRowClick(e, record)}
               >
-                {columns.map((child, index) => {
-                  const key =
-                    (child.props as { source?: string }).source ?? index;
-                  return (
-                    <Table.DataCell key={key}>
-                      {cloneElement(child)}
-                    </Table.DataCell>
-                  );
-                })}
+                {columns.map((child, index) => (
+                  <Table.DataCell key={index}>
+                    {cloneElement(child)}
+                  </Table.DataCell>
+                ))}
               </Table.Row>
             )}
           </RecordContextProvider>


### PR DESCRIPTION

<img width="2534" height="466" alt="image" src="https://github.com/user-attachments/assets/8aec5ad2-5d34-47b2-ab5b-fde08090d0b2" />


The AssumePartyPage renders multiple columns with the same source="party_id" (and source="id") in the same Datagrid.
Switched to index as  table columns are statically ordered and never reordered at runtime.