### PR TITLE
feat(ui): show product type names and MAP (up/down) in SPGPA list (FLEX-1352)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5400,9 +5400,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.12",
-            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/dompurify/-/dompurify-3.4.12.tgz",
-            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+            "version": "3.4.13",
+            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/dompurify/-/dompurify-3.4.13.tgz",
+            "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -7937,9 +7937,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {

--- a/frontend/src/components/ProductTypeArrayField.tsx
+++ b/frontend/src/components/ProductTypeArrayField.tsx
@@ -1,0 +1,49 @@
+import { Tag } from "./ui";
+import { useQuery } from "@tanstack/react-query";
+import { listProductType, ProductType } from "../generated-client";
+import { throwOnError } from "../util";
+
+// display a product type with name and example products if present
+const displayProductType = (productType: ProductType) =>
+  productType.name + (productType.products ? ` (${productType.products})` : "");
+
+const PRODUCT_TYPE_QUERY_KEY = ["product_type", "all"] as const;
+
+// hook to get all possible product types sorted by ID
+export function useGetAllProductTypes() {
+  const { data } = useQuery({
+    queryKey: PRODUCT_TYPE_QUERY_KEY,
+    queryFn: () => listProductType().then(throwOnError),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  const productTypes = data?.map((product_type) => ({
+    id: product_type.id,
+    name: displayProductType(product_type),
+  }));
+  productTypes?.sort((pt1, pt2) => pt1.id - pt2.id);
+
+  return productTypes;
+}
+
+type ProductTypeArrayFieldProps = {
+  productTypeIds: number[];
+};
+
+// component displaying MULTIPLE product types
+export const ProductTypeArrayField = ({
+  productTypeIds,
+}: ProductTypeArrayFieldProps) => {
+  const productTypes = useGetAllProductTypes();
+
+  return (
+    <div className="flex flex-row gap-2">
+      {productTypeIds?.map((ptId) => (
+        <Tag key={ptId}>
+          {productTypes?.find((productType) => productType.id === ptId)?.name}
+        </Tag>
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/notice/NoticeShowDetails.tsx
+++ b/frontend/src/notice/NoticeShowDetails.tsx
@@ -3,9 +3,10 @@ import {
   RecordContextProvider,
   ResourceContextProvider,
 } from "ra-core";
+import { FunctionField } from "react-admin";
 import { BodyText, Heading, VerticalSpace } from "../components/ui";
 import { DateField } from "../components/EDS-ra";
-import { ProductTypeArrayField } from "../product_type/components";
+import { ProductTypeArrayField } from "../components/ProductTypeArrayField";
 import { Notice as GNotice } from "../generated-client";
 import {
   zControllableUnitServiceProvider,
@@ -78,9 +79,12 @@ const NoticeSPPSProductTypeNotQualifiedShowDetails = ({
       </Heading>
       <VerticalSpace />
       <RecordContextProvider value={notice.data}>
-        <ProductTypeArrayField
+        <FunctionField
           label="field.service_provider_product_suspension.product_type_ids"
           source={noticeDataFields.product_type_ids.source}
+          render={(record) => (
+            <ProductTypeArrayField productTypeIds={record.product_type_ids} />
+          )}
         />
       </RecordContextProvider>
     </>

--- a/frontend/src/product_type/components.tsx
+++ b/frontend/src/product_type/components.tsx
@@ -1,19 +1,16 @@
 import React from "react";
 import {
-  ArrayField,
   FieldProps,
   Link,
   SelectInput,
   useGetOne,
   useRecordContext,
-  WithListContext,
 } from "react-admin";
-import { Stack, Chip, Tooltip } from "@mui/material";
+import { Chip, Tooltip } from "@mui/material";
 import {
   listSystemOperatorProductType,
   ProductType,
 } from "../generated-client";
-import { Tag } from "../components/ui";
 import {
   ArrayInput,
   ArrayInputOption,
@@ -104,33 +101,6 @@ export const ProductTypeInput = (props: any) => {
   const productTypes = useGetAllProductTypes();
 
   return <SelectInput choices={productTypes} {...props} />;
-};
-
-// field component to display MULTIPLE product types
-export const ProductTypeArrayField = (props: any) => {
-  const productTypes = useGetAllProductTypes();
-
-  return (
-    <ArrayField source="product_type_ids" {...props}>
-      <WithListContext
-        render={({ data }) => (
-          <Stack direction="row" spacing={2}>
-            {data?.map((pt_id) => (
-              <Tag key={pt_id as any}>
-                {
-                  productTypes?.find(
-                    // The typing from react-admin is not great here. It says its a record but its a number
-                    (productType) =>
-                      productType.id === (pt_id as unknown as number),
-                  )?.name
-                }
-              </Tag>
-            ))}
-          </Stack>
-        )}
-      />
-    </ArrayField>
-  );
 };
 
 // input component to select MULTIPLE product types

--- a/frontend/src/service_provider_product_application/ServiceProviderProductApplicationList.tsx
+++ b/frontend/src/service_provider_product_application/ServiceProviderProductApplicationList.tsx
@@ -1,4 +1,5 @@
 import { usePermissions } from "ra-core";
+import { FunctionField } from "react-admin";
 import { Link } from "react-router-dom";
 import { List, Datagrid } from "../components/EDS-ra/list";
 import {
@@ -14,7 +15,7 @@ import {
 } from "../components/EDS-ra/inputs";
 import { Button, Tooltip } from "../components/ui";
 import { IconPlus, IconQuestionCircleOutlined } from "@elhub/ds-icons";
-import { ProductTypeArrayField } from "../product_type/components";
+import { ProductTypeArrayField } from "../components/ProductTypeArrayField";
 import {
   isProductApplicationBlocked,
   getProductApplicationBlockDate,
@@ -108,7 +109,12 @@ export const ServiceProviderProductApplicationList = () => {
         >
           <TextField source="name" />
         </ReferenceField>
-        <ProductTypeArrayField source={fields.product_type_ids.source} />
+        <FunctionField
+          source={fields.product_type_ids.source}
+          render={(record) => (
+            <ProductTypeArrayField productTypeIds={record.product_type_ids} />
+          )}
+        />
         <StatusBadgeField
           source={fields.status.source}
           enumKey="service_provider_product_application.status"

--- a/frontend/src/service_provider_product_suspension/ServiceProviderProductSuspensionList.tsx
+++ b/frontend/src/service_provider_product_suspension/ServiceProviderProductSuspensionList.tsx
@@ -1,4 +1,5 @@
 import { usePermissions } from "ra-core";
+import { FunctionField } from "react-admin";
 import { List, Datagrid } from "../components/EDS-ra/list";
 import {
   DateField,
@@ -12,7 +13,7 @@ import {
   EnumArrayInput,
   PartyReferenceInput,
 } from "../components/EDS-ra/inputs";
-import { ProductTypeArrayField } from "../product_type/components";
+import { ProductTypeArrayField } from "../components/ProductTypeArrayField";
 import { Permissions } from "../auth/permissions";
 import { zServiceProviderProductSuspension } from "../generated-client/zod.gen";
 import { getFields } from "../zod";
@@ -65,7 +66,12 @@ export const ServiceProviderProductSuspensionList = () => {
         >
           <TextField source="name" />
         </ReferenceField>
-        <ProductTypeArrayField source={fields.product_type_ids.source} />
+        <FunctionField
+          source={fields.product_type_ids.source}
+          render={(record) => (
+            <ProductTypeArrayField productTypeIds={record.product_type_ids} />
+          )}
+        />
         <EnumField
           source={fields.reason.source}
           enumKey="service_provider_product_suspension.reason"

--- a/frontend/src/service_provider_product_suspension/ServiceProviderProductSuspensionShow.tsx
+++ b/frontend/src/service_provider_product_suspension/ServiceProviderProductSuspensionShow.tsx
@@ -1,4 +1,5 @@
 import { Content, Heading, VerticalSpace } from "../components/ui";
+import { FunctionField } from "react-admin";
 import {
   Show,
   TextField,
@@ -7,7 +8,7 @@ import {
   IdentityField,
   EnumField,
 } from "../components/EDS-ra";
-import { ProductTypeArrayField } from "../product_type/components";
+import { ProductTypeArrayField } from "../components/ProductTypeArrayField";
 import { getFields } from "../zod";
 import { zServiceProviderProductSuspensionHistory } from "../generated-client/zod.gen";
 
@@ -35,7 +36,13 @@ export const ServiceProviderProductSuspensionShow = () => {
           reference="party"
           label
         />
-        <ProductTypeArrayField source={fields.product_type_ids.source} label />
+        <FunctionField
+          source={fields.product_type_ids.source}
+          label
+          render={(record) => (
+            <ProductTypeArrayField productTypeIds={record.product_type_ids} />
+          )}
+        />
         <EnumField
           source={fields.reason.source}
           enumKey="service_provider_product_suspension.reason"

--- a/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationHistoryList.tsx
+++ b/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationHistoryList.tsx
@@ -1,4 +1,5 @@
 import { useParams } from "react-router-dom";
+import { FunctionField } from "react-admin";
 import { Datagrid, List } from "../../components/EDS-ra/list";
 import {
   DateField,
@@ -8,7 +9,7 @@ import {
   TextField,
 } from "../../components/EDS-ra/fields";
 import { TextInput } from "../../components/EDS-ra/inputs";
-import { ProductTypeArrayField } from "../../product_type/components";
+import { ProductTypeArrayField } from "../../components/ProductTypeArrayField";
 import { ListServiceProvidingGroupProductApplicationHistoryData } from "../../generated-client";
 import { getFields } from "../../zod";
 import {
@@ -55,7 +56,13 @@ export const ServiceProvidingGroupProductApplicationHistoryList = () => {
         >
           <TextField {...procuringSystemOperatorIdFields.name} />
         </ReferenceField>
-        <ProductTypeArrayField source="product_type_ids" sortable={false} />
+        <FunctionField
+          source="product_type_ids"
+          sortable={false}
+          render={(record) => (
+            <ProductTypeArrayField productTypeIds={record.product_type_ids} />
+          )}
+        />
         <EnumField
           {...spgpaFields.status}
           enumKey="service_providing_group_product_application.status"

--- a/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationList.tsx
+++ b/frontend/src/service_providing_group/product_application/ServiceProvidingGroupProductApplicationList.tsx
@@ -11,7 +11,7 @@ import { SpgpaStatusBadge } from "../../components/SpgpaStatusBadge";
 import { Button, Tooltip } from "../../components/ui";
 import { IconPlus, IconQuestionCircleOutlined } from "@elhub/ds-icons";
 import { Permissions } from "../../auth/permissions";
-import { ProductTypeArrayField } from "../../product_type/components";
+import { ProductTypeArrayField } from "../../components/ProductTypeArrayField";
 import {
   isProductApplicationBlocked,
   getProductApplicationBlockDate,
@@ -109,7 +109,12 @@ export const ServiceProvidingGroupProductApplicationList = () => {
           >
             <TextField source="name" />
           </ReferenceField>
-          <ProductTypeArrayField source={fields.product_type_ids.source} />
+          <FunctionField
+            source={fields.product_type_ids.source}
+            render={(record) => (
+              <ProductTypeArrayField productTypeIds={record.product_type_ids} />
+            )}
+          />
           <FunctionField
             label={fields.status.source}
             render={(record: { status: string }) => (

--- a/frontend/src/service_providing_group/product_suspension/ServiceProvidingGroupProductSuspensionList.tsx
+++ b/frontend/src/service_providing_group/product_suspension/ServiceProvidingGroupProductSuspensionList.tsx
@@ -3,6 +3,7 @@ import {
   useRecordContext,
   ResourceContextProvider,
 } from "ra-core";
+import { FunctionField } from "react-admin";
 import { Link, useLocation } from "react-router-dom";
 import { Datagrid, List } from "../../components/EDS-ra/list";
 import {
@@ -16,7 +17,7 @@ import { DeleteButton } from "../../components/EDS-ra/buttons";
 import { Button } from "../../components/ui";
 import { IconPlus } from "@elhub/ds-icons";
 import { Permissions } from "../../auth/permissions";
-import { ProductTypeArrayField } from "../../product_type/components";
+import { ProductTypeArrayField } from "../../components/ProductTypeArrayField";
 import { zServiceProvidingGroupProductSuspension } from "../../generated-client/zod.gen";
 import { getFields } from "../../zod";
 
@@ -91,7 +92,14 @@ export const ServiceProvidingGroupProductSuspensionList = () => {
             >
               <TextField source="name" />
             </ReferenceField>
-            <ProductTypeArrayField source={fields.product_type_ids.source} />
+            <FunctionField
+              source={fields.product_type_ids.source}
+              render={(record) => (
+                <ProductTypeArrayField
+                  productTypeIds={record.product_type_ids}
+                />
+              )}
+            />
             <EnumField
               source={fields.reason.source}
               enumKey="service_providing_group_product_suspension.reason"

--- a/frontend/src/service_providing_group/product_suspension/ServiceProvidingGroupProductSuspensionShow.tsx
+++ b/frontend/src/service_providing_group/product_suspension/ServiceProvidingGroupProductSuspensionShow.tsx
@@ -1,4 +1,5 @@
 import { useRecordContext, usePermissions } from "ra-core";
+import { FunctionField } from "react-admin";
 import { Link } from "react-router-dom";
 import { IconPencil, IconClockReset } from "@elhub/ds-icons";
 import { Button, Content, Heading, VerticalSpace } from "../../components/ui";
@@ -11,7 +12,7 @@ import {
   EnumField,
 } from "../../components/EDS-ra";
 import { EventButton } from "../../event/EventButton";
-import { ProductTypeArrayField } from "../../product_type/components";
+import { ProductTypeArrayField } from "../../components/ProductTypeArrayField";
 import { Permissions } from "../../auth/permissions";
 import { ServiceProvidingGroupProductSuspension } from "../../generated-client";
 import { getFields } from "../../zod";
@@ -92,7 +93,13 @@ export const ServiceProvidingGroupProductSuspensionShow = () => {
           reference="party"
           label
         />
-        <ProductTypeArrayField source={fields.product_type_ids.source} label />
+        <FunctionField
+          source={fields.product_type_ids.source}
+          label
+          render={(record) => (
+            <ProductTypeArrayField productTypeIds={record.product_type_ids} />
+          )}
+        />
       </Content>
       <VerticalSpace />
       <Heading level={2} size="small" spacing>

--- a/frontend/src/service_providing_group/show/ServiceProvidingGroupShowProductApplicationsTable.tsx
+++ b/frontend/src/service_providing_group/show/ServiceProvidingGroupShowProductApplicationsTable.tsx
@@ -14,6 +14,7 @@ import {
   isProductApplicationBlocked,
   getProductApplicationBlockDate,
 } from "../../productApplicationBlock";
+import { ProductTypeArrayField } from "../../components/ProductTypeArrayField";
 
 type Props = {
   spgId: number;
@@ -45,7 +46,23 @@ export const ServiceProvidingGroupShowProductApplicationsTable = ({
     {
       key: "productTypeIds",
       header: t("service_providing_group_product_application.product_type_ids"),
-      render: (value) => String(value),
+      render: (value) => (
+        <ProductTypeArrayField productTypeIds={value as number[]} />
+      ),
+    },
+    {
+      key: "maximumActivePowerUp",
+      header: t(
+        "service_providing_group_product_application.maximum_active_power_up",
+      ),
+      render: (value) => `${value} kW`,
+    },
+    {
+      key: "maximumActivePowerDown",
+      header: t(
+        "service_providing_group_product_application.maximum_active_power_down",
+      ),
+      render: (value) => `${value} kW`,
     },
     {
       key: "status",

--- a/frontend/src/service_providing_group/show/useSpgProductApplications.ts
+++ b/frontend/src/service_providing_group/show/useSpgProductApplications.ts
@@ -10,6 +10,8 @@ export type SpgProductApplicationRow = {
   id: number;
   procuringSystemOperatorName: string;
   productTypeIds: number[];
+  maximumActivePowerUp: number;
+  maximumActivePowerDown: number;
   status: ServiceProvidingGroupProductApplicationStatus;
 };
 
@@ -43,6 +45,8 @@ const fetchSpgProductApplications = async (
       partyMap[a.procuring_system_operator_id] ??
       String(a.procuring_system_operator_id),
     productTypeIds: a.product_type_ids,
+    maximumActivePowerUp: a.maximum_active_power_up,
+    maximumActivePowerDown: a.maximum_active_power_down,
     status: a.status,
   }));
 };


### PR DESCRIPTION
This PR shows the product types as names instead of bare numbers in the SPGPA list and also adds MAP information (up and down directions).

We use the PR as an occasion to replace the `ProductTypeArrayField` component everywhere it is used. I don't know whether we should push it further (_i.e._, migrating to EDS all the concerned pages) but at least the old component is deleted.

<img width="1187" height="101" alt="Skjermbilde 2026-08-10 095650" src="https://github.com/user-attachments/assets/518d5db6-7e6b-4af7-a52e-7a2b356fa0ba" />