### PR TITLE
test: log first 8 KB of multipart form preamble (FLEX-1323)

### DIFF
--- a/kbackend/build.gradle.kts
+++ b/kbackend/build.gradle.kts
@@ -15,6 +15,7 @@ buildscript {
 dependencies {
     // Ktor
     implementation(libs.bundles.ktor)
+    implementation(libs.ktor.server.double.receive)
     implementation(libs.bundles.functional.programming)
     // Koin
     implementation(libs.bundles.dependency.injection)

--- a/kbackend/gradle/libs.versions.toml
+++ b/kbackend/gradle/libs.versions.toml
@@ -80,6 +80,7 @@ ktor-server-metrics-micrometer = { group = "io.ktor", name = "ktor-server-metric
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-server-netty = { group = "io.ktor", name = "ktor-server-netty", version.ref = "ktor" }
 ktor-server-swagger = { group = "io.ktor", name = "ktor-server-swagger", version.ref = "ktor" }
+ktor-server-double-receive = { group = "io.ktor", name = "ktor-server-double-receive", version.ref = "ktor" }
 ktor-server-status-pages = { group = "io.ktor", name = "ktor-server-status-pages", version.ref = "ktor" }
 krontab = { group = "dev.inmo", name = "krontab", version.ref = "krontab" }
 logging-logback = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }

--- a/kbackend/src/main/kotlin/no/elhub/flex/Application.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/Application.kt
@@ -3,6 +3,7 @@ package no.elhub.flex
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.netty.EngineMain
+import io.ktor.server.plugins.doublereceive.DoubleReceive
 import kotlinx.datetime.TimeZone
 import no.elhub.flex.auth.FlexAuthentication
 import no.elhub.flex.config.Tracing
@@ -39,6 +40,7 @@ class FlexApp
  */
 fun Application.module() {
     install(Tracing.plugin)
+    install(DoubleReceive)
     configureLogging()
     configureSerialization()
     configureDatabase()

--- a/kbackend/src/main/kotlin/no/elhub/flex/attachment/AttachmentHandler.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/attachment/AttachmentHandler.kt
@@ -8,7 +8,10 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.MultiPartData
 import io.ktor.http.content.PartData
+import io.ktor.http.content.forEachPart
+import io.ktor.server.request.receiveChannel
 import io.ktor.server.routing.RoutingCall
+import io.ktor.utils.io.readAvailable
 import io.ktor.utils.io.toByteArray
 import no.elhub.flex.auth.AccessTokenKey
 import no.elhub.flex.auth.FlexPrincipal
@@ -97,7 +100,18 @@ class AttachmentHandler(
         either {
             val principal = call.attributes[AccessTokenKey].toFlexPrincipal()
 
-            // extract information from multipart body
+            // TEMPORARY
+            // log raw body first 8 KB to see if garbage has been added to the body before the first multipart boundary
+            val rawPrefix = ByteArray(8192)
+            val rawPrefixRead = call.receiveChannel().readAvailable(rawPrefix)
+            val rawPrefixBytes = rawPrefix.take(rawPrefixRead).toByteArray()
+            logger.info {
+                "Multipart raw body prefix ($rawPrefixRead bytes) hex: ${rawPrefixBytes.joinToString("") { "%02x".format(it) }}"
+            }
+            logger.info {
+                "Multipart raw body prefix text: ${rawPrefixBytes.toString(Charsets.UTF_8).replace("\r", "\\r").replace("\n", "\\n\n")}"
+            }
+
             val createBody =
                 call.multipart(MAX_MULTIPART_SIZE_BYTES)
                     .flatMap { with(principal) { CreateBody.parse(it, baseResource, repo) } }

--- a/kbackend/src/main/kotlin/no/elhub/flex/attachment/AttachmentHandler.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/attachment/AttachmentHandler.kt
@@ -8,7 +8,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.MultiPartData
 import io.ktor.http.content.PartData
-import io.ktor.http.content.forEachPart
 import io.ktor.server.request.receiveChannel
 import io.ktor.server.routing.RoutingCall
 import io.ktor.utils.io.readAvailable


### PR DESCRIPTION
The error message we are having when testing the file upload endpoint is the following:

```
Limit of 8193 bytes exceeded while searching for \"------geckoformboundaryb4c6805dd231b1a94aa7171e104af15d\"
```

and this happens on the first call to `body.readPart()` where the part content is only an integer. Moreover, we have explicitly set the limit to 20 MB on part content, so 8 KB should not be a problem. This suggests the error happens _before even reading the first_ `boundary`, which is the delimiter needed to be able to parse all the parts in the multipart form. In our test requests, the _preamble_ (the part before the first boundary) is empty, and it should probably always be empty. But because of proxying/WAF/whatever coming before our backend, it may happen that some garbage is added there and that the multipart body parser does not accept it. Actually, the Ktor server core uses the CIO multipart parser internally. This parser [expects](https://github.com/ktorio/ktor/blob/4fdb1f8c8587d1f20ca6368ab9fa17279306c0ff/ktor-http/ktor-http-cio/common/src/io/ktor/http/cio/Multipart.kt#L229) the first boundary to be found within the first 8 KB of data.

This PR logs the first 8 KB of the body of such requests, so we see the preamble. This is temporary and should be reverted once we understand where the problem lies. Since the feature is only deployed to test environments right now, we don't have to be especially careful about wrapping such things in a feature switch for example.

We can probably "clean" the raw body manually before calling the multipart parser, to cover for problems happening before the requests reach our backend, but to be able to do this it would be nice to actually see what requests look like at the moment.