### PR TITLE
refactor: implement attachment download as single link (FLEX-1341)

### DIFF
--- a/backend/internal/middleware/apiversion.go
+++ b/backend/internal/middleware/apiversion.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"slices"
+	"strings"
 )
 
 type contextKey string
@@ -15,7 +16,9 @@ const apiVersionKey contextKey = "api-version"
 // contains an unsupported version. On success it echoes the latest version
 // back in the response and stores the requested version in the context.
 // Add a new entry to knownVersions when a breaking change ships. Remove old entries at sunset.
-// The OpenAPI endpoints (/ and /openapi.json) are exempt.
+// The OpenAPI endpoints (/ and /openapi.json) are exempt, as are download
+// endpoints (paths ending in /download) since they are navigated to directly
+// by the browser and cannot carry custom headers.
 func RequireAPIVersion(next http.Handler) http.Handler {
 	knownVersions := []string{
 		"2026-06-08",
@@ -26,7 +29,7 @@ func RequireAPIVersion(next http.Handler) http.Handler {
 		"/openapi.json": true,
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if exempt[r.URL.Path] {
+		if exempt[r.URL.Path] || strings.HasSuffix(r.URL.Path, "/download") {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/frontend/src/components/attachments/AttachmentList.tsx
+++ b/frontend/src/components/attachments/AttachmentList.tsx
@@ -30,63 +30,25 @@ function formatDate(iso: string): string {
   });
 }
 
-// trigger a browser download from a blob
-async function triggerDownload(
-  onDownload: (id: number) => Promise<Blob>,
-  attachmentId: number,
-  fileName: string,
-) {
-  const blob = await onDownload(attachmentId);
-
-  // temporary object URL that will allow downloading without changing pages
-  const objectUrl = URL.createObjectURL(blob);
-
-  // add download link, click it, remove it
-  const a = document.createElement("a");
-  a.href = objectUrl;
-  a.download = fileName;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-
-  URL.revokeObjectURL(objectUrl);
-}
-
 // AttachmentCard (component showing each attachment in the list)
 
 type AttachmentCardProps = {
   attachment: AttachmentItem;
-  onDownload: (id: number) => Promise<Blob>;
+  downloadUrl: string;
   onDelete: () => Promise<void>;
   canDelete: boolean;
 };
 
 function AttachmentCard({
   attachment,
-  onDownload,
+  downloadUrl,
   onDelete,
   canDelete,
 }: AttachmentCardProps) {
   const [downloadHovered, setDownloadHovered] = useState(false);
   const [deleteHovered, setDeleteHovered] = useState(false);
-  const [isDownloading, setIsDownloading] = useState(false);
-  const [downloadError, setDownloadError] = useState(false);
 
   const isImage = attachment.content_type.startsWith("image/");
-
-  async function handleDownload() {
-    setDownloadError(false);
-    setIsDownloading(true);
-    try {
-      await triggerDownload(onDownload, attachment.id, attachment.filename);
-    } catch {
-      setDownloadError(true);
-    } finally {
-      setIsDownloading(false);
-    }
-  }
-
-  // confirm popup on delete to ensure no accidental delete is possible
   const { buttonProps: deleteButtonProps, dialog: deleteDialog } =
     useConfirmAction({
       title: "Delete attachment",
@@ -117,15 +79,15 @@ function AttachmentCard({
       style={{ backgroundColor: "var(--eds-global-color-white)" }}
       className="flex items-center gap-3 px-4 py-3 border border-solid border-semantic-border-default rounded-md"
     >
-      {/* file-type icon button, switches to download icon on hover */}
-      <button
-        type="button"
+      {/* file-type icon link, switches to download icon on hover */}
+      <a
+        href={downloadUrl}
+        target="_blank"
+        rel="noreferrer"
         aria-label={`Download ${attachment.filename}`}
         onMouseEnter={() => setDownloadHovered(true)}
         onMouseLeave={() => setDownloadHovered(false)}
-        onClick={handleDownload}
-        disabled={isDownloading}
-        className="shrink-0 flex items-center justify-center w-9 h-9 rounded-md text-semantic-text-subtle hover:text-semantic-background-action-primary hover:bg-semantic-background-action-selected transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-wait"
+        className="shrink-0 flex items-center justify-center w-9 h-9 rounded-md text-semantic-text-subtle hover:text-semantic-background-action-primary hover:bg-semantic-background-action-selected transition-colors cursor-pointer"
       >
         {downloadHovered ? (
           <IconDownload size="medium" />
@@ -134,7 +96,7 @@ function AttachmentCard({
         ) : (
           <IconDocument size="medium" />
         )}
-      </button>
+      </a>
 
       {/* name + metadata */}
       <div className="flex-1 min-w-0">
@@ -145,11 +107,6 @@ function AttachmentCard({
           {attachment.content_type} · {formatBytes(attachment.size_bytes)} ·{" "}
           {formatDate(attachment.recorded_at)}
         </p>
-        {downloadError && (
-          <p className="text-xs text-semantic-text-error mt-0.5">
-            Download failed. Please try again.
-          </p>
-        )}
       </div>
 
       {/* delete button */}
@@ -307,7 +264,7 @@ export function AttachmentList({ resource, parentId }: AttachmentListProps) {
             <AttachmentCard
               key={attachment.id}
               attachment={attachment}
-              onDownload={client.download}
+              downloadUrl={client.downloadUrl(attachment.id)}
               onDelete={() =>
                 deleteAttachment.mutateAsync(attachment.id).then(() => {})
               }

--- a/frontend/src/components/attachments/registry.ts
+++ b/frontend/src/components/attachments/registry.ts
@@ -2,16 +2,16 @@ import {
   listServiceProvidingGroupProductApplicationAttachment,
   createServiceProvidingGroupProductApplicationAttachment,
   deleteServiceProvidingGroupProductApplicationAttachment,
-  callDownloadServiceProvidingGroupProductApplicationAttachment,
 } from "../../generated-client";
 import { throwOnError } from "../../util";
+import { apiURL } from "../../httpConfig";
 
 // generic fetch functions for a given attachment resource
 export type AttachmentClient = {
   list: (parentId: number) => Promise<AttachmentItem[]>;
   upload: (parentId: number, file: File) => Promise<unknown>;
   delete: (attachmentId: number) => Promise<unknown>;
-  download: (attachmentId: number) => Promise<Blob>;
+  downloadUrl: (attachmentId: number) => string;
 };
 
 // common shape shared by all attachment resources
@@ -43,11 +43,8 @@ export const attachmentRegistry = {
       deleteServiceProvidingGroupProductApplicationAttachment({
         path: { id: attachmentId },
       }).then(throwOnError),
-    download: (attachmentId: number) =>
-      callDownloadServiceProvidingGroupProductApplicationAttachment({
-        path: { id: attachmentId },
-        parseAs: "blob",
-      }).then(throwOnError) as Promise<Blob>,
+    downloadUrl: (attachmentId: number) =>
+      `${apiURL}/service_providing_group_product_application_attachment/${attachmentId}/download`,
   },
 } satisfies Record<string, AttachmentClient>;
 


### PR DESCRIPTION
This PR implements attachment download in the frontend as a single link, so that we do not have to add an exception in the `Content-Security-Policy` header for the bucket.

In order to be able to just click a link, we need to remove all strict header requirements on this endpoint (or endpoint family), namely `Api-Version`.

The link targets a blank tab so that if the download succeeds this blank tab is just closed automatically, and if it fails at least we show the error message on the newly opened tab.