### PR TITLE
fix(backend): filter terminated CUs earlier in the CU lookup handler (FLEX-1226)

### DIFF
--- a/db/api/controllable_unit_lookup.sql
+++ b/db/api/controllable_unit_lookup.sql
@@ -19,7 +19,8 @@ AS $$
     FROM flex.controllable_unit AS cu
         INNER JOIN flex.accounting_point AS ap
             ON cu.accounting_point_id = ap.id
-    WHERE cu.business_id = l_controllable_unit_business_id::uuid;
+    WHERE cu.business_id = l_controllable_unit_business_id::uuid
+        AND cu.status != 'terminated';
 $$;
 
 

--- a/kbackend/src/main/kotlin/no/elhub/flex/controllableunit/db/ControllableUnitQuery.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/controllableunit/db/ControllableUnitQuery.kt
@@ -7,7 +7,6 @@ FROM (
              cu.id,
              cu.business_id::text,
              cu.name,
-             cu.status,
              cu.start_date,
              (
                  SELECT coalesce(jsonb_agg(row_to_json(tr)), '[]'::jsonb)
@@ -22,5 +21,6 @@ FROM (
                              ON cu.accounting_point_id = ap.id
                                  AND coalesce(cu.business_id = nullIf(?, '')::uuid, true)
                                  AND coalesce(ap.business_id = nullIf(?, ''), true)
+         WHERE cu.status != 'terminated'
      ) as cu;
 """

--- a/kbackend/src/main/kotlin/no/elhub/flex/controllableunit/db/ControllableUnitRepository.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/controllableunit/db/ControllableUnitRepository.kt
@@ -32,8 +32,8 @@ import java.sql.ResultSet
 interface ControllableUnitRepository {
 
     /**
-     * Retrieves all controllable units associated with either the given [controllableUnitBusinessId] or the given
-     * [accountingPointBusinessId].
+     * Retrieves all non-terminated controllable units associated with either the given [controllableUnitBusinessId]
+     * or the given [accountingPointBusinessId].
      *
      * Returns [RepositoryError] when the query fails.
      */

--- a/kbackend/src/main/kotlin/no/elhub/flex/model/domain/ControllableUnitForLookup.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/model/domain/ControllableUnitForLookup.kt
@@ -16,7 +16,6 @@ data class ControllableUnitForLookup(
     val id: Long,
     @SerialName("business_id") val businessId: String,
     val name: String,
-    val status: ControllableUnitStatus,
     @SerialName("technical_resources") val technicalResources: List<TechnicalResource>,
     @SerialName("start_date") val startDate: LocalDate?,
 )

--- a/kbackend/src/main/kotlin/no/elhub/flex/model/dto/DtoMapper.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/model/dto/DtoMapper.kt
@@ -13,7 +13,6 @@ fun List<ControllableUnitForLookup>.toDtos(): List<ControllableUnitDto> =
             businessId = cu.businessId,
             name = cu.name,
             technicalResources = cu.technicalResources.toDtos()
-
         )
     }
 

--- a/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
+++ b/kbackend/src/main/kotlin/no/elhub/flex/routes/controllableunit/ControllableUnitLookup.kt
@@ -11,7 +11,6 @@ import no.elhub.flex.auth.FlexPrincipal
 import no.elhub.flex.controllableunit.db.ControllableUnitRepository
 import no.elhub.flex.event.db.EventRepository
 import no.elhub.flex.model.domain.ControllableUnitForLookup
-import no.elhub.flex.model.domain.ControllableUnitStatus
 import no.elhub.flex.model.domain.GSRN
 import no.elhub.flex.model.dto.generated.models.ControllableUnitLookupRequest
 import no.elhub.flex.model.dto.generated.models.ControllableUnitLookupResponse
@@ -61,7 +60,7 @@ class ControllableUnitLookup(
                     request.controllableUnitBusinessId,
                     accountingPointBusinessId
                 ).bind()
-                logger.debug { "Found ${controllableUnits.size} controllable units on accounting point $accountingPointBusinessId" }
+                logger.debug { "Found ${controllableUnits.size} non-terminated controllable units on accounting point $accountingPointBusinessId" }
 
                 val validFrom = controllableUnits.mapNotNull { it.startDate }.minByOrNull { it }?.asLocalMidnightInstant(timezone)
                     ?: Instant.todayLocalMidnight(timezone)
@@ -91,9 +90,7 @@ class ControllableUnitLookup(
                         businessId = accountingPoint.businessId
                     ),
                     endUser = ControllableUnitLookupResponseEndUser(id = endUserId),
-                    controllableUnits = controllableUnits
-                        .filter { it.status != ControllableUnitStatus.TERMINATED }
-                        .toDtos(),
+                    controllableUnits = controllableUnits.toDtos(),
                 )
             }
         }.respondJson(call)

--- a/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTest.kt
+++ b/kbackend/src/test/kotlin/no/elhub/flex/controllableunit/ControllableUnitLookupTest.kt
@@ -30,7 +30,6 @@ import no.elhub.flex.controllableunit.db.ControllableUnitRepository
 import no.elhub.flex.event.db.EventRepository
 import no.elhub.flex.model.domain.AccountingPoint
 import no.elhub.flex.model.domain.ControllableUnitForLookup
-import no.elhub.flex.model.domain.ControllableUnitStatus
 import no.elhub.flex.model.dto.generated.models.ControllableUnitLookupResponse
 import no.elhub.flex.model.error.InternalServerError
 import no.elhub.flex.model.error.ResourceNotFoundError
@@ -543,7 +542,6 @@ class ControllableUnitLookupTest :
                         id = 1,
                         businessId = controllableUnitBusinessId,
                         name = "My CU",
-                        status = ControllableUnitStatus.ACTIVE,
                         technicalResources = emptyList(),
                         startDate = Clock.System.todayIn(TimeZone.of("Europe/Oslo")),
                     ),
@@ -560,62 +558,6 @@ class ControllableUnitLookupTest :
                 body.contains("accounting_point") shouldBe true
                 body.contains("end_user") shouldBe true
                 body.contains("controllable_units") shouldBe true
-                app.stop()
-            }
-
-            test("happy path should not return terminated CUs") {
-                val endUserBusinessId = "123456789"
-                val accountingPointBusinessId = "133700000000000053"
-                val controllableUnitBusinessId = "550e8400-e29b-41d4-a716-446655440000"
-                coEvery {
-                    with(any<FlexPrincipal>()) { mockAccountingPointService.getCurrentAccountingPoint(any()) }
-                } returns AccountingPoint(id = 1, businessId = accountingPointBusinessId).right()
-                coEvery {
-                    mockAccountingPointService.synchronizeAccountingPoint(any(), any())
-                } returns Unit.right()
-                coEvery {
-                    with(any<FlexPrincipal>()) {
-                        mockAccountingPointService.checkEndUserMatchesAccountingPoint(endUserBusinessId, accountingPointBusinessId)
-                    }
-                } returns 7L.right()
-                coEvery {
-                    with(any<FlexPrincipal>()) {
-                        mockAccountingPointService.getAccountingPointByBusinessId(accountingPointBusinessId)
-                    }
-                } returns AccountingPoint(id = 1, businessId = accountingPointBusinessId).right()
-                coEvery {
-                    with(any<FlexPrincipal>()) { mockRepo.lookupControllableUnits(any(), any()) }
-                } returns listOf(
-                    ControllableUnitForLookup(
-                        id = 1,
-                        businessId = controllableUnitBusinessId,
-                        name = "Terminated CU",
-                        status = ControllableUnitStatus.TERMINATED,
-                        technicalResources = emptyList(),
-                        startDate = null,
-                    ),
-                    ControllableUnitForLookup(
-                        id = 2,
-                        businessId = controllableUnitBusinessId,
-                        name = "My CU",
-                        status = ControllableUnitStatus.ACTIVE,
-                        technicalResources = emptyList(),
-                        startDate = Clock.System.todayIn(TimeZone.of("Europe/Oslo")),
-                    ),
-                ).right()
-
-                val app = testApp(mockRepo, mockAccountingPointService, mockEventRepo)
-                val response = app.client.post("/controllable_unit/lookup") {
-                    contentType(ContentType.Application.Json)
-                    header("Authorization", "Bearer ${makeJwt()}")
-                    setBody("""{"end_user":"$endUserBusinessId","accounting_point":"$accountingPointBusinessId"}""")
-                }
-                response.status shouldBe HttpStatusCode.OK
-
-                val lookupResponse = Json.decodeFromString<ControllableUnitLookupResponse>(response.bodyAsText())
-                lookupResponse.controllableUnits.size shouldBe 1
-                lookupResponse.controllableUnits.first().id shouldBe 2
-
                 app.stop()
             }
 
@@ -662,7 +604,6 @@ class ControllableUnitLookupTest :
                         id = 10L,
                         businessId = "550e8400-e29b-41d4-a716-446655440000",
                         name = "CU 1",
-                        status = ControllableUnitStatus.INACTIVE,
                         technicalResources = emptyList(),
                         startDate = null
                     ),
@@ -670,7 +611,6 @@ class ControllableUnitLookupTest :
                         id = 20L,
                         businessId = "660e8400-e29b-41d4-a716-446655440001",
                         name = "CU 2",
-                        status = ControllableUnitStatus.ACTIVE,
                         technicalResources = emptyList(),
                         startDate = null
                     ),
@@ -768,7 +708,6 @@ class ControllableUnitLookupTest :
                         id = 10L,
                         businessId = controllableUnitBusinessId,
                         name = "CU 1",
-                        status = ControllableUnitStatus.ACTIVE,
                         technicalResources = emptyList(),
                         startDate = null
                     ),

--- a/test/api_client_tests/test_cu_lookup.py
+++ b/test/api_client_tests/test_cu_lookup.py
@@ -5,11 +5,13 @@ from security_token_service import (
 from flex.models import (
     ControllableUnitLookupRequest,
     ControllableUnitCreateRequest,
+    ControllableUnitUpdateRequest,
     ControllableUnitLookupResponse,
     ControllableUnitRegulationDirection,
     ControllableUnitResponse,
     ControllableUnitServiceProviderCreateRequest,
     ControllableUnitServiceProviderResponse,
+    ControllableUnitStatus,
     EntityCreateRequest,
     EntityBusinessIdType,
     EntityType,
@@ -19,6 +21,7 @@ from flex.models import (
 from flex.api.controllable_unit import (
     read_controllable_unit,
     create_controllable_unit,
+    update_controllable_unit,
     call_controllable_unit_lookup,
 )
 from flex.api.controllable_unit_service_provider import (
@@ -437,3 +440,58 @@ def test_cu_lookup_flow(sts):
         ),
     )
     assert isinstance(cu_sp, ControllableUnitServiceProviderResponse)
+
+
+def test_cu_lookup_terminated_cu_excluded(sts):
+    client_fiso = sts.get_client(TestEntity.TEST, "FISO")
+
+    eu_entity = read_entity.sync(
+        client=client_fiso,
+        id=sts.get_userinfo(sts.get_client(TestEntity.TEST))["entity_id"],
+    )
+    assert isinstance(eu_entity, EntityResponse)
+
+    end_user = birth_date_from_pid(eu_entity.business_id)
+
+    # first create a CU and check we can look it up
+    cu = create_controllable_unit.sync(
+        client=client_fiso,
+        body=ControllableUnitCreateRequest(
+            name="TEST-CU-LOOKUP-TERMINATED",
+            accounting_point_id=1001,  # technical ID of AP 133700000000010007
+            regulation_direction=ControllableUnitRegulationDirection.BOTH,
+            maximum_active_power=3.5,
+        ),
+    )
+    assert isinstance(cu, ControllableUnitResponse)
+
+    cul = call_controllable_unit_lookup.sync(
+        client=client_fiso,
+        body=ControllableUnitLookupRequest(
+            end_user=end_user,
+            controllable_unit=cu.business_id,
+        ),
+    )
+    assert isinstance(cul, ControllableUnitLookupResponse)
+    assert len(cul.controllable_units) == 1
+    assert cul.controllable_units[0].id == cu.id
+
+    # now terminate the CU and check it is no longer returned by the lookup
+    u = update_controllable_unit.sync(
+        client=client_fiso,
+        id=cast(int, cu.id),
+        body=ControllableUnitUpdateRequest(
+            status=ControllableUnitStatus.TERMINATED,
+        ),
+    )
+    assert not isinstance(u, ErrorMessage)
+
+    e = call_controllable_unit_lookup.sync(
+        client=client_fiso,
+        body=ControllableUnitLookupRequest(
+            end_user=end_user,
+            controllable_unit=cu.business_id,
+        ),
+    )
+    assert isinstance(e, ErrorMessage)
+    assert e.code == "HTTP404"


### PR DESCRIPTION
This PR fixes internal errors caused by the fact some terminated CUs were still being processed in the lookup handler, even though they were not returned in the end response.

The fix is to filter out terminated CUs from the very beginning (DB query). We also fail when trying to get the current AP of a terminated CU, because then it can lead to a 404 when calling lookup with a CU business ID that is terminated (which I think should be the right behaviour).

Simple API test looking up a CU, then terminating it, then checking we cannot see it anymore.