### PR TITLE
feat(ui): temporary banner when coming close to session expiry (FLEX-1350)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5400,9 +5400,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.4.12",
-            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/dompurify/-/dompurify-3.4.12.tgz",
-            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+            "version": "3.4.13",
+            "resolved": "https://jfrog.elhub.cloud/artifactory/api/npm/elhub-npm/dompurify/-/dompurify-3.4.13.tgz",
+            "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,7 @@ import postgrestRestProvider, {
 import { useI18nProvider } from "./intl/intl";
 import { Header } from "./components/Header/Header";
 import { NavigationHistoryProvider } from "./components/NavigationHistoryProvider";
+import { SessionExpiryBanner } from "./components/SessionExpiryBanner";
 
 const config: IDataProviderConfig = {
   apiUrl: apiURL,
@@ -61,6 +62,7 @@ const dataProvider: DataProvider = {
 const Layout = ({ children }: LayoutProps) => (
   <NavigationHistoryProvider>
     <Header />
+    <SessionExpiryBanner />
     <div className="py-8 px-6 ">{children}</div>
     <ReactQueryDevtools initialIsOpen={false} />
   </NavigationHistoryProvider>

--- a/frontend/src/components/SessionExpiryBanner.tsx
+++ b/frontend/src/components/SessionExpiryBanner.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { Alert } from "@mui/material";
+
+// show the banner 5 minutes before expiry
+const WARN_BEFORE_MS = 5 * 60 * 1000;
+
+const SESSION_KEY = "flexSession";
+
+function getExpiry(): number | null {
+  const raw = localStorage.getItem(SESSION_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw)["exp"] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// component to show a banner when the session is about to expire
+// TODO: remove when we have proper session refresh
+export const SessionExpiryBanner = () => {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    let timer: number;
+
+    function schedule() {
+      setShow(false);
+      clearTimeout(timer);
+
+      const exp = getExpiry();
+      if (!exp) return;
+
+      const delay = exp * 1000 - Date.now() - WARN_BEFORE_MS;
+
+      if (delay <= 0 && exp * 1000 > Date.now()) {
+        // already within the warning window but not yet expired
+        setShow(true);
+      } else if (delay > 0) {
+        timer = setTimeout(() => setShow(true), delay);
+      }
+      // if already expired, don't show — checkAuth will handle the redirect
+    }
+
+    // schedule the banner on mount
+    schedule();
+
+    // and whenever the session changes (for example if several tabs are open)
+    window.addEventListener("storage", schedule);
+
+    // cleanup on unmount
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("storage", schedule);
+    };
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <Alert
+      severity="error"
+      variant="filled"
+      sx={{
+        position: "fixed",
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 9999, // above everything else
+        borderRadius: 0,
+      }}
+    >
+      Your session will expire in 5 minutes. To continue your work in the
+      Flexibility Information System, please log out and log in again.
+    </Alert>
+  );
+};


### PR DESCRIPTION
Quick fix waiting for better session management later

<img width="1754" height="188" alt="Skjermbilde 2026-08-11 144847" src="https://github.com/user-attachments/assets/66f1fba3-d045-4a9c-8899-9b673ab6e6b9" />
