### PR TITLE
feat(ui): make additional information clearer on SPG create page (FLEX-1200)

### DIFF
--- a/frontend/src/intl/text.ts
+++ b/frontend/src/intl/text.ts
@@ -45,7 +45,9 @@ export type TextKey =
   | "spg_manage_members_review_modal_removing_plural"
   | "spg_manage_members_review_modal_close"
   | "comment.visibility.same_party.description"
-  | "comment.visibility.any_involved_party.description";
+  | "comment.visibility.any_involved_party.description"
+  | "spg_create_additional_information_override_description"
+  | "spg_create_additional_information_placeholder";
 
 export const text: Record<string, Record<TextKey, string>> = {
   en: {
@@ -109,6 +111,10 @@ export const text: Record<string, Record<TextKey, string>> = {
       "Only visible to your current party",
     "comment.visibility.any_involved_party.description":
       "Visible to all parties involved in this resource",
+    spg_create_additional_information_override_description:
+      "This field is meant to capture any additional information about the service providing group that might be relevant.",
+    spg_create_additional_information_placeholder:
+      "This field is optional and can be left empty.",
   },
   nb: {
     entity_role: "Entitet",
@@ -170,5 +176,9 @@ export const text: Record<string, Record<TextKey, string>> = {
       "Kun synlig for din nåværende aktør",
     "comment.visibility.any_involved_party.description":
       "Synlig for alle parter involvert i denne ressursen",
+    spg_create_additional_information_override_description:
+      "Dette feltet er ment å fange opp eventuell tilleggsinformasjon om fleksibilitetsgruppen som kan være relevant.",
+    spg_create_additional_information_placeholder:
+      "Dette feltet er valgfritt og kan stå tomt.",
   },
 };

--- a/frontend/src/service_providing_group/input/ServiceProvidingGroupFields.tsx
+++ b/frontend/src/service_providing_group/input/ServiceProvidingGroupFields.tsx
@@ -1,4 +1,5 @@
 import { useGetIdentity } from "ra-core";
+import { Divider, Heading } from "../../components/ui";
 import { zServiceProvidingGroupCreateRequest } from "../../generated-client/zod.gen";
 import { getFields } from "../../zod";
 import {
@@ -43,10 +44,18 @@ export const ServiceProvidingGroupFields = ({ isEdit }: Props) => {
           description
         />
       )}
+      <div className="pt-6 pb-3">
+        <Divider />
+      </div>
+      <Heading level={4} size="small" className="pb-3">
+        Other
+      </Heading>
       <TextAreaInput
         {...fields.additional_information}
         rows={5}
         description
+        placeholder="This field is optional and can be left empty."
+        descriptionOverride="This field is meant to capture any additional information about the service providing group that might be relevant."
         tooltip={false}
         warning="Please remember not to write any sensitive (power/market/personal) information in this field."
       />

--- a/frontend/src/service_providing_group/input/ServiceProvidingGroupFields.tsx
+++ b/frontend/src/service_providing_group/input/ServiceProvidingGroupFields.tsx
@@ -1,4 +1,4 @@
-import { useGetIdentity } from "ra-core";
+import { useGetIdentity, useTranslate } from "ra-core";
 import { Divider, Heading } from "../../components/ui";
 import { zServiceProvidingGroupCreateRequest } from "../../generated-client/zod.gen";
 import { getFields } from "../../zod";
@@ -14,6 +14,7 @@ type Props = {
 };
 
 export const ServiceProvidingGroupFields = ({ isEdit }: Props) => {
+  const translate = useTranslate();
   const { data: identity } = useGetIdentity();
   const isServiceProvider = identity?.role === "flex_service_provider";
   const fields = getFields(zServiceProvidingGroupCreateRequest.shape);
@@ -54,8 +55,12 @@ export const ServiceProvidingGroupFields = ({ isEdit }: Props) => {
         {...fields.additional_information}
         rows={5}
         description
-        placeholder="This field is optional and can be left empty."
-        descriptionOverride="This field is meant to capture any additional information about the service providing group that might be relevant."
+        placeholder={translate(
+          "text.spg_create_additional_information_placeholder",
+        )}
+        descriptionOverride={translate(
+          "text.spg_create_additional_information_override_description",
+        )}
         tooltip={false}
         warning="Please remember not to write any sensitive (power/market/personal) information in this field."
       />


### PR DESCRIPTION
Just a bit more space, better text and a placeholder to make it very clear that this is optional.

<img width="829" height="317" alt="Skjermbilde 2026-08-04 161509" src="https://github.com/user-attachments/assets/d8bab6bc-f0d8-46cd-a333-b9d91ad66a41" />