### PR TITLE
feat: power ratio badge and warning alert on an active CU show page if flexible power exceeds combined TR rated power (FLEX-1359)

### DIFF
--- a/frontend/src/controllable_unit/show/ControllableUnitShowSummary.tsx
+++ b/frontend/src/controllable_unit/show/ControllableUnitShowSummary.tsx
@@ -177,13 +177,13 @@ export const ControllableUnitShowSummary = ({
             tooltip
             labelKey="controllable_unit.maximum_active_power"
             value={
-              <div className="flex items-center gap-3">
+              <span className="inline-flex items-center gap-3">
                 <span>{controllableUnit.maximum_active_power} kW</span>
                 <PowerRatio
                   flexiblePower={controllableUnit.maximum_active_power}
                   ratedPower={trRatedPower}
                 />
-              </div>
+              </span>
             }
           />
           <LabelValue

--- a/frontend/src/controllable_unit/show/ControllableUnitShowSummary.tsx
+++ b/frontend/src/controllable_unit/show/ControllableUnitShowSummary.tsx
@@ -6,6 +6,7 @@ import { IconPencil } from "@elhub/ds-icons";
 import { usePermissions, useTranslate } from "ra-core";
 import { Link as RouterLink } from "react-router-dom";
 import { Permissions } from "../../auth/permissions";
+import { PowerRatio } from "../../components/PowerRatio";
 
 const formatRange = (start: string | undefined, end: string | undefined) => {
   if (!start) {
@@ -35,7 +36,13 @@ export const ControllableUnitShowSummary = ({
     biddingZone,
     meteringGridArea,
     energySupplier,
+    technicalResources,
   } = viewModel;
+
+  const trRatedPower = technicalResources?.reduce(
+    (sum, tr) => sum + tr.maximum_active_power,
+    0,
+  );
 
   const translate = useTranslate();
   const { permissions } = usePermissions<Permissions>();
@@ -169,8 +176,15 @@ export const ControllableUnitShowSummary = ({
             size="small"
             tooltip
             labelKey="controllable_unit.maximum_active_power"
-            value={controllableUnit.maximum_active_power}
-            unit="kW"
+            value={
+              <div className="flex items-center gap-3">
+                <span>{controllableUnit.maximum_active_power} kW</span>
+                <PowerRatio
+                  flexiblePower={controllableUnit.maximum_active_power}
+                  ratedPower={trRatedPower}
+                />
+              </div>
+            }
           />
           <LabelValue
             size="small"

--- a/frontend/src/controllable_unit/show/components/ControllableUnitAlerts.tsx
+++ b/frontend/src/controllable_unit/show/components/ControllableUnitAlerts.tsx
@@ -1,5 +1,6 @@
 import type { ControllableUnitShowViewModel } from "../useControllableUnitViewModel";
 import { BodyText, Alert, Heading } from "../../../components/ui";
+import { useTranslate } from "ra-core";
 
 type AlertType = {
   severity: "info" | "success" | "warning" | "error";
@@ -10,6 +11,7 @@ type AlertType = {
 const useControllableUnitAlerts = (
   controllableUnitViewModel: ControllableUnitShowViewModel,
 ): AlertType | null => {
+  const translate = useTranslate();
   const { controllableUnit, suspensions, technicalResources } =
     controllableUnitViewModel;
 
@@ -19,6 +21,20 @@ const useControllableUnitAlerts = (
       severity: "error",
       heading: "Controllable unit is suspended",
       body: `Reason: ${suspension.reason}`,
+    };
+  }
+
+  if (
+    controllableUnit.status === "active" &&
+    technicalResources &&
+    technicalResources.length > 0 &&
+    controllableUnit.maximum_active_power >
+      technicalResources.reduce((s, tr) => s + tr.maximum_active_power, 0)
+  ) {
+    return {
+      severity: "warning",
+      heading: translate("text.cu_flexible_power_exceeds_rated_power_heading"),
+      body: translate("text.cu_flexible_power_exceeds_rated_power_body"),
     };
   }
 

--- a/frontend/src/intl/text.ts
+++ b/frontend/src/intl/text.ts
@@ -78,7 +78,7 @@ export const text: Record<string, Record<TextKey, string>> = {
     cu_flexible_power_exceeds_rated_power_heading:
       "Flexible power exceeds rated power",
     cu_flexible_power_exceeds_rated_power_body:
-      "The flexible power of this controllable unit exceeds the combined maximum active power of all its technical resources. Update the flexible power or add technical resources to match the actual rated power.",
+      "The flexible power of this controllable unit exceeds the combined maximum active power of all its technical resources. Update the flexible power or add technical resources.",
     "lookup.input.accounting_point": "Accounting point",
     "lookup.input.controllable_unit": "Controllable unit",
     "lookup.input.end_user": "End user",
@@ -159,7 +159,7 @@ export const text: Record<string, Record<TextKey, string>> = {
     cu_flexible_power_exceeds_rated_power_heading:
       "Fleksibel effekt overstiger installert effekt",
     cu_flexible_power_exceeds_rated_power_body:
-      "Den fleksible effekten til denne kontrollerbare enheten overstiger den kombinerte maksimale aktive effekten til alle tekniske ressurser. Oppdater fleksibel effekt eller legg til tekniske ressurser for å samsvare med faktisk installert effekt.",
+      "Den fleksible effekten til denne kontrollerbare enheten overstiger merkeeffekten. Oppdater fleksibel effekt eller legg til tekniske ressurser.",
     "lookup.input.accounting_point": "Avregningspunkt",
     "lookup.input.controllable_unit": "Kontrollerbar enhet",
     "lookup.input.end_user": "Sluttbruker",

--- a/frontend/src/intl/text.ts
+++ b/frontend/src/intl/text.ts
@@ -11,6 +11,8 @@ export type TextKey =
   | "controllable_unit.is_small.true.label"
   | "controllable_unit.is_small.false"
   | "controllable_unit.is_small.false.label"
+  | "cu_flexible_power_exceeds_rated_power_heading"
+  | "cu_flexible_power_exceeds_rated_power_body"
   | "lookup.input.accounting_point"
   | "lookup.input.controllable_unit"
   | "lookup.input.end_user"
@@ -73,6 +75,10 @@ export const text: Record<string, Record<TextKey, string>> = {
     "controllable_unit.is_small.false":
       "No (Not small, > 50 kW of flexible power)",
     "controllable_unit.is_small.false.label": "No",
+    cu_flexible_power_exceeds_rated_power_heading:
+      "Flexible power exceeds rated power",
+    cu_flexible_power_exceeds_rated_power_body:
+      "The flexible power of this controllable unit exceeds the combined maximum active power of all its technical resources. Update the flexible power or add technical resources to match the actual rated power.",
     "lookup.input.accounting_point": "Accounting point",
     "lookup.input.controllable_unit": "Controllable unit",
     "lookup.input.end_user": "End user",
@@ -150,6 +156,10 @@ export const text: Record<string, Record<TextKey, string>> = {
     "controllable_unit.is_small.false":
       "Nei (Ikke liten, > 50 kW fleksibel effekt)",
     "controllable_unit.is_small.false.label": "Nei",
+    cu_flexible_power_exceeds_rated_power_heading:
+      "Fleksibel effekt overstiger installert effekt",
+    cu_flexible_power_exceeds_rated_power_body:
+      "Den fleksible effekten til denne kontrollerbare enheten overstiger den kombinerte maksimale aktive effekten til alle tekniske ressurser. Oppdater fleksibel effekt eller legg til tekniske ressurser for å samsvare med faktisk installert effekt.",
     "lookup.input.accounting_point": "Avregningspunkt",
     "lookup.input.controllable_unit": "Kontrollerbar enhet",
     "lookup.input.end_user": "Sluttbruker",


### PR DESCRIPTION

Warning shown if the CU is active
<img width="947" height="419" alt="image" src="https://github.com/user-attachments/assets/aae657ee-8733-4ee3-9f62-bc6c421051b2" />

Badge always shown:
<img width="644" height="263" alt="image" src="https://github.com/user-attachments/assets/11d2a2a3-16d9-4576-a6e2-e9a8cdd0bce8" />

