### PR TITLE
fix(ui): field reset in accounting point location input form (FLEX-1134)

### DIFF
--- a/frontend/src/accounting_point/grid_location/AccountingPointGridLocationInput.tsx
+++ b/frontend/src/accounting_point/grid_location/AccountingPointGridLocationInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Form, ResourceContextProvider, useNotify } from "ra-core";
 import { useFormContext } from "react-hook-form";
 import { useQueryClient } from "@tanstack/react-query";
@@ -135,34 +135,41 @@ export const AccountingPointGridLocationInput = ({
   const notify = useNotify();
   const isCreate = gridLocation === undefined;
 
-  // initial form values + override with selected substation if present
-  const baseRecord: Partial<
-    z.infer<typeof zAccountingPointGridLocationCreateRequest>
-  > = isCreate
-    ? {
-        accounting_point_id: apId,
-        object_type: "substation",
-        quality: "guessed",
-      }
-    : {
-        accounting_point_id: apId,
-        name: gridLocation.name,
-        object_type: gridLocation.object_type,
-        business_id: gridLocation.business_id ?? undefined,
-        nominal_voltage: gridLocation.nominal_voltage,
-        quality: gridLocation.quality,
-        additional_information: gridLocation.additional_information ?? "",
-      };
+  // clearing selectedSubstation by picking via the combobox should not reset
+  // the form fields (namely nominal voltage) so we compute the initial form
+  // values once when the input component loads and then only explicit
+  // manipulation of the form state can cause changes
+  const record = useMemo(() => {
+    const base: Partial<
+      z.infer<typeof zAccountingPointGridLocationCreateRequest>
+    > = isCreate
+      ? {
+          accounting_point_id: apId,
+          object_type: "substation",
+          quality: "guessed",
+        }
+      : {
+          accounting_point_id: apId,
+          name: gridLocation.name,
+          object_type: gridLocation.object_type,
+          business_id: gridLocation.business_id ?? undefined,
+          nominal_voltage: gridLocation.nominal_voltage,
+          quality: gridLocation.quality,
+          additional_information: gridLocation.additional_information ?? "",
+        };
 
-  const record = selectedSubstation
-    ? {
-        ...baseRecord,
+    if (selectedSubstation) {
+      return {
+        ...base,
         name: selectedSubstation.name,
         object_type: "substation" as const,
         business_id: selectedSubstation.business_id,
         nominal_voltage: undefined,
-      }
-    : baseRecord;
+      };
+    }
+    return base;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onSubmit = async (values: object) => {
     if (isCreate) {

--- a/frontend/src/accounting_point/grid_location/AccountingPointGridLocationPanel.tsx
+++ b/frontend/src/accounting_point/grid_location/AccountingPointGridLocationPanel.tsx
@@ -23,11 +23,12 @@ export const AccountingPointGridLocationPanel = ({
   onCancelSelection?: () => void;
 }) => {
   const translate = useTranslate();
-  const [isEditingManual, setIsEditingManual] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
   // when a substation is clicked on the map, open the edit form
-  const isEditing = isEditingManual || (!!selectedSubstation && userCanEdit);
-  const setIsEditing = (value: boolean) => setIsEditingManual(value);
+  if (!!selectedSubstation && userCanEdit && !isEditing) {
+    setIsEditing(true);
+  }
 
   const handleDone = () => {
     setIsEditing(false);
@@ -56,7 +57,10 @@ export const AccountingPointGridLocationPanel = ({
           apId={apId}
           gridLocation={gridLocation}
           onDone={handleDone}
-          onCancel={onCancelSelection ?? handleDone}
+          onCancel={() => {
+            setIsEditing(false);
+            onCancelSelection?.();
+          }}
           selectedSubstation={selectedSubstation}
           onClearMapSelection={onClearSelection}
         />


### PR DESCRIPTION
This PR fixes various glitches we had on the AP location input form. The component is linked to the map and the nominal voltage was not reset correctly in some cases (like selecting a substation on the map, then changing the business ID by searching directly in the field, etc). The Cancel button was also not working in some cases. No visual change involved here, only behaviour made correct.