### PR TITLE
fix: broken big.pdf test

### DIFF
--- a/test/api_client_tests/test_spgpa_attachment.py
+++ b/test/api_client_tests/test_spgpa_attachment.py
@@ -63,7 +63,7 @@ import datetime
 
 
 # return a structurally minimal but valid single-page PDF
-def minimal_pdf() -> bytes:
+def minimal_pdf(extra_null_bytes: int = 0) -> bytes:
     stream = b"BT /F1 12 Tf 72 720 Td (hello) Tj ET"
     length = len(stream)
     parts = []
@@ -98,7 +98,9 @@ def minimal_pdf() -> bytes:
     for off in offsets:
         w(f"{off:010d} 00000 n \n".encode())
     w(b"trailer\n<< /Size 6 /Root 1 0 R >>\n")
-    w(f"startxref\n{xref_offset}\n%%EOF\n".encode())
+    w(f"startxref\n{xref_offset}\n".encode())
+    w(b"\x00" * extra_null_bytes)
+    w("\n%%EOF\n".encode())
     return b"".join(parts)
 
 
@@ -113,10 +115,9 @@ def upload_attachment(
     client: AuthenticatedClient,
     spgpa_id: int,
     filename: str = "test.pdf",
-    pdf_bytes: bytes | None = None,
+    extra_null_bytes: int = 0,
 ):
-    if pdf_bytes is None:
-        pdf_bytes = minimal_pdf()
+    pdf_bytes = minimal_pdf(extra_null_bytes)
     body = CreateServiceProvidingGroupProductApplicationAttachmentBody(
         service_providing_group_product_application_id=spgpa_id,
         file=_make_file(pdf_bytes, filename),
@@ -132,10 +133,9 @@ def upload_attachment_detailed(
     client: AuthenticatedClient,
     spgpa_id: int,
     filename: str = "test.pdf",
-    pdf_bytes: bytes | None = None,
+    extra_null_bytes: int = 0,
 ):
-    if pdf_bytes is None:
-        pdf_bytes = minimal_pdf()
+    pdf_bytes = minimal_pdf(extra_null_bytes=extra_null_bytes)
     body = CreateServiceProvidingGroupProductApplicationAttachmentBody(
         service_providing_group_product_application_id=spgpa_id,
         file=_make_file(pdf_bytes, filename),
@@ -360,7 +360,7 @@ def test_spgpaa_fiso(data):
 
     # a file exceeding the 20 MB size limit is rejected
     resp = upload_attachment_detailed(
-        client_fiso, spgpa_id, filename="big.pdf", pdf_bytes=bytes(20_000_001)
+        client_fiso, spgpa_id, filename="big.pdf", extra_null_bytes=20 * 1024 * 1024
     )
     assert resp.status_code.value == 400
 


### PR DESCRIPTION
This currently fails with ngnix throwing a HTTPStatus.CONTENT_TOO_LARGE: 413 .

The test expects 400. I think the test should expect a 413, but we shouldn't test ngnix I guess